### PR TITLE
feat: add branch protection, validation, and topic-branch-workflow skill

### DIFF
--- a/.agent/skills/topic-branch-workflow/SKILL.md
+++ b/.agent/skills/topic-branch-workflow/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: topic-branch-workflow
+description: Use when about to commit and push code changes, or when deciding whether to push directly to main or use a topic branch
+---
+
+# Topic Branch Workflow
+
+## Default Rule
+
+Always use a topic branch unless the user explicitly says "push to main" or "commit directly to main". Main is protected — direct pushes are rejected by default.
+
+## Branch Naming
+
+```
+<type>/<short-description>
+```
+
+Types: `feat`, `fix`, `docs`, `chore`, `test`, `refactor`
+
+Examples: `feat/gh-issue-helper`, `fix/nordri-velero-assert`, `docs/kuttl-gotchas`
+
+## Full Workflow
+
+```bash
+# 1. Start from an up-to-date main
+source /Users/cervator/dev/git_ws/yggdrasil/.env
+git checkout main
+git pull siliconsaga main
+
+# 2. Create topic branch
+git checkout -b <type>/<description>
+
+# 3. Do the work — commit as normal
+git add <files>
+git commit -m "type: description
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+
+# 4. Push topic branch
+git push siliconsaga <type>/<description>
+
+# 5. Open PR
+gh pr create \
+  --repo SiliconSaga/REPO \
+  --base main \
+  --head <type>/<description> \
+  --title "type: concise description" \
+  --body "$(cat <<'EOF'
+## Summary
+- What this does and why
+
+## Related
+- Closes #N (if applicable)
+
+🤖 Assisted by Claude Code
+EOF
+)"
+```
+
+## After the PR is Merged
+
+```bash
+git checkout main
+git pull siliconsaga main
+git branch -d <type>/<description>
+```
+
+## Key Notes
+
+- `source .env` is required before `git push` — the credential helper reads `GH_TOKEN` from the environment
+- PR title follows the same `type:` convention as commit messages and issue titles
+- If the PR resolves a GitHub issue, add `Closes #N` to the PR body — GitHub will close the issue on merge
+- For multi-commit PRs, squash on merge keeps main history clean; leave this to the human reviewer
+
+## When Direct Push to Main Is Acceptable
+
+Only when the user explicitly requests it, AND branch protection has not yet been configured on the repo. Once protection is active, all pushes to main require a PR regardless.

--- a/scripts/setup-branch-protection.sh
+++ b/scripts/setup-branch-protection.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# setup-branch-protection.sh — configure main branch protection on all SiliconSaga repos
+#
+# Requires admin permission on each repo. Run with a token that has repo admin scope,
+# or as the org owner via: source .env && ./scripts/setup-branch-protection.sh
+#
+# What this sets on main for each repo:
+#   - Pull request required before merging (1 approval)
+#   - Dismiss stale reviews when new commits are pushed
+#   - No force pushes
+#   - No branch deletion
+#   - Admins are NOT exempt (enforce_admins: true) — use bypass sparingly
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_FILE="$SCRIPT_DIR/../.env"
+
+if [[ -z "${GH_TOKEN:-}" ]]; then
+  if [[ -f "$ENV_FILE" ]]; then
+    # shellcheck source=/dev/null
+    source "$ENV_FILE"
+  else
+    echo "ERROR: GH_TOKEN not set and $ENV_FILE not found" >&2
+    exit 1
+  fi
+fi
+
+REPOS=(nordri nidavellir mimir yggdrasil vordu)
+ORG="SiliconSaga"
+BRANCH="main"
+
+for REPO in "${REPOS[@]}"; do
+  echo "Configuring $ORG/$REPO branch protection on '$BRANCH'..."
+
+  gh api \
+    --method PUT \
+    "/repos/$ORG/$REPO/branches/$BRANCH/protection" \
+    --field required_status_checks=null \
+    --field enforce_admins=true \
+    --field "required_pull_request_reviews[required_approving_review_count]=1" \
+    --field "required_pull_request_reviews[dismiss_stale_reviews]=true" \
+    --field restrictions=null \
+    --field allow_force_pushes=false \
+    --field allow_deletions=false \
+    --silent \
+    && echo "  ✓ $REPO" \
+    || echo "  ✗ $REPO (failed — check token has admin scope)"
+
+done
+
+echo ""
+echo "Done. Verify with: ./scripts/validate-agent-setup.sh"

--- a/scripts/validate-agent-setup.sh
+++ b/scripts/validate-agent-setup.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# validate-agent-setup.sh — verify agent tooling prerequisites are correctly configured
+#
+# Run at the start of any session where agent will push code or file issues:
+#   source .env && ./scripts/validate-agent-setup.sh
+#
+# Checks:
+#   1. GH_TOKEN set and gh authenticated
+#   2. git credential helper wired to gh (git push will work)
+#   3. All five repos reachable with push permission
+#   4. Branch protection enabled on main for each repo
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_FILE="$SCRIPT_DIR/../.env"
+PASS="✓"
+FAIL="✗"
+WARN="⚠"
+ERRORS=0
+
+check() {
+  local label="$1"; shift
+  if "$@" &>/dev/null; then
+    echo "  $PASS $label"
+  else
+    echo "  $FAIL $label"
+    ERRORS=$((ERRORS + 1))
+  fi
+}
+
+# ── 1. GH_TOKEN and auth ─────────────────────────────────────────────────────
+echo "[ gh auth ]"
+
+if [[ -z "${GH_TOKEN:-}" ]]; then
+  if [[ -f "$ENV_FILE" ]]; then
+    # shellcheck source=/dev/null
+    source "$ENV_FILE"
+    echo "  $WARN GH_TOKEN loaded from .env (not in environment — add 'source .env' to shell profile)"
+  else
+    echo "  $FAIL GH_TOKEN not set and $ENV_FILE not found"
+    ERRORS=$((ERRORS + 1))
+  fi
+else
+  echo "  $PASS GH_TOKEN set in environment"
+fi
+
+check "gh authenticated" gh auth status
+
+GH_USER=$(gh api /user --jq .login 2>/dev/null || echo "unknown")
+echo "  $PASS authenticated as: $GH_USER"
+
+# ── 2. git credential helper ─────────────────────────────────────────────────
+echo ""
+echo "[ git credentials ]"
+
+if git config --list | grep -q 'credential.https://github.com.helper.*gh auth'; then
+  echo "  $PASS gh credential helper configured for github.com"
+else
+  echo "  $FAIL gh credential helper not set — run: gh auth setup-git"
+  ERRORS=$((ERRORS + 1))
+fi
+
+# ── 3. Repo access ───────────────────────────────────────────────────────────
+echo ""
+echo "[ repo access ]"
+
+REPOS=(nordri nidavellir mimir yggdrasil vordu)
+ORG="SiliconSaga"
+
+for REPO in "${REPOS[@]}"; do
+  PERMS=$(gh api "/repos/$ORG/$REPO" --jq '[.permissions.push, .permissions.pull] | @csv' 2>/dev/null || echo "false,false")
+  CAN_PUSH=$(echo "$PERMS" | cut -d, -f1)
+  if [[ "$CAN_PUSH" == "true" ]]; then
+    echo "  $PASS $ORG/$REPO (push)"
+  else
+    echo "  $FAIL $ORG/$REPO (no push — check token scopes)"
+    ERRORS=$((ERRORS + 1))
+  fi
+done
+
+# ── 4. Branch protection ─────────────────────────────────────────────────────
+echo ""
+echo "[ branch protection ]"
+
+for REPO in "${REPOS[@]}"; do
+  PROTECTED=$(gh api "/repos/$ORG/$REPO/branches/main" --jq '.protected' 2>/dev/null || echo "false")
+  if [[ "$PROTECTED" == "true" ]]; then
+    echo "  $PASS $ORG/$REPO main is protected"
+  else
+    echo "  $WARN $ORG/$REPO main is NOT protected — run: ./scripts/setup-branch-protection.sh"
+  fi
+done
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+echo ""
+if [[ $ERRORS -eq 0 ]]; then
+  echo "All checks passed. Agent is ready to push and file issues."
+else
+  echo "$ERRORS check(s) failed. Resolve before pushing code."
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- `scripts/setup-branch-protection.sh` — configures PR-required + no-force-push on main for all 5 repos; run once with admin token
- `scripts/validate-agent-setup.sh` — session-start health check: gh auth, credential helper, push access, branch protection state
- `.agent/skills/topic-branch-workflow/SKILL.md` — documents the default topic branch → push → PR workflow for agents

## Notes
- Validation script exits 0 even with protection warnings (they're advisory until protection is set)
- `source .env` is required before `git push` since the credential helper reads `GH_TOKEN` from the environment
- This PR itself demonstrates the workflow end-to-end

🤖 Assisted by Claude Code