### PR TITLE
docs: Knarr design spec — identity, routing, federation, future explorations

### DIFF
--- a/docs/plans/2026-04-02-knarr-design.md
+++ b/docs/plans/2026-04-02-knarr-design.md
@@ -165,6 +165,57 @@ flowchart LR
 - New Reddit mention of "Terasology" → post alert to `#terasology/social-watch`, await human decision
 - Blog post draft approved in `#terasology/engine-room` → Autoboros adapts per platform → publish via `knarr.messages.outbound`
 
+### Alert Batching and Threaded Digests
+
+High-volume sources like GitHub can generate dozens of notifications in a short
+window. Kafka stores every event individually (full granularity, replayable), but
+the router controls how they're *displayed* in Matrix.
+
+**Three display modes, configurable per room:**
+
+| Mode | When to use | How it works |
+|------|------------|--------------|
+| Individual | Low-volume, each item may need action | One message per alert, reacji workflows work directly |
+| Threaded digest | High-volume monitoring | Batch summary as top-level message; each item posted as a thread reply for per-item reactions |
+| Flat digest | Thin channels (SMS, email) | Plain text summary, no threading |
+
+**Threaded digest example** (in Matrix or bridged Discord):
+
+```
+📋 GitHub — MovingBlocks/Terasology (last 30 min)
+  4 new notifications
+  ├─ [Issue] Fix rendering on ARM Macs (#5678)
+  ├─ [PR] Update Gradle wrapper (#5679)
+  ├─ [Issue] Crash on world gen (#5680)
+  └─ [PR] Module loading refactor (#5681) — merged
+```
+
+The summary is the top-level message. Each item is a thread reply that power
+users can expand and react to individually (approve forward, dismiss, etc.).
+Casual readers just see the compact summary.
+
+**Platform capabilities:**
+- **Matrix + Discord:** Both support threads, both bridge threads via
+  mautrix-discord. These two get the full threaded digest experience.
+- **WhatsApp:** Has reply-to but not threads. Falls back to flat digest.
+- **SMS/Email:** Flat digest only — a plain text summary of the batch.
+
+**Routing rule integration:** The display mode is a per-room routing attribute:
+
+```yaml
+routing_rules:
+  "#terasology/social-watch":
+    display: threaded-digest
+    batch_window_minutes: 30
+  "#terasology/dev":
+    display: individual
+  "#sports-league/announcements":
+    display: individual
+```
+
+The Kafka side is unaffected — watchers always publish individual events. Batching
+is purely a router display concern, applied at the point of posting to Matrix.
+
 ### Layer 3: Agent Layer (Watchers + Integration Points)
 
 **Platform watchers** — services that poll or subscribe to external platforms and

--- a/docs/plans/2026-04-02-knarr-design.md
+++ b/docs/plans/2026-04-02-knarr-design.md
@@ -240,6 +240,7 @@ flowchart LR
 | `knarr.routing.decisions` | Approval/rejection events from power users |
 | `knarr.watch.alerts` | Platform monitoring alerts (new mention, new thread) |
 | `knarr.content.draft` | Content being shaped by Autoboros before publishing |
+| `knarr.identity.changes` | Keycloak user/group change events for Valkey cache invalidation |
 
 **Routing rule examples:**
 - Messages in `#sports-league/announcements` → auto-forward to WhatsApp group + SMS list
@@ -337,7 +338,33 @@ logged and others can see it's handled. Kafka replay supports tooling for catch-
 
 ## Event Schema
 
-Common envelope for all Kafka events:
+### Phase 0/1 envelope (implemented)
+
+The current producers/consumers use a reduced payload:
+
+```json
+{
+  "event_id": "uuid",
+  "timestamp": "2026-04-02T10:30:00Z",
+  "source": {
+    "platform": "reddit",
+    "channel": "r/Terasology",
+    "community": "terasology"
+  },
+  "content": {
+    "type": "new_post",
+    "body": "**Post title** by u/author",
+    "url": "https://reddit.com/r/Terasology/..."
+  }
+}
+```
+
+This matches the `WatchAlert` dataclass in `src/watchers/schemas.py`.
+
+### Target envelope (future)
+
+When the routing layer and subscription model are implemented, the envelope
+expands with `author` and `routing` fields:
 
 ```json
 {
@@ -366,6 +393,9 @@ Common envelope for all Kafka events:
 
 For approval workflows, `routing.status` cycles: `pending` → `approved`/`rejected`
 → `published`, with each transition as a separate event on `knarr.routing.decisions`.
+
+All services should include a `schema_version` field when the target envelope
+is introduced, to support backward-compatible rollout.
 
 ---
 
@@ -514,21 +544,24 @@ sequenceDiagram
     participant Bridge as mautrix-gmessages
     participant Synapse as Synapse
     participant Router as Router
-    participant DB as Subscription DB
+    participant KC as Keycloak
+    participant VK as Valkey Cache
 
     P->>Phone: Text "JOIN PANTHERS"
     Phone->>Bridge: SMS received
     Bridge->>Synapse: Matrix message
     Synapse->>Router: message event
-    Router->>DB: create subscription (sms, +1555..., #panthers)
+    Router->>KC: create/update user, add to Panthers group
+    Router->>VK: update subscription cache
     Router->>Synapse: reply "You're subscribed"
     Synapse->>Bridge: Matrix reply
     Bridge->>Phone: SMS reply
     Phone->>P: "You're subscribed to Panthers via SMS"
 
-    Note over Router,DB: Later, when announcement is posted...
+    Note over Router,VK: Later, when announcement is posted...
 
-    Router->>DB: lookup subscribers for #panthers/announcements
+    Router->>VK: lookup subscribers for #panthers/announcements
+    VK-->>Router: [{sms, +1555...}, {email, pat@...}]
     Router->>Bridge: send SMS to +1555...
     Bridge->>Phone: SMS
     Phone->>P: "Game cancelled due to rain"

--- a/docs/plans/2026-04-02-knarr-design.md
+++ b/docs/plans/2026-04-02-knarr-design.md
@@ -92,23 +92,104 @@ Synapse homeserver with mautrix bridges, deployed via Helm into k3s.
 
 **Room hierarchy:**
 
+Matrix Spaces can nest, allowing a Feeds sub-space per community for automated
+platform monitoring, separate from human conversation rooms.
+
 ```
-#terasology/               (public space)
+#terasology/                       (public space)
   #general
   #dev
-  #social-watch            (Reddit, Twitter, Steam mentions — Layer 2)
-  #engine-room             (private — content drafting, invite-only)
+  #engine-room                     (private — content drafting, invite-only)
+  #highlights                      (AI-curated important items — see below)
+  #feeds/                          (sub-space — automated platform monitoring)
+    #feed-reddit
+    #feed-github
+    #feed-steam
+    #feed-twitter
+    #feed-youtube
+    #feed-discord                  (activity from non-bridged Discord channels)
 
-#pta/                      (private space, invite-only)
+#gdd/                              (space — workspace/tooling)
+  #general
+  #highlights
+  #feeds/
+    #feed-github                   (separate from Terasology's — different repos)
+
+#pta/                              (private space, invite-only)
   #announcements
   #volunteers
   #events
 
-#sports-league/            (private space, invite-only)
-  #announcements           (bridged to WhatsApp group + SMS)
+#sports-league/                    (private space, invite-only)
+  #announcements                   (bridged to WhatsApp group + SMS)
   #coaches
-  #schedule                (game times, cancellations)
+  #schedule                        (game times, cancellations)
 ```
+
+### Cross-Room Linking
+
+A single event may be relevant to multiple communities — e.g. a Bifrost PR that
+touches both Terasology game code and GDD infrastructure patterns. Matrix doesn't
+have native cross-room message linking, but the router can handle this:
+
+**Link, don't mirror.** The router posts the full alert (with thread replies for
+reactions/approval) in the primary room based on repo or first keyword match. In
+secondary rooms, it posts a lightweight cross-reference with a Matrix permalink:
+
+```
+#terasology/feeds/feed-github:
+  📋 [PR] Bifrost module linking (#42)
+    ├─ full details, thread replies, reacji workflows
+
+#gdd/feeds/feed-github:
+  🔗 Cross-ref from #terasology: Bifrost PR touches GDD patterns → [matrix.to link]
+```
+
+This preserves **single-point-of-action** (react/approve in one place) while
+maintaining **cross-community awareness**. The cross-ref is informational — it
+doesn't duplicate approval workflows or create processing ambiguity.
+
+**Keyword routing rules** drive the matching:
+
+```yaml
+routing_rules:
+  watchers:
+    github:
+      "MovingBlocks/*":
+        primary: "#terasology/feeds/feed-github"
+        keywords:
+          gdd: "#gdd/feeds/feed-github"        # cross-ref if GDD mentioned
+          bifrost: "#terasology/feeds/feed-github"  # stays primary
+      "SiliconSaga/*":
+        primary: "#gdd/feeds/feed-github"
+        keywords:
+          terasology: "#terasology/feeds/feed-github"
+```
+
+### AI Highlights Channel (Future)
+
+When feed volume justifies it, an AI assessor consumes `knarr.watch.alerts` and
+scores events for importance. Only significant items get promoted to a
+`#highlights` room. This is another Kafka consumer — no new infrastructure.
+
+```mermaid
+flowchart LR
+    kafka["knarr.watch.alerts"] --> assessor["AI Assessor"]
+    assessor -->|"important"| highlights_topic["knarr.highlights"]
+    assessor -->|"routine"| discard["(not promoted)"]
+    highlights_topic --> router["Router"]
+    router --> highlights_room["#highlights"]
+```
+
+**What the assessor looks for:**
+- New contributor struggling (first-time PR with CI failures, confused issue report)
+- Influencer or notable account mentioning the project
+- Unusual activity spike (sudden burst of stars, downloads, or forum posts)
+- Breakage signals (multiple issues filed about the same topic in short succession)
+- Cross-project events (Bifrost PR linking Terasology and Destination Sol)
+
+**Deferred** until feed volume makes manual monitoring impractical. The
+architecture supports it whenever it becomes worthwhile — just add a consumer.
 
 **User visibility model:** Power users (owner + a few volunteers) use Matrix directly
 via Element. Everyone else stays on their native platform and never needs to know

--- a/docs/plans/2026-04-02-knarr-design.md
+++ b/docs/plans/2026-04-02-knarr-design.md
@@ -292,9 +292,11 @@ provided by Nidavellir) as the identity backbone:
 
 **Performance:** The router needs fast subscription lookups on every message
 fan-out. Hitting the Keycloak admin API per message would be too slow. The router
-maintains a local subscription cache that syncs from Keycloak on a schedule or via
-event hooks. Keycloak's event listener SPI can push user/group changes to a Kafka
-topic (`knarr.identity.changes`) for near-real-time cache invalidation.
+uses a Valkey cache (provisioned via Mimir's Crossplane composition) for
+subscription lookups — a hash per room mapping to subscriber entries. Keycloak's
+event listener SPI pushes user/group changes to a Kafka topic
+(`knarr.identity.changes`); a small sync service consumes those events and
+invalidates the Valkey cache for near-real-time updates.
 
 **Frictionless principle:** The self-service SMS/email flow creates a Keycloak user
 behind the scenes. A parent texting "JOIN PANTHERS" should never encounter a login

--- a/docs/plans/2026-04-02-knarr-design.md
+++ b/docs/plans/2026-04-02-knarr-design.md
@@ -61,9 +61,16 @@ load, reshape goods for each market, and negotiate deals.
 ### Other Boundaries
 
 - **Mimir (Tier 2):** Provides Kafka via Strimzi and PostgreSQL via Percona Crossplane compositions. Knarr declares what it needs; Mimir provisions.
-- **Nidavellir (Tier 2):** Provides Keycloak for admin auth if needed.
+- **Nidavellir (Tier 2):** Provides Keycloak as the ecosystem identity provider.
+  Knarr uses Keycloak as the identity backbone for the subscription model (see
+  Identity and Subscription Model section below).
 - **Nordri (Tier 1):** Provides k3s cluster, Longhorn storage, Traefik ingress.
-- **GDD Git interface:** Future integration point. Autoboros chatbots could surface GDD-style Git commands for human preview/approval in Matrix rooms. Knarr provides transport; command formatting and approval UX is an Autoboros concern.
+- **Nornir:** Governs permissions and approvals. Composes naturally with Keycloak
+  identity — "is this person authorized to post announcements?" is a Nornir
+  question answered using Keycloak identity.
+- **GDD Git interface:** Future integration point. Autoboros chatbots could surface
+  GDD-style Git commands for human preview/approval in Matrix rooms. Knarr provides
+  transport; command formatting and approval UX is an Autoboros concern.
 
 ---
 
@@ -266,8 +273,33 @@ user:
       mode: digest                 # daily digest instead of per-message
 ```
 
-Storage: a simple table in the Synapse PostgreSQL instance (or a separate small DB).
-The router reads subscriptions when deciding where to fan out a message.
+### Keycloak as Identity Backbone
+
+Rather than building a standalone user database, Knarr uses Keycloak (already
+provided by Nidavellir) as the identity backbone:
+
+- **Each Knarr user is a Keycloak user** — created automatically when someone
+  opts in via SMS/email, or manually by a power user. Non-technical users never
+  see Keycloak or a login page.
+- **Platform accounts as user attributes** — WhatsApp number, Discord ID, email,
+  Matrix ID stored as Keycloak custom attributes on the user profile.
+- **Keycloak groups as teams** — "Panthers parents" is a Keycloak group.
+  Membership drives which rooms/subscriptions are available.
+- **SSO for future web UI** — any Knarr admin interface is just an OIDC client
+  against Keycloak. No separate auth system.
+- **Nornir integration** — Nornir can answer authorization questions ("can this
+  person post league-wide announcements?") using the same Keycloak identity.
+
+**Performance:** The router needs fast subscription lookups on every message
+fan-out. Hitting the Keycloak admin API per message would be too slow. The router
+maintains a local subscription cache that syncs from Keycloak on a schedule or via
+event hooks. Keycloak's event listener SPI can push user/group changes to a Kafka
+topic (`knarr.identity.changes`) for near-real-time cache invalidation.
+
+**Frictionless principle:** The self-service SMS/email flow creates a Keycloak user
+behind the scenes. A parent texting "JOIN PANTHERS" should never encounter a login
+page, password prompt, or any hint that Keycloak exists. Power users and admins get
+the full Keycloak experience (SSO, user management, group assignment).
 
 ### How Routing Changes
 

--- a/docs/plans/2026-04-02-knarr-design.md
+++ b/docs/plans/2026-04-02-knarr-design.md
@@ -95,7 +95,7 @@ Synapse homeserver with mautrix bridges, deployed via Helm into k3s.
 Matrix Spaces can nest, allowing a Feeds sub-space per community for automated
 platform monitoring, separate from human conversation rooms.
 
-```
+```text
 #terasology/                       (public space)
   #general
   #dev
@@ -136,7 +136,7 @@ have native cross-room message linking, but the router can handle this:
 reactions/approval) in the primary room based on repo or first keyword match. In
 secondary rooms, it posts a lightweight cross-reference with a Matrix permalink:
 
-```
+```text
 #terasology/feeds/feed-github:
   📋 [PR] Bifrost module linking (#42)
     ├─ full details, thread replies, reacji workflows
@@ -262,7 +262,7 @@ the router controls how they're *displayed* in Matrix.
 
 **Threaded digest example** (in Matrix or bridged Discord):
 
-```
+```text
 📋 GitHub — MovingBlocks/Terasology (last 30 min)
   4 new notifications
   ├─ [Issue] Fix rendering on ARM Macs (#5678)
@@ -439,13 +439,13 @@ the full Keycloak experience (SSO, user management, group assignment).
 
 Current model (room-level):
 
-```
+```text
 #panthers/announcements → WhatsApp group (all members see everything)
 ```
 
 Extended model (room + user subscriptions):
 
-```
+```text
 #panthers/announcements →
   WhatsApp group (for whatsapp subscribers — transparent bridge)
   SMS to +1-555-0123 (Coach Mike, subscribed via SMS)
@@ -462,7 +462,8 @@ Non-technical users never need to know Matrix exists. They interact with Knarr
 through the channel they already use:
 
 **SMS (via spare phone / mautrix-gmessages):**
-```
+
+```text
 → Text "JOIN PANTHERS" to the Knarr number
 ← "You're subscribed to Panthers announcements via SMS. Text STOP to unsubscribe."
 
@@ -474,7 +475,8 @@ through the channel they already use:
 ```
 
 **Email:**
-```
+
+```text
 → Send any email to panthers+join@knarr.example.com
 ← Auto-reply: "You're subscribed to Panthers announcements via email."
 
@@ -494,7 +496,7 @@ opt-in needed — the bridge handles it. They can leave the group to unsubscribe
 Power users can manage subscriptions on behalf of others via Matrix bot commands
 in an admin room:
 
-```
+```text
 !knarr subscribe +15550123 #panthers/announcements sms
 !knarr subscribe mike@example.com #league/schedule email-digest
 !knarr list-subscribers #panthers/announcements
@@ -626,7 +628,7 @@ flowchart TB
 
 ### Helm Chart Structure
 
-```
+```text
 knarr/
   Chart.yaml
   values.yaml               # Defaults
@@ -752,7 +754,7 @@ homeserver. Simple, no federation needed.
 Helm chart, their own infrastructure). Federation is enabled between the two
 Synapse homeservers. Users on either server can join rooms on the other.
 
-```
+```text
 knarr.town-a.org                     knarr.town-b.org
 ├─ #town-a-pta/                      ├─ #town-b-pta/
 │   (local rooms)                    │   (local rooms)

--- a/docs/plans/2026-04-02-knarr-design.md
+++ b/docs/plans/2026-04-02-knarr-design.md
@@ -230,6 +230,187 @@ For approval workflows, `routing.status` cycles: `pending` → `approved`/`rejec
 
 ---
 
+## Identity and Subscription Model
+
+The routing layer (Layer 2) currently thinks in terms of rooms and platforms: "messages
+in this room go to that WhatsApp group." The identity model adds a user dimension:
+"this person wants notifications from this room via SMS."
+
+This is critical for the sports league and PTA use cases where each parent has a
+preferred channel and non-technical users need a frictionless way to opt in.
+
+### User Identity
+
+A Knarr identity ties together a person's accounts across platforms:
+
+```yaml
+user:
+  display_name: "Coach Mike"
+  community: sports-league
+  accounts:
+    - platform: matrix
+      id: "@mike:knarr.local"      # only if power user
+    - platform: whatsapp
+      id: "+15550123"
+    - platform: sms
+      id: "+15550123"              # can overlap with whatsapp number
+    - platform: email
+      id: "mike@example.com"
+  subscriptions:
+    - room: "#panthers/announcements"
+      channel: sms
+    - room: "#panthers/coaches"
+      channel: whatsapp
+    - room: "#league/schedule"
+      channel: email
+      mode: digest                 # daily digest instead of per-message
+```
+
+Storage: a simple table in the Synapse PostgreSQL instance (or a separate small DB).
+The router reads subscriptions when deciding where to fan out a message.
+
+### How Routing Changes
+
+Current model (room-level):
+
+```
+#panthers/announcements → WhatsApp group (all members see everything)
+```
+
+Extended model (room + user subscriptions):
+
+```
+#panthers/announcements →
+  WhatsApp group (for whatsapp subscribers — transparent bridge)
+  SMS to +1-555-0123 (Coach Mike, subscribed via SMS)
+  SMS to +1-555-0456 (Parent Jane, subscribed via SMS)
+  email to pat@example.com (Parent Pat, subscribed via email)
+```
+
+The WhatsApp group bridge is still a transparent mautrix bridge. The SMS and email
+deliveries are individual fan-outs handled by the router based on subscription data.
+
+### Self-Service Opt-In/Opt-Out
+
+Non-technical users never need to know Matrix exists. They interact with Knarr
+through the channel they already use:
+
+**SMS (via spare phone / mautrix-gmessages):**
+```
+→ Text "JOIN PANTHERS" to the Knarr number
+← "You're subscribed to Panthers announcements via SMS. Text STOP to unsubscribe."
+
+→ Text "STOP"
+← "You've been unsubscribed from all notifications."
+
+→ Text "HELP"
+← "Available teams: PANTHERS, EAGLES, TIGERS. Text JOIN <team> to subscribe."
+```
+
+**Email:**
+```
+→ Send any email to panthers+join@knarr.example.com
+← Auto-reply: "You're subscribed to Panthers announcements via email."
+
+→ Send to panthers+stop@knarr.example.com
+← Auto-reply: "You've been unsubscribed."
+```
+
+Email opt-in/out requires a mail receiver — either a simple SMTP listener in the
+cluster or an inbound webhook from a service like Mailgun/Sendgrid.
+
+**WhatsApp:**
+Users who join the bridged WhatsApp group are implicitly subscribed. No extra
+opt-in needed — the bridge handles it. They can leave the group to unsubscribe.
+
+### Power User Admin
+
+Power users can manage subscriptions on behalf of others via Matrix bot commands
+in an admin room:
+
+```
+!knarr subscribe +15550123 #panthers/announcements sms
+!knarr subscribe mike@example.com #league/schedule email-digest
+!knarr list-subscribers #panthers/announcements
+!knarr unsubscribe +15550123 all
+```
+
+Or eventually a small web UI. The bot command gets there first.
+
+### Subscription Flow
+
+```mermaid
+sequenceDiagram
+    participant P as Parent (SMS)
+    participant Phone as Spare Phone
+    participant Bridge as mautrix-gmessages
+    participant Synapse as Synapse
+    participant Router as Router
+    participant DB as Subscription DB
+
+    P->>Phone: Text "JOIN PANTHERS"
+    Phone->>Bridge: SMS received
+    Bridge->>Synapse: Matrix message
+    Synapse->>Router: message event
+    Router->>DB: create subscription (sms, +1555..., #panthers)
+    Router->>Synapse: reply "You're subscribed"
+    Synapse->>Bridge: Matrix reply
+    Bridge->>Phone: SMS reply
+    Phone->>P: "You're subscribed to Panthers via SMS"
+
+    Note over Router,DB: Later, when announcement is posted...
+
+    Router->>DB: lookup subscribers for #panthers/announcements
+    Router->>Bridge: send SMS to +1555...
+    Bridge->>Phone: SMS
+    Phone->>P: "Game cancelled due to rain"
+```
+
+---
+
+## Bridge Limitations
+
+Bridges between rich and thin platforms involve inherent trade-offs. The design
+principle: accept graceful degradation rather than building complex translation
+layers.
+
+### Emoji Reactions
+
+| Bridge | Support | Notes |
+|--------|---------|-------|
+| Matrix ↔ Discord | Good | mautrix-discord supports bidirectional reactions. Custom emoji may not translate. |
+| Matrix ↔ WhatsApp | Basic | mautrix-whatsapp supports standard emoji reactions. |
+| Matrix ↔ SMS | None | Reactions appear as text: "(Mike reacted with 👍)" |
+| Matrix ↔ Email | None | Same text degradation as SMS. |
+
+Rich-to-rich bridging (Discord ↔ Matrix ↔ WhatsApp) works well. Thin channels
+(SMS, email) get text descriptions. Don't try to build a universal reaction system.
+
+### Threads
+
+| Bridge | Support | Notes |
+|--------|---------|-------|
+| Matrix ↔ Discord | Reasonable | Discord threads map to Matrix threads (MSC3440). Workable but not perfect. |
+| Matrix ↔ WhatsApp | Reply-to only | WhatsApp has reply-to-message but not threads. Threads collapse to replies. |
+| Matrix ↔ SMS/Email | None | Threads collapse into the flat message stream. |
+
+Discord forum channels are a special case — they're "a room full of threads." The
+bridge maps each forum post to a Matrix thread, which is usable but lossy. For
+communities using forum channels heavily, a dedicated Matrix room per forum post
+may work better than bridging the entire forum channel.
+
+### Design Guidance
+
+- **Don't normalize up.** Don't try to give SMS users a thread experience. They
+  signed up for a simpler channel and that's fine.
+- **Preserve richness where it exists.** Discord ↔ Matrix reactions and threads
+  work — let them work. Don't strip features to match the lowest common denominator.
+- **Inform users of limitations.** A power user configuring a bridge should know
+  that SMS subscribers won't see threads or reactions. Surface this in the admin
+  tooling.
+
+---
+
 ## Tech Stack
 
 | Component | Technology | Rationale |

--- a/docs/plans/2026-04-02-knarr-design.md
+++ b/docs/plans/2026-04-02-knarr-design.md
@@ -1,0 +1,425 @@
+# Knarr Design Spec
+
+**Date:** 2026-04-02
+**Status:** Draft
+**Component:** knarr (new)
+
+---
+
+## Overview
+
+Knarr is the integration/bridging layer of the Yggdrasil ecosystem. It owns the
+communication infrastructure: a self-hosted Matrix homeserver, bridge fleet, Kafka
+message bus, and routing logic. It serves as a multi-community communication hub
+for three audiences with very different platform mixes and engagement patterns.
+
+**The metaphor:** Knarr is the merchant ship and its trade routes. It carries messages
+between ports (platforms), knows the routes (routing rules), and keeps a manifest
+(Kafka event log). Autoboros is the crew aboard — the agents who decide what cargo to
+load, reshape goods for each market, and negotiate deals.
+
+### Target Communities
+
+| Community | Platforms in use | Urgency |
+|-----------|-----------------|---------|
+| **Terasology** (OSS game dev) | Discord, GitHub, Reddit, Twitter x2, YouTube, Steam forum, 2 blog sites, LinkedIn, Patreon, own forum (broken) | North star model; watching capability wanted immediately |
+| **Sports league** (kids, parent coaches) | TeamSnap, scattered email, barely any communication | Spring season starts mid-April 2026 |
+| **PTA** | WhatsApp, texting, email, Facebook | Demo-ready by end of school year (~June 2026) |
+
+### Design Goals
+
+1. **Spider in the web** — detect activity across platforms from a single Matrix dashboard
+2. **Team visibility** — volunteer teams share awareness of what needs attention and what's been handled
+3. **Meet people where they are** — parents use WhatsApp/SMS/Facebook; gamers use Discord; power users use Element
+4. **Curated routing** — some messages flow automatically, some need human approval before fan-out
+5. **Content adaptation** — write once, reshape per platform, review before publishing (Autoboros concern, Knarr provides the transport)
+
+---
+
+## System Boundaries
+
+### Knarr Owns
+
+| Concern | Description |
+|---------|-------------|
+| Matrix homeserver (Synapse) | Core communication hub |
+| Bridge fleet (mautrix-*) | Platform connectivity |
+| Kafka topics and event schemas | Internal message bus |
+| Routing rules | What goes where, auto vs approval-gated |
+| Room topology and access control | Spaces, rooms, permissions |
+| Platform watchers | Monitoring external platforms for activity |
+
+### Autoboros Owns
+
+| Concern | Description |
+|---------|-------------|
+| Chatbot personalities and command handling | Body + brain components |
+| Content adaptation | Reshaping posts per platform format |
+| ChatOps workflows | PR creation, issue triage, etc. |
+| AI agent integration | OpenClaw, LLM calls |
+
+### Other Boundaries
+
+- **Mimir (Tier 2):** Provides Kafka via Strimzi and PostgreSQL via Percona Crossplane compositions. Knarr declares what it needs; Mimir provisions.
+- **Nidavellir (Tier 2):** Provides Keycloak for admin auth if needed.
+- **Nordri (Tier 1):** Provides k3s cluster, Longhorn storage, Traefik ingress.
+- **GDD Git interface:** Future integration point. Autoboros chatbots could surface GDD-style Git commands for human preview/approval in Matrix rooms. Knarr provides transport; command formatting and approval UX is an Autoboros concern.
+
+---
+
+## Architecture Layers
+
+### Layer 1: Nervous System (Matrix + Bridges)
+
+Synapse homeserver with mautrix bridges, deployed via Helm into k3s.
+
+**Bridge fleet:**
+
+| Bridge | Community | Notes |
+|--------|-----------|-------|
+| mautrix-discord | Terasology | Immediate priority |
+| mautrix-whatsapp | PTA, sports league | Spare phone as anchor device |
+| mautrix-gmessages | Sports league, PTA | SMS via Google Messages on spare phone |
+| mautrix-facebook | PTA | Meeting parents where they are |
+| mautrix-slack | Future | If needed |
+
+**Room hierarchy:**
+
+```
+#terasology/               (public space)
+  #general
+  #dev
+  #social-watch            (Reddit, Twitter, Steam mentions — Layer 2)
+  #engine-room             (private — content drafting, invite-only)
+
+#pta/                      (private space, invite-only)
+  #announcements
+  #volunteers
+  #events
+
+#sports-league/            (private space, invite-only)
+  #announcements           (bridged to WhatsApp group + SMS)
+  #coaches
+  #schedule                (game times, cancellations)
+```
+
+**User visibility model:** Power users (owner + a few volunteers) use Matrix directly
+via Element. Everyone else stays on their native platform and never needs to know
+Matrix exists. Power users are encouraged to "upgrade" to Element over time.
+
+### Layer 2: Routing Layer (Kafka + Routing Logic)
+
+A lightweight Knarr service that handles curated, rule-based message fan-out beyond
+what transparent bridging provides. The router connects to Synapse as a Matrix bot
+(client-server API), parallel to the bridges which use the appservice API. Bridges
+handle transparent bidirectional chat; the router handles everything else — watching,
+approval workflows, cross-posting orchestration.
+
+```mermaid
+flowchart LR
+    subgraph "Platform Bridges - Layer 1"
+        discord["mautrix-discord"]
+        whatsapp["mautrix-whatsapp"]
+        sms["mautrix-gmessages"]
+        fb["mautrix-facebook"]
+    end
+
+    subgraph "Knarr Routing - Layer 2"
+        router["Route Engine"]
+        kafka["Kafka via Mimir"]
+        rules["Routing Rules"]
+    end
+
+    subgraph "Consumers - Layer 3+"
+        autoboros["Autoboros bots"]
+        watchers["Platform Watchers"]
+        agents["AI Agents"]
+    end
+
+    discord & whatsapp & sms & fb <--> router
+    router <--> kafka
+    rules --> router
+    kafka <--> autoboros & watchers & agents
+```
+
+**Kafka topics:**
+
+| Topic | Purpose |
+|-------|---------|
+| `knarr.messages.inbound` | All messages arriving from any bridge |
+| `knarr.messages.outbound` | Messages approved for publishing to platforms |
+| `knarr.routing.pending` | Messages awaiting human approval before fan-out |
+| `knarr.routing.decisions` | Approval/rejection events from power users |
+| `knarr.watch.alerts` | Platform monitoring alerts (new mention, new thread) |
+| `knarr.content.draft` | Content being shaped by Autoboros before publishing |
+
+**Routing rule examples:**
+- Messages in `#sports-league/announcements` → auto-forward to WhatsApp group + SMS list
+- New Reddit mention of "Terasology" → post alert to `#terasology/social-watch`, await human decision
+- Blog post draft approved in `#terasology/engine-room` → Autoboros adapts per platform → publish via `knarr.messages.outbound`
+
+### Layer 3: Agent Layer (Watchers + Integration Points)
+
+**Platform watchers** — services that poll or subscribe to external platforms and
+publish alerts to Kafka:
+
+- Reddit watcher (API polling for subreddit/mention activity)
+- Steam forum watcher (scraping or API)
+- Twitter/X watcher (API access permitting)
+- YouTube comment watcher
+- GitHub notification aggregator
+
+**Approval workflow:**
+
+```mermaid
+sequenceDiagram
+    participant W as Watcher
+    participant K as Kafka
+    participant R as Router
+    participant M as Matrix Room
+    participant P as Poweruser
+    participant T as Target Platform
+
+    W->>K: watch.alert (new Reddit mention)
+    K->>R: consume alert
+    R->>M: post to #social-watch with action buttons
+    P->>M: approves forward (reaction or command)
+    M->>K: routing.decision (approved)
+    K->>R: consume decision
+    R->>T: publish response via bridge/API
+    R->>K: messages.outbound (logged)
+```
+
+**Team visibility:** Because everything flows through Kafka, any volunteer in the
+Matrix room can see what alerts are pending. When someone responds, the event is
+logged and others can see it's handled. Kafka replay supports tooling for catch-up.
+
+---
+
+## Event Schema
+
+Common envelope for all Kafka events:
+
+```json
+{
+  "event_id": "uuid",
+  "timestamp": "2026-04-02T10:30:00Z",
+  "source": {
+    "platform": "discord",
+    "channel": "terasology-general",
+    "community": "terasology"
+  },
+  "author": {
+    "platform_id": "discord:12345",
+    "display_name": "contributor42"
+  },
+  "content": {
+    "type": "text",
+    "body": "Has anyone tried the new module system?"
+  },
+  "routing": {
+    "status": "auto",
+    "targets": ["matrix:#terasology/general"],
+    "requires_approval": false
+  }
+}
+```
+
+For approval workflows, `routing.status` cycles: `pending` → `approved`/`rejected`
+→ `published`, with each transition as a separate event on `knarr.routing.decisions`.
+
+---
+
+## Tech Stack
+
+| Component | Technology | Rationale |
+|-----------|-----------|-----------|
+| Homeserver | Synapse | Most mature, best bridge compatibility, Python |
+| Bridges | mautrix suite | Active development, Python, consistent API |
+| Router | Python (FastAPI or similar) | Lightweight, same language as bridges and Autoboros |
+| Watchers | Python | Same ecosystem; each watcher is a small service |
+| Message bus | Kafka via Mimir | Already in stack, durable log for audit and replay |
+| Database | PostgreSQL via Mimir | Synapse requires it, already vended by Crossplane |
+| Client | Element | Standard Matrix client, mobile + desktop |
+
+---
+
+## Deployment Architecture
+
+Knarr is a Tier 3 application deployed via ArgoCD.
+
+```mermaid
+flowchart TB
+    subgraph "Nordri - Tier 1"
+        k3s["k3s cluster"]
+        traefik["Traefik ingress"]
+        storage["Longhorn PVs"]
+    end
+
+    subgraph "Mimir - Tier 2"
+        pg["PostgreSQL - Synapse DB"]
+        kafka["Kafka - Strimzi"]
+    end
+
+    subgraph "Knarr - Tier 3"
+        synapse["Synapse homeserver"]
+        bridges["Bridge pods"]
+        router["Router service"]
+        watchers["Watcher pods"]
+    end
+
+    k3s --> synapse & bridges & router & watchers
+    traefik --> synapse
+    storage --> synapse
+    pg --> synapse
+    kafka <--> router
+    kafka <--> watchers
+    bridges <--> synapse
+```
+
+### Helm Chart Structure
+
+```
+knarr/
+  Chart.yaml
+  values.yaml               # Defaults
+  values-local.yaml          # Local k3s overrides
+  values-gke.yaml            # GKE production overrides
+  templates/
+    synapse/
+      deployment.yaml
+      service.yaml
+      configmap.yaml         # homeserver.yaml generation
+    bridges/
+      discord.yaml
+      whatsapp.yaml
+      gmessages.yaml
+      facebook.yaml
+    router/
+      deployment.yaml
+      service.yaml
+      configmap.yaml         # routing rules
+    watchers/
+      reddit.yaml
+      steam.yaml
+      twitter.yaml
+      youtube.yaml
+      github.yaml
+  config/
+    homeserver/              # Synapse config templates
+    bridges/                 # Bridge registration files
+    routing/                 # Routing rule definitions
+  src/
+    router/                  # Knarr router service source
+    watchers/                # Watcher service source
+  tests/
+    features/                # BDD specs for routing behavior
+  docs/
+    architecture.md
+    bridges.md
+    routing-rules.md
+```
+
+### Spare Phone
+
+The spare phone serves as the persistent anchor for mautrix-whatsapp (WhatsApp Web
+session) and mautrix-gmessages (SMS via Google Messages). It must stay powered on
+and connected. For local testing it sits on the same network as the k3s node. When
+the homeserver moves to GKE, the phone needs to remain reachable — either colocated
+with a bridge pod on a local machine, or via a relay. The phone is 100% dedicated
+to Knarr.
+
+---
+
+## Phasing
+
+| Phase | Scope | Timeline | Goal |
+|-------|-------|----------|------|
+| 0 | Bare Synapse + Postgres on M1 Mac k3s | Week 1 | "I can chat with myself across devices via my own server" |
+| 1 | mautrix-discord + Terasology watching | Week 2 | "I can see Terasology activity across platforms from one place" |
+| 2 | mautrix-whatsapp + mautrix-gmessages for sports league | Weeks 3-4 | "Coaches and parents can communicate, I see everything in Element" |
+| 3 | Kafka topics + routing engine + approval workflows | Weeks 5-8 | "The volunteer team has shared awareness of what needs attention" |
+| 4 | Cross-posting + content adaptation (Autoboros integration) | Weeks 8-12 | "I write a post once and publish everywhere with review" |
+| 5 | PTA bridges + demo | Months 2-3 | "Show a working communication hub that meets parents where they are" |
+
+### Phase Details
+
+**Phase 0 — Bare homeserver:**
+Deploy Synapse + Postgres on M1 Mac k3s. Create room hierarchy (spaces for each
+community). Connect with Element from phone and desktop. Federation disabled
+(private homeserver). Validate basic operation.
+
+**Phase 1 — Discord bridge + Terasology watching:**
+Deploy mautrix-discord, bridge key Terasology channels. Deploy Kafka topics via
+Mimir. Deploy first watchers (Reddit, GitHub notifications). Stand up
+`#terasology/social-watch` room with alerts flowing in.
+
+**Phase 2 — Sports league bridge:**
+Deploy mautrix-whatsapp, link spare phone. Bridge `#sports-league/announcements`
+to WhatsApp group. Deploy mautrix-gmessages for SMS. Test with coaches first.
+
+**Phase 3 — Routing engine + approval workflows:**
+Build the Knarr router service. Implement routing rules (auto-forward vs
+pending-approval). Approval UX in Matrix rooms (reactions or bot commands). Team
+visibility — volunteers see what's been handled.
+
+**Phase 4 — Cross-posting + content adaptation:**
+Integration point for Autoboros content adaptation. Blog post → multi-platform
+publish workflow. Platform-specific formatting.
+
+**Phase 5 — PTA demo:**
+Apply bridge infrastructure (WhatsApp, SMS, Facebook). PTA-specific room hierarchy
+and routing rules. Demo to PTA leadership.
+
+---
+
+## Autoboros Migration Path
+
+The stem component in Autoboros becomes legacy. Migration steps:
+
+1. Knarr deploys with Kafka topics active
+2. Autoboros adds a Kafka consumer/producer (replacing NATS client code in stem)
+3. Autoboros body/brain connect to `knarr.messages.inbound` to receive chat events
+4. Autoboros publishes responses to `knarr.messages.outbound`
+5. Stem's NATS code is archived or removed
+
+After migration, Autoboros no longer connects directly to Discord. It connects to
+Kafka, and Knarr handles all platform I/O.
+
+---
+
+## Future Explorations
+
+### Web-Searchable Chat Archive ("Scribe")
+
+Bring back IRC-style public chat logging for the modern multi-platform world.
+A Kafka consumer ("scribe") reads `knarr.messages.inbound`, writes messages to
+a static site (Hugo/Jekyll/plain HTML) organized by room and date, and deploys
+to GitHub Pages or in-cluster. Because everything flows through Kafka, this
+archives all bridged platforms (Discord, Matrix, future bridges) — not just
+Matrix-native messages. Kafka replay enables regenerating the archive from
+history. Public rooms only; routing rules can control what gets archived.
+
+### Blog Comments via Cactus Comments
+
+Cactus Comments uses Matrix rooms as a commenting backend for static sites.
+Each blog post gets a dedicated Matrix room. Comments posted on the blog appear
+in Matrix (and vice versa — moderatable from Element). The JS widget renders
+client-side, so comments are not search-engine indexable by default. The scribe
+archiver above could solve this: blog comment rooms flow through Kafka like any
+other room, and the scribe produces a static indexed copy. This gives interactive
+commenting + permanent searchable record.
+
+Relevant for the Terasology blog sites and the personal blog (Cervator.github.io).
+
+---
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Message bus | Kafka (not NATS) | Already in stack via Mimir; NATS had cross-platform reliability issues; Kafka's durable log enables team visibility and replay |
+| Homeserver | Synapse (not Dendrite/Conduit) | Most mature, best bridge compatibility |
+| Approach | Layered Hub (not Bridge-First Monolith or Federation-First) | Clean separation of concerns; can deploy Layer 1 immediately and build Layers 2-3 iteratively; can split to federation later if needed |
+| Phasing order | Terasology first (not sports league) | More engaged testers, watching capability wanted immediately |
+| User visibility | Matrix hidden from end users | Power users use Element directly; everyone else stays on native platforms |

--- a/docs/plans/2026-04-02-knarr-design.md
+++ b/docs/plans/2026-04-02-knarr-design.md
@@ -735,6 +735,92 @@ Kafka, and Knarr handles all platform I/O.
 
 ---
 
+## Federation and Multi-Instance Growth
+
+Knarr is designed as a Demicracy community component. A single instance serves
+one community (or several small ones under one admin), but over time neighboring
+communities may want their own instances — with their own admins, data, and
+policies — while still sharing some rooms.
+
+### Growth Stages
+
+**Stage 1 — Single instance.** One Knarr/Synapse deployment hosts everything.
+Users from other communities join as guests or registered users on the same
+homeserver. Simple, no federation needed.
+
+**Stage 2 — Second instance.** Another community deploys their own Knarr (same
+Helm chart, their own infrastructure). Federation is enabled between the two
+Synapse homeservers. Users on either server can join rooms on the other.
+
+```
+knarr.town-a.org                     knarr.town-b.org
+├─ #town-a-pta/                      ├─ #town-b-pta/
+│   (local rooms)                    │   (local rooms)
+└─ #regional-league/  ←─federation─→ └─ #regional-league/
+    (shared, replicated)                 (shared, replicated)
+```
+
+**Stage 3 — Shared spaces, separate admin.** A cross-community space (e.g. a
+sports league spanning two towns) is federated. Each server holds a replica of
+the shared rooms. Each admin controls their own users and local rooms. If one
+server goes down, the other continues operating — messages queue and sync on
+reconnect.
+
+**Stage 4 — Community kit.** The full Knarr deployment — Helm chart, bridge
+configs, routing rules, subscription model — becomes a Demicracy "community kit"
+template. A new neighborhood deploys it, customizes their rooms and bridges, and
+federates with neighbors as desired.
+
+### What Federates and What Stays Local
+
+Matrix federation handles chat replication between homeservers natively. The
+question is what happens to the Knarr-specific layers (Kafka, routing,
+subscriptions, watchers) when multiple instances exist.
+
+Several options exist, and the right choice depends on how the communities
+actually grow:
+
+**Option A — Federation at Matrix only, everything else local.** Each Knarr
+instance runs its own Kafka, watchers, router, Keycloak, and Valkey. Instances
+connect only through Matrix federation for shared rooms. Each town's router
+handles their own subscribers (local parents get SMS/email from their local
+Knarr). Simplest, most robust, each deployment is self-contained.
+
+**Option B — Shared watchers, separate routing.** For a federated sports league,
+the social media watcher runs on one instance and posts to the federated room.
+Both towns' routers see the Matrix message and handle their own local subscribers.
+No cross-instance Kafka needed — federation delivers the message to both
+homeservers.
+
+**Option C — Cross-instance event bus.** Kafka topics are mirrored between
+instances (via MirrorMaker or similar). Both routers see all events. More
+complex, potentially useful if cross-community workflows (like shared approval
+chains) are needed.
+
+**Option D — Hub-and-spoke.** One instance acts as the "league hub" for shared
+watchers and routing. Spoke instances handle local rooms and subscribers only.
+The hub federates with all spokes via Matrix. Simpler than full mesh, but
+introduces a central point.
+
+These options are not mutually exclusive — a deployment could start with Option A
+and adopt elements of B or D as the federation grows. The design intentionally
+leaves this open; the right answer depends on real usage patterns that don't exist
+yet.
+
+### Identity Across Instances
+
+Keycloak supports cross-realm trust and identity brokering. A user registered on
+Town A's Keycloak could authenticate to Town B's Knarr web UI via OIDC federation,
+without creating a separate account. This parallels how Matrix federation handles
+user identity — `@coach:town-a.org` is recognized on `town-b.org` without
+re-registration.
+
+The subscription model works per-instance: Coach Mike's SMS subscription is
+managed by his local Knarr instance, even if the room he's subscribed to is
+federated from another server.
+
+---
+
 ## Future Explorations
 
 ### Web-Searchable Chat Archive ("Scribe")

--- a/docs/plans/2026-04-02-knarr-phase0-phase1-plan.md
+++ b/docs/plans/2026-04-02-knarr-phase0-phase1-plan.md
@@ -1,0 +1,2225 @@
+# Knarr Phase 0 + Phase 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deploy a self-hosted Matrix homeserver (Synapse) on the local k3d cluster with a Discord bridge for Terasology, Kafka event bus, and initial platform watchers — establishing Knarr as a working communication hub.
+
+**Architecture:** Synapse runs as a Kubernetes deployment backed by PostgreSQL via Mimir's Crossplane composition. mautrix-discord bridges Terasology Discord channels into Matrix rooms. A Kafka cluster (also via Mimir) provides the event bus for platform watchers that monitor Reddit and GitHub. The Knarr router bot connects to Synapse and posts watcher alerts to a `#social-watch` Matrix room.
+
+**Tech Stack:** Synapse (Matrix homeserver), mautrix-discord (bridge), Kafka via Strimzi/Mimir, PostgreSQL via Percona/Mimir, Python (router + watchers), Helm, k3d (OrbStack on M1 Mac), ArgoCD, Traefik.
+
+**Target cluster:** `k3d-nordri-test` (M1 Mac, OrbStack, K3s v1.31.5, Traefik on LoadBalancer, Longhorn absent — uses `local-path` default StorageClass)
+
+**Prerequisites:**
+- `k3d-nordri-test` cluster running (confirmed: 3 nodes, operators ready)
+- Crossplane compositions available: `xpostgresql-percona`, `xkafkacluster-strimzi`
+- Strimzi operator running in `kafka` namespace
+- Percona PG operator running in `percona` namespace
+- A Discord bot token for the Terasology server (user must create this)
+- Element app installed on phone and/or desktop
+
+---
+
+## File Map
+
+All files are created in a new `knarr` Git repository, to be cloned into `components/knarr/`.
+
+```
+knarr/
+├── k8s/
+│   ├── namespace.yaml                    # knarr namespace
+│   ├── postgres-claim.yaml               # Crossplane PostgreSQLInstance for Synapse
+│   ├── kafka-claim.yaml                  # Crossplane KafkaCluster for event bus
+│   ├── kafka-topics.yaml                 # Strimzi KafkaTopic resources
+│   ├── synapse/
+│   │   ├── deployment.yaml               # Synapse homeserver pod
+│   │   ├── service.yaml                  # ClusterIP service
+│   │   ├── configmap.yaml                # homeserver.yaml config
+│   │   └── ingressroute.yaml             # Traefik IngressRoute
+│   └── bridges/
+│       └── discord/
+│           ├── deployment.yaml           # mautrix-discord pod
+│           ├── configmap.yaml            # bridge config
+│           └── registration-secret.yaml  # appservice registration
+├── src/
+│   ├── router/
+│   │   ├── __init__.py
+│   │   ├── main.py                       # Knarr router bot (Matrix + Kafka)
+│   │   ├── kafka_consumer.py             # Consume watcher alerts, post to Matrix
+│   │   └── Dockerfile
+│   └── watchers/
+│       ├── __init__.py
+│       ├── reddit_watcher.py             # Poll Reddit API, publish to Kafka
+│       ├── github_watcher.py             # Poll GitHub notifications, publish to Kafka
+│       ├── schemas.py                    # Shared Kafka event envelope schema
+│       └── Dockerfile
+├── tests/
+│   ├── test_schemas.py                   # Event envelope validation
+│   ├── test_reddit_watcher.py            # Reddit watcher unit tests
+│   ├── test_github_watcher.py            # GitHub watcher unit tests
+│   └── test_router.py                    # Router bot unit tests
+├── pyproject.toml                        # Python project config
+├── requirements.txt                      # Python dependencies
+└── README.md                             # Component overview
+```
+
+---
+
+## Task 1: Create the Knarr Repository and Namespace
+
+**Files:**
+- Create: `knarr/k8s/namespace.yaml`
+- Create: `knarr/README.md`
+- Create: `knarr/pyproject.toml`
+- Create: `knarr/requirements.txt`
+
+- [ ] **Step 1: Create the knarr repo on GitHub**
+
+Create a new repository `knarr` under the SiliconSaga org (or your personal GitHub). Initialize with a README.
+
+```bash
+gh repo create SiliconSaga/knarr --public --description "Integration/bridging layer — Matrix homeserver, bridges, and message routing" --clone
+```
+
+If using personal GitHub instead, adjust the org name.
+
+- [ ] **Step 2: Create the namespace manifest**
+
+Create `k8s/namespace.yaml`:
+
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: knarr
+  labels:
+    app.kubernetes.io/part-of: knarr
+```
+
+- [ ] **Step 3: Create pyproject.toml**
+
+Create `pyproject.toml`:
+
+```toml
+[project]
+name = "knarr"
+version = "0.1.0"
+description = "Knarr — Matrix integration hub, bridges, and message routing"
+requires-python = ">=3.11"
+dependencies = [
+    "matrix-nio>=0.24.0",
+    "confluent-kafka>=2.6.0",
+    "pydantic>=2.0",
+    "httpx>=0.27.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24.0",
+]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+```
+
+- [ ] **Step 4: Create requirements.txt**
+
+Create `requirements.txt`:
+
+```
+matrix-nio>=0.24.0
+confluent-kafka>=2.6.0
+pydantic>=2.0
+httpx>=0.27.0
+```
+
+- [ ] **Step 5: Create README.md**
+
+Create `README.md`:
+
+```markdown
+# Knarr
+
+Integration/bridging layer for the Yggdrasil ecosystem. Self-hosted Matrix
+homeserver with bridges, Kafka event bus, and platform watchers.
+
+See [knarr-design.md](../yggdrasil/docs/plans/2026-04-02-knarr-design.md) for
+the full design spec.
+
+## Components
+
+- **Synapse** — Matrix homeserver
+- **mautrix-discord** — Discord bridge
+- **Router** — Kafka-to-Matrix alert routing bot
+- **Watchers** — Reddit, GitHub platform monitors
+```
+
+- [ ] **Step 6: Apply the namespace**
+
+```bash
+kubectl --context k3d-nordri-test apply -f k8s/namespace.yaml
+```
+
+Expected: `namespace/knarr created`
+
+- [ ] **Step 7: Commit**
+
+Write `.commits/01-init.md`:
+
+```markdown
+---
+add:
+  - k8s/namespace.yaml
+  - README.md
+  - pyproject.toml
+  - requirements.txt
+---
+
+feat: initialize knarr repository with namespace and project config
+```
+
+```bash
+bash scripts/ws commit knarr .commits/01-init.md
+```
+
+---
+
+## Task 2: Provision PostgreSQL for Synapse
+
+**Files:**
+- Create: `knarr/k8s/postgres-claim.yaml`
+
+- [ ] **Step 1: Create the Crossplane PostgreSQL claim**
+
+Create `k8s/postgres-claim.yaml`:
+
+```yaml
+apiVersion: database.example.org/v1alpha1
+kind: PostgreSQLInstance
+metadata:
+  name: synapse-db
+  namespace: knarr
+spec:
+  parameters:
+    storageSize: 2Gi
+    version: "15"
+    replicas: 1
+    databaseName: synapse
+  compositionSelector:
+    matchLabels:
+      provider: percona
+      service: postgresql
+```
+
+- [ ] **Step 2: Apply the claim**
+
+```bash
+kubectl --context k3d-nordri-test apply -f k8s/postgres-claim.yaml
+```
+
+Expected: `postgresqlinstance.database.example.org/synapse-db created`
+
+- [ ] **Step 3: Wait for the database to become ready**
+
+```bash
+kubectl --context k3d-nordri-test get postgresqlinstance synapse-db -n knarr -w
+```
+
+Wait until `READY` shows `True`. This may take 2-3 minutes as Percona creates the cluster. While waiting, verify the pods:
+
+```bash
+kubectl --context k3d-nordri-test get pods -n knarr
+```
+
+Expected: pods like `synapse-db-instance1-xxxx-0` appearing and reaching `Running`.
+
+- [ ] **Step 4: Verify the connection secret**
+
+```bash
+kubectl --context k3d-nordri-test get secrets -n knarr | grep synapse-db
+```
+
+Look for a secret containing connection credentials. Note the secret name — it will be referenced in the Synapse config.
+
+```bash
+kubectl --context k3d-nordri-test get secret synapse-db-pguser-synapse-db -n knarr -o jsonpath='{.data}' | python3 -c "import sys,json,base64; d=json.load(sys.stdin); [print(f'{k}: {base64.b64decode(v).decode()}') for k,v in d.items()]"
+```
+
+Record the host, port, user, password, and dbname values.
+
+- [ ] **Step 5: Commit**
+
+Write `.commits/02-postgres.md`:
+
+```markdown
+---
+add:
+  - k8s/postgres-claim.yaml
+---
+
+feat: provision PostgreSQL for Synapse via Mimir Crossplane composition
+```
+
+```bash
+bash scripts/ws commit knarr .commits/02-postgres.md
+```
+
+---
+
+## Task 3: Deploy Synapse Homeserver
+
+**Files:**
+- Create: `knarr/k8s/synapse/configmap.yaml`
+- Create: `knarr/k8s/synapse/deployment.yaml`
+- Create: `knarr/k8s/synapse/service.yaml`
+- Create: `knarr/k8s/synapse/ingressroute.yaml`
+
+- [ ] **Step 1: Generate a Synapse signing key and registration shared secret**
+
+```bash
+# Generate a signing key (Synapse format)
+python3 -c "
+import base64, os
+key_bytes = os.urandom(32)
+key_id = 'a_' + base64.b64encode(os.urandom(3)).decode().rstrip('=')
+key_b64 = base64.b64encode(key_bytes).decode()
+print(f'ed25519 {key_id} {key_b64}')
+" > /tmp/synapse-signing-key.txt
+cat /tmp/synapse-signing-key.txt
+
+# Generate a registration shared secret
+python3 -c "import secrets; print(secrets.token_urlsafe(32))"
+```
+
+Record both values. The signing key goes in a Secret; the shared secret goes in homeserver.yaml.
+
+- [ ] **Step 2: Create the signing key secret**
+
+```bash
+kubectl --context k3d-nordri-test create secret generic synapse-signing-key \
+  -n knarr \
+  --from-file=signing.key=/tmp/synapse-signing-key.txt
+rm /tmp/synapse-signing-key.txt
+```
+
+Expected: `secret/synapse-signing-key created`
+
+- [ ] **Step 3: Create the Synapse configmap**
+
+Create `k8s/synapse/configmap.yaml`. Replace `REGISTRATION_SHARED_SECRET` with the value from Step 1. Replace `DB_HOST`, `DB_USER`, `DB_PASSWORD` with values from Task 2 Step 4.
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: synapse-config
+  namespace: knarr
+data:
+  homeserver.yaml: |
+    server_name: "knarr.local"
+    pid_file: "/data/homeserver.pid"
+    listeners:
+      - port: 8008
+        tls: false
+        type: http
+        x_forwarded: true
+        resources:
+          - names: [client, federation]
+            compress: false
+    database:
+      name: psycopg2
+      args:
+        user: "DB_USER"
+        password: "DB_PASSWORD"
+        database: "synapse"
+        host: "DB_HOST"
+        port: "5432"
+        cp_min: 2
+        cp_max: 5
+    signing_key_path: "/keys/signing.key"
+    suppress_key_server_warning: true
+    enable_registration: false
+    registration_shared_secret: "REGISTRATION_SHARED_SECRET"
+    federation_domain_whitelist: []
+    allow_public_rooms_over_federation: false
+    media_store_path: "/data/media_store"
+    log_config: "/config/log.yaml"
+    trusted_key_servers: []
+    app_service_config_files: []
+
+  log.yaml: |
+    version: 1
+    formatters:
+      precise:
+        format: '%(asctime)s - %(name)s - %(lineno)d - %(levelname)s - %(message)s'
+    handlers:
+      console:
+        class: logging.StreamHandler
+        formatter: precise
+    root:
+      level: INFO
+      handlers: [console]
+```
+
+Note: `federation_domain_whitelist: []` and empty `trusted_key_servers` effectively disable federation — this is a private homeserver.
+
+- [ ] **Step 4: Create the Synapse deployment**
+
+Create `k8s/synapse/deployment.yaml`:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: synapse
+  namespace: knarr
+  labels:
+    app: synapse
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: synapse
+  template:
+    metadata:
+      labels:
+        app: synapse
+    spec:
+      containers:
+        - name: synapse
+          image: matrixdotorg/synapse:v1.122.0
+          ports:
+            - containerPort: 8008
+          volumeMounts:
+            - name: config
+              mountPath: /config
+            - name: signing-key
+              mountPath: /keys
+              readOnly: true
+            - name: data
+              mountPath: /data
+          env:
+            - name: SYNAPSE_CONFIG_DIR
+              value: /config
+            - name: SYNAPSE_CONFIG_PATH
+              value: /config/homeserver.yaml
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              memory: 512Mi
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8008
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8008
+            initialDelaySeconds: 30
+            periodSeconds: 30
+      volumes:
+        - name: config
+          configMap:
+            name: synapse-config
+        - name: signing-key
+          secret:
+            secretName: synapse-signing-key
+        - name: data
+          emptyDir: {}
+```
+
+Note: `data` uses `emptyDir` for now. Media uploads will be lost on pod restart, which is acceptable for initial testing. A PVC can be added later.
+
+- [ ] **Step 5: Create the Synapse service**
+
+Create `k8s/synapse/service.yaml`:
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: synapse
+  namespace: knarr
+spec:
+  selector:
+    app: synapse
+  ports:
+    - port: 8008
+      targetPort: 8008
+      protocol: TCP
+  type: ClusterIP
+```
+
+- [ ] **Step 6: Create the Traefik IngressRoute**
+
+Create `k8s/synapse/ingressroute.yaml`:
+
+```yaml
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: synapse
+  namespace: knarr
+spec:
+  entryPoints:
+    - web
+  routes:
+    - match: Host(`matrix.knarr.local`)
+      kind: Rule
+      services:
+        - name: synapse
+          port: 8008
+```
+
+- [ ] **Step 7: Add a local DNS entry**
+
+Add to `/etc/hosts` (requires sudo):
+
+```bash
+echo "127.0.0.1 matrix.knarr.local" | sudo tee -a /etc/hosts
+```
+
+If using OrbStack, the k3d LoadBalancer IP may differ. Check with:
+
+```bash
+kubectl --context k3d-nordri-test get svc -n kube-system traefik -o jsonpath='{.status.loadBalancer.ingress[0].ip}'
+```
+
+Use that IP instead of `127.0.0.1` if different.
+
+- [ ] **Step 8: Deploy Synapse**
+
+```bash
+kubectl --context k3d-nordri-test apply -f k8s/synapse/
+```
+
+Expected: configmap, deployment, service, and ingressroute created.
+
+- [ ] **Step 9: Verify Synapse is running**
+
+```bash
+kubectl --context k3d-nordri-test get pods -n knarr -l app=synapse
+```
+
+Wait for `Running` and `1/1 Ready`. If the pod crashes, check logs:
+
+```bash
+kubectl --context k3d-nordri-test logs -n knarr -l app=synapse --tail=50
+```
+
+Then test the health endpoint:
+
+```bash
+curl -s http://matrix.knarr.local/health
+```
+
+Expected: `OK`
+
+- [ ] **Step 10: Create an admin user**
+
+```bash
+kubectl --context k3d-nordri-test exec -n knarr deploy/synapse -- \
+  register_new_matrix_user -c /config/homeserver.yaml \
+  -u admin -p <choose-a-password> -a \
+  http://localhost:8008
+```
+
+Replace `<choose-a-password>` with an actual password. The `-a` flag makes this an admin account.
+
+- [ ] **Step 11: Test login from Element**
+
+Open Element (desktop or phone), click "Sign in", use custom homeserver: `http://matrix.knarr.local`. Log in with the admin user created above. If on phone, ensure the phone can reach the k3d cluster (same network, or use the OrbStack IP).
+
+- [ ] **Step 12: Create the room hierarchy**
+
+From Element as admin, create:
+- Space: `Terasology` (public)
+  - Room: `#general` (in Terasology space)
+  - Room: `#dev` (in Terasology space)
+  - Room: `#social-watch` (in Terasology space)
+  - Room: `#engine-room` (in Terasology space, invite-only)
+- Space: `Sports League` (private, invite-only)
+  - Room: `#announcements`
+  - Room: `#coaches`
+  - Room: `#schedule`
+- Space: `PTA` (private, invite-only)
+  - Room: `#announcements`
+  - Room: `#volunteers`
+  - Room: `#events`
+
+This can be done via the Element UI. The rooms will be populated with bridges later.
+
+- [ ] **Step 13: Commit**
+
+Write `.commits/03-synapse.md`:
+
+```markdown
+---
+add:
+  - k8s/synapse/configmap.yaml
+  - k8s/synapse/deployment.yaml
+  - k8s/synapse/service.yaml
+  - k8s/synapse/ingressroute.yaml
+---
+
+feat: deploy Synapse homeserver with Traefik ingress
+
+Private Matrix homeserver on knarr.local, federation disabled,
+backed by Percona PostgreSQL via Crossplane.
+```
+
+```bash
+bash scripts/ws commit knarr .commits/03-synapse.md
+```
+
+---
+
+## Task 4: Provision Kafka for the Event Bus
+
+**Files:**
+- Create: `knarr/k8s/kafka-claim.yaml`
+- Create: `knarr/k8s/kafka-topics.yaml`
+
+- [ ] **Step 1: Create the Kafka cluster claim**
+
+Create `k8s/kafka-claim.yaml`:
+
+```yaml
+apiVersion: mimir.siliconsaga.org/v1alpha1
+kind: KafkaCluster
+metadata:
+  name: knarr-kafka
+  namespace: knarr
+spec:
+  parameters:
+    replicas: 1
+    storageSize: "2Gi"
+    version: "4.0.0"
+```
+
+Note: `replicas: 1` for local testing. Production (GKE) would use 3.
+
+- [ ] **Step 2: Apply the Kafka claim**
+
+```bash
+kubectl --context k3d-nordri-test apply -f k8s/kafka-claim.yaml
+```
+
+Expected: `kafkacluster.mimir.siliconsaga.org/knarr-kafka created`
+
+- [ ] **Step 3: Wait for Kafka to become ready**
+
+```bash
+kubectl --context k3d-nordri-test get kafkacluster knarr-kafka -n knarr -w
+```
+
+This takes longer than Postgres — Strimzi needs to create the KRaft controller and broker. Watch pods:
+
+```bash
+kubectl --context k3d-nordri-test get pods -n kafka -w
+```
+
+Wait until the kafka pods are `Running` and `Ready`.
+
+- [ ] **Step 4: Verify the bootstrap service**
+
+```bash
+kubectl --context k3d-nordri-test get svc -n kafka | grep knarr
+```
+
+Look for a service like `knarr-kafka-kafka-bootstrap`. Record the full service name — it will be used as the Kafka bootstrap server: `<service-name>.kafka.svc.cluster.local:9092`
+
+- [ ] **Step 5: Create the Kafka topics**
+
+Create `k8s/kafka-topics.yaml`:
+
+```yaml
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: knarr.messages.inbound
+  namespace: kafka
+  labels:
+    strimzi.io/cluster: knarr-kafka-kafka
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: "604800000"
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: knarr.messages.outbound
+  namespace: kafka
+  labels:
+    strimzi.io/cluster: knarr-kafka-kafka
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: "604800000"
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: knarr.watch.alerts
+  namespace: kafka
+  labels:
+    strimzi.io/cluster: knarr-kafka-kafka
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: "604800000"
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: knarr.routing.pending
+  namespace: kafka
+  labels:
+    strimzi.io/cluster: knarr-kafka-kafka
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: "604800000"
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: knarr.routing.decisions
+  namespace: kafka
+  labels:
+    strimzi.io/cluster: knarr-kafka-kafka
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: "604800000"
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: knarr.content.draft
+  namespace: kafka
+  labels:
+    strimzi.io/cluster: knarr-kafka-kafka
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: "604800000"
+```
+
+Note: `strimzi.io/cluster` label must match the Kafka cluster name created by the Crossplane composition. Check with `kubectl get kafka -n kafka` and use the name shown. It may be `knarr-kafka-kafka` (the composition appends `-kafka`). Adjust if different.
+
+Partitions and replicas are both 1 for local single-broker testing.
+
+- [ ] **Step 6: Apply the topics**
+
+```bash
+kubectl --context k3d-nordri-test apply -f k8s/kafka-topics.yaml
+```
+
+Expected: 6 KafkaTopic resources created.
+
+- [ ] **Step 7: Verify topics**
+
+```bash
+kubectl --context k3d-nordri-test get kafkatopics -n kafka | grep knarr
+```
+
+Expected: all 6 topics in `Ready: True` state.
+
+- [ ] **Step 8: Commit**
+
+Write `.commits/04-kafka.md`:
+
+```markdown
+---
+add:
+  - k8s/kafka-claim.yaml
+  - k8s/kafka-topics.yaml
+---
+
+feat: provision Kafka cluster and event bus topics via Mimir
+
+Single-replica Kafka for local testing with 6 Knarr routing topics.
+```
+
+```bash
+bash scripts/ws commit knarr .commits/04-kafka.md
+```
+
+---
+
+## Task 5: Deploy mautrix-discord Bridge
+
+**Files:**
+- Create: `knarr/k8s/bridges/discord/configmap.yaml`
+- Create: `knarr/k8s/bridges/discord/deployment.yaml`
+- Create: `knarr/k8s/bridges/discord/registration-secret.yaml`
+
+**Prerequisites:** You need a Discord bot token. Go to https://discord.com/developers/applications, create an application, add a bot, copy the token. The bot needs:
+- `MESSAGE_CONTENT` intent (privileged, must enable in portal)
+- `GUILDS`, `GUILD_MESSAGES` intents
+- Invite the bot to the Terasology Discord server with appropriate permissions.
+
+- [ ] **Step 1: Generate the appservice registration**
+
+The mautrix-discord bridge needs an appservice registration file that Synapse loads. Generate the shared secret tokens:
+
+```bash
+AS_TOKEN=$(python3 -c "import secrets; print(secrets.token_hex(32))")
+HS_TOKEN=$(python3 -c "import secrets; print(secrets.token_hex(32))")
+echo "as_token: $AS_TOKEN"
+echo "hs_token: $HS_TOKEN"
+```
+
+Record both tokens.
+
+- [ ] **Step 2: Create the registration secret**
+
+Create `k8s/bridges/discord/registration-secret.yaml`. Replace `AS_TOKEN` and `HS_TOKEN` with the values from Step 1.
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: discord-bridge-registration
+  namespace: knarr
+stringData:
+  registration.yaml: |
+    id: discord
+    url: http://mautrix-discord:29334
+    as_token: "AS_TOKEN"
+    hs_token: "HS_TOKEN"
+    sender_localpart: discordbot
+    rate_limited: false
+    namespaces:
+      users:
+        - regex: "@discord_.*:knarr\\.local"
+          exclusive: true
+      aliases:
+        - regex: "#discord_.*:knarr\\.local"
+          exclusive: true
+```
+
+- [ ] **Step 3: Update Synapse config to load the appservice**
+
+Edit `k8s/synapse/configmap.yaml`. Change the `app_service_config_files` line in `homeserver.yaml`:
+
+```yaml
+    app_service_config_files:
+      - /bridges/discord/registration.yaml
+```
+
+- [ ] **Step 4: Update Synapse deployment to mount the registration**
+
+Edit `k8s/synapse/deployment.yaml`. Add a volume mount and volume for the bridge registration:
+
+Under `volumeMounts:` add:
+
+```yaml
+            - name: discord-bridge-reg
+              mountPath: /bridges/discord
+              readOnly: true
+```
+
+Under `volumes:` add:
+
+```yaml
+        - name: discord-bridge-reg
+          secret:
+            secretName: discord-bridge-registration
+```
+
+- [ ] **Step 5: Create the bridge configmap**
+
+Create `k8s/bridges/discord/configmap.yaml`. Replace `DISCORD_BOT_TOKEN` with the real token.
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mautrix-discord-config
+  namespace: knarr
+data:
+  config.yaml: |
+    homeserver:
+      address: http://synapse:8008
+      domain: knarr.local
+    appservice:
+      address: http://mautrix-discord:29334
+      hostname: 0.0.0.0
+      port: 29334
+      database:
+        type: sqlite3-fk-wal
+        uri: /data/mautrix-discord.db
+      id: discord
+      bot:
+        username: discordbot
+        displayname: Discord Bridge Bot
+      as_token: "AS_TOKEN"
+      hs_token: "HS_TOKEN"
+    bridge:
+      username_template: "discord_{{.}}"
+      displayname_template: "{{.Username}} (Discord)"
+      portal_message_buffer: 128
+      delivery_receipts: true
+      message_status_events: true
+      permissions:
+        "*": relay
+        "@admin:knarr.local": admin
+    logging:
+      min_level: info
+      writers:
+        - type: stdout
+          format: pretty-colored
+```
+
+Replace `AS_TOKEN` and `HS_TOKEN` with the same values from Step 1.
+
+- [ ] **Step 6: Create the Discord bot token secret**
+
+```bash
+kubectl --context k3d-nordri-test create secret generic discord-bot-token \
+  -n knarr \
+  --from-literal=token='YOUR_DISCORD_BOT_TOKEN'
+```
+
+Replace `YOUR_DISCORD_BOT_TOKEN` with the actual token.
+
+- [ ] **Step 7: Create the bridge deployment**
+
+Create `k8s/bridges/discord/deployment.yaml`:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mautrix-discord
+  namespace: knarr
+  labels:
+    app: mautrix-discord
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mautrix-discord
+  template:
+    metadata:
+      labels:
+        app: mautrix-discord
+    spec:
+      containers:
+        - name: mautrix-discord
+          image: dock.mau.dev/mautrix/discord:v0.7.2
+          ports:
+            - containerPort: 29334
+          volumeMounts:
+            - name: config
+              mountPath: /config
+            - name: data
+              mountPath: /data
+          env:
+            - name: DISCORD_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: discord-bot-token
+                  key: token
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              memory: 256Mi
+      volumes:
+        - name: config
+          configMap:
+            name: mautrix-discord-config
+        - name: data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mautrix-discord
+  namespace: knarr
+spec:
+  selector:
+    app: mautrix-discord
+  ports:
+    - port: 29334
+      targetPort: 29334
+```
+
+- [ ] **Step 8: Deploy the bridge and restart Synapse**
+
+```bash
+kubectl --context k3d-nordri-test apply -f k8s/bridges/discord/registration-secret.yaml
+kubectl --context k3d-nordri-test apply -f k8s/synapse/
+kubectl --context k3d-nordri-test apply -f k8s/bridges/discord/
+kubectl --context k3d-nordri-test rollout restart deploy/synapse -n knarr
+```
+
+- [ ] **Step 9: Verify bridge is running**
+
+```bash
+kubectl --context k3d-nordri-test get pods -n knarr -l app=mautrix-discord
+kubectl --context k3d-nordri-test logs -n knarr -l app=mautrix-discord --tail=30
+```
+
+Look for "Bridge started" or similar. Check Synapse logs for appservice registration:
+
+```bash
+kubectl --context k3d-nordri-test logs -n knarr -l app=synapse --tail=30 | grep -i appservice
+```
+
+- [ ] **Step 10: Login to the bridge and link Discord**
+
+From Element, start a chat with `@discordbot:knarr.local`. Send `login-token` and follow the instructions to authenticate with your Discord bot token. Then bridge a channel:
+
+1. In Element, invite `@discordbot:knarr.local` to the `#general` room in the Terasology space
+2. Send `!discord bridge <channel-id>` with the Discord channel ID for Terasology #general
+
+Test by sending a message in Discord and verifying it appears in Element (and vice versa).
+
+- [ ] **Step 11: Commit**
+
+Write `.commits/05-discord-bridge.md`:
+
+```markdown
+---
+add:
+  - k8s/bridges/discord/configmap.yaml
+  - k8s/bridges/discord/deployment.yaml
+  - k8s/bridges/discord/registration-secret.yaml
+---
+
+feat: deploy mautrix-discord bridge for Terasology
+
+Bridges Terasology Discord channels into Matrix rooms.
+Registration secret and Synapse appservice config included.
+```
+
+```bash
+bash scripts/ws commit knarr .commits/05-discord-bridge.md
+```
+
+---
+
+## Task 6: Event Schema and Watcher Foundation
+
+**Files:**
+- Create: `knarr/src/__init__.py`
+- Create: `knarr/src/watchers/__init__.py`
+- Create: `knarr/src/watchers/schemas.py`
+- Create: `knarr/tests/__init__.py`
+- Create: `knarr/tests/test_schemas.py`
+
+- [ ] **Step 1: Write the failing test for the event schema**
+
+Create `tests/__init__.py` (empty file).
+
+Create `tests/test_schemas.py`:
+
+```python
+from datetime import datetime, timezone
+
+from src.watchers.schemas import WatchAlert, Source, Content
+
+
+def test_watch_alert_serializes_to_dict():
+    alert = WatchAlert(
+        source=Source(
+            platform="reddit",
+            channel="r/Terasology",
+            community="terasology",
+        ),
+        content=Content(
+            type="mention",
+            body="Check out this Terasology build!",
+            url="https://reddit.com/r/Terasology/comments/abc123",
+        ),
+    )
+    data = alert.to_kafka_dict()
+
+    assert data["source"]["platform"] == "reddit"
+    assert data["source"]["community"] == "terasology"
+    assert data["content"]["type"] == "mention"
+    assert data["content"]["url"] == "https://reddit.com/r/Terasology/comments/abc123"
+    assert "event_id" in data
+    assert "timestamp" in data
+
+
+def test_watch_alert_from_kafka_dict_roundtrip():
+    alert = WatchAlert(
+        source=Source(
+            platform="github",
+            channel="MovingBlocks/Terasology",
+            community="terasology",
+        ),
+        content=Content(
+            type="notification",
+            body="New issue #1234: Fix rendering bug",
+        ),
+    )
+    data = alert.to_kafka_dict()
+    restored = WatchAlert.from_kafka_dict(data)
+
+    assert restored.source.platform == "github"
+    assert restored.content.body == "New issue #1234: Fix rendering bug"
+    assert restored.event_id == alert.event_id
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd components/knarr && python -m pytest tests/test_schemas.py -v
+```
+
+Expected: `ModuleNotFoundError: No module named 'src.watchers'`
+
+- [ ] **Step 3: Write the schema implementation**
+
+Create `src/__init__.py` (empty file).
+
+Create `src/watchers/__init__.py` (empty file).
+
+Create `src/watchers/schemas.py`:
+
+```python
+"""Kafka event envelope schemas for Knarr watchers."""
+
+import uuid
+from datetime import datetime, timezone
+from dataclasses import dataclass, field, asdict
+from typing import Optional
+
+
+@dataclass
+class Source:
+    platform: str
+    channel: str
+    community: str
+
+
+@dataclass
+class Content:
+    type: str
+    body: str
+    url: Optional[str] = None
+
+
+@dataclass
+class WatchAlert:
+    source: Source
+    content: Content
+    event_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    timestamp: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat()
+    )
+
+    def to_kafka_dict(self) -> dict:
+        return asdict(self)
+
+    @classmethod
+    def from_kafka_dict(cls, data: dict) -> "WatchAlert":
+        return cls(
+            source=Source(**data["source"]),
+            content=Content(**data["content"]),
+            event_id=data["event_id"],
+            timestamp=data["timestamp"],
+        )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd components/knarr && python -m pytest tests/test_schemas.py -v
+```
+
+Expected: 2 passed.
+
+- [ ] **Step 5: Commit**
+
+Write `.commits/06-schemas.md`:
+
+```markdown
+---
+add:
+  - src/__init__.py
+  - src/watchers/__init__.py
+  - src/watchers/schemas.py
+  - tests/__init__.py
+  - tests/test_schemas.py
+---
+
+feat: add Kafka event envelope schema with tests
+
+Dataclass-based WatchAlert schema for platform watcher events,
+with serialization roundtrip.
+```
+
+```bash
+bash scripts/ws commit knarr .commits/06-schemas.md
+```
+
+---
+
+## Task 7: Reddit Watcher
+
+**Files:**
+- Create: `knarr/src/watchers/reddit_watcher.py`
+- Create: `knarr/tests/test_reddit_watcher.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_reddit_watcher.py`:
+
+```python
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.watchers.reddit_watcher import RedditWatcher
+from src.watchers.schemas import WatchAlert
+
+
+@pytest.fixture
+def watcher():
+    return RedditWatcher(
+        subreddit="Terasology",
+        kafka_bootstrap="localhost:9092",
+        kafka_topic="knarr.watch.alerts",
+        poll_interval_seconds=60,
+    )
+
+
+def test_parse_reddit_post_into_alert(watcher):
+    post_data = {
+        "data": {
+            "title": "Cool Terasology build showcase",
+            "author": "gamer42",
+            "permalink": "/r/Terasology/comments/abc123/cool_build/",
+            "selftext": "Check out this amazing build I made!",
+            "created_utc": 1743600000.0,
+            "name": "t3_abc123",
+        }
+    }
+
+    alert = watcher.parse_post(post_data)
+
+    assert isinstance(alert, WatchAlert)
+    assert alert.source.platform == "reddit"
+    assert alert.source.channel == "r/Terasology"
+    assert alert.source.community == "terasology"
+    assert alert.content.type == "new_post"
+    assert "Cool Terasology build showcase" in alert.content.body
+    assert "reddit.com/r/Terasology/comments/abc123" in alert.content.url
+
+
+def test_deduplication_skips_seen_posts(watcher):
+    post_data = {
+        "data": {
+            "title": "Duplicate post",
+            "author": "user1",
+            "permalink": "/r/Terasology/comments/dup1/duplicate/",
+            "selftext": "",
+            "created_utc": 1743600000.0,
+            "name": "t3_dup1",
+        }
+    }
+
+    alert1 = watcher.parse_post(post_data)
+    assert alert1 is not None
+
+    alert2 = watcher.parse_post(post_data)
+    assert alert2 is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd components/knarr && python -m pytest tests/test_reddit_watcher.py -v
+```
+
+Expected: `ModuleNotFoundError: No module named 'src.watchers.reddit_watcher'`
+
+- [ ] **Step 3: Write the Reddit watcher implementation**
+
+Create `src/watchers/reddit_watcher.py`:
+
+```python
+"""Reddit watcher — polls a subreddit for new posts and publishes alerts to Kafka."""
+
+import json
+import logging
+from typing import Optional
+
+import httpx
+
+from .schemas import WatchAlert, Source, Content
+
+logger = logging.getLogger(__name__)
+
+REDDIT_BASE = "https://www.reddit.com"
+
+
+class RedditWatcher:
+    def __init__(
+        self,
+        subreddit: str,
+        kafka_bootstrap: str,
+        kafka_topic: str,
+        poll_interval_seconds: int = 300,
+    ):
+        self.subreddit = subreddit
+        self.kafka_bootstrap = kafka_bootstrap
+        self.kafka_topic = kafka_topic
+        self.poll_interval_seconds = poll_interval_seconds
+        self._seen_ids: set[str] = set()
+
+    def parse_post(self, post_data: dict) -> Optional[WatchAlert]:
+        """Parse a Reddit post JSON object into a WatchAlert. Returns None if already seen."""
+        data = post_data["data"]
+        post_id = data["name"]
+
+        if post_id in self._seen_ids:
+            return None
+        self._seen_ids.add(post_id)
+
+        title = data["title"]
+        author = data.get("author", "[deleted]")
+        permalink = data["permalink"]
+        selftext = data.get("selftext", "")
+
+        body = f"**{title}** by u/{author}"
+        if selftext:
+            preview = selftext[:200] + ("..." if len(selftext) > 200 else "")
+            body += f"\n{preview}"
+
+        return WatchAlert(
+            source=Source(
+                platform="reddit",
+                channel=f"r/{self.subreddit}",
+                community="terasology",
+            ),
+            content=Content(
+                type="new_post",
+                body=body,
+                url=f"https://www.reddit.com{permalink}",
+            ),
+        )
+
+    async def fetch_new_posts(self) -> list[WatchAlert]:
+        """Fetch recent posts from the subreddit and return unseen alerts."""
+        url = f"{REDDIT_BASE}/r/{self.subreddit}/new.json?limit=10"
+        headers = {"User-Agent": "knarr-watcher/0.1 (by u/Cervator)"}
+
+        async with httpx.AsyncClient() as client:
+            response = await client.get(url, headers=headers, follow_redirects=True)
+            response.raise_for_status()
+
+        posts = response.json()["data"]["children"]
+        alerts = []
+        for post in posts:
+            alert = self.parse_post(post)
+            if alert is not None:
+                alerts.append(alert)
+        return alerts
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd components/knarr && python -m pytest tests/test_reddit_watcher.py -v
+```
+
+Expected: 2 passed.
+
+- [ ] **Step 5: Commit**
+
+Write `.commits/07-reddit-watcher.md`:
+
+```markdown
+---
+add:
+  - src/watchers/reddit_watcher.py
+  - tests/test_reddit_watcher.py
+---
+
+feat: add Reddit watcher with post parsing and deduplication
+
+Polls r/Terasology for new posts, parses into WatchAlert events.
+Deduplicates by Reddit post ID.
+```
+
+```bash
+bash scripts/ws commit knarr .commits/07-reddit-watcher.md
+```
+
+---
+
+## Task 8: GitHub Notification Watcher
+
+**Files:**
+- Create: `knarr/src/watchers/github_watcher.py`
+- Create: `knarr/tests/test_github_watcher.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_github_watcher.py`:
+
+```python
+from src.watchers.github_watcher import GitHubWatcher
+from src.watchers.schemas import WatchAlert
+
+
+def test_parse_notification_into_alert():
+    watcher = GitHubWatcher(
+        repos=["MovingBlocks/Terasology"],
+        kafka_bootstrap="localhost:9092",
+        kafka_topic="knarr.watch.alerts",
+    )
+
+    notification = {
+        "id": "12345",
+        "subject": {
+            "title": "Fix rendering bug on ARM Macs",
+            "type": "Issue",
+            "url": "https://api.github.com/repos/MovingBlocks/Terasology/issues/5678",
+        },
+        "repository": {
+            "full_name": "MovingBlocks/Terasology",
+            "html_url": "https://github.com/MovingBlocks/Terasology",
+        },
+        "reason": "subscribed",
+        "updated_at": "2026-04-02T10:00:00Z",
+    }
+
+    alert = watcher.parse_notification(notification)
+
+    assert isinstance(alert, WatchAlert)
+    assert alert.source.platform == "github"
+    assert alert.source.channel == "MovingBlocks/Terasology"
+    assert alert.content.type == "Issue"
+    assert "Fix rendering bug on ARM Macs" in alert.content.body
+    assert "github.com/MovingBlocks/Terasology/issues/5678" in alert.content.url
+
+
+def test_deduplication_skips_seen_notifications():
+    watcher = GitHubWatcher(
+        repos=["MovingBlocks/Terasology"],
+        kafka_bootstrap="localhost:9092",
+        kafka_topic="knarr.watch.alerts",
+    )
+
+    notification = {
+        "id": "99999",
+        "subject": {
+            "title": "Some issue",
+            "type": "Issue",
+            "url": "https://api.github.com/repos/MovingBlocks/Terasology/issues/1",
+        },
+        "repository": {
+            "full_name": "MovingBlocks/Terasology",
+            "html_url": "https://github.com/MovingBlocks/Terasology",
+        },
+        "reason": "mention",
+        "updated_at": "2026-04-02T10:00:00Z",
+    }
+
+    alert1 = watcher.parse_notification(notification)
+    assert alert1 is not None
+
+    alert2 = watcher.parse_notification(notification)
+    assert alert2 is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd components/knarr && python -m pytest tests/test_github_watcher.py -v
+```
+
+Expected: `ModuleNotFoundError: No module named 'src.watchers.github_watcher'`
+
+- [ ] **Step 3: Write the GitHub watcher implementation**
+
+Create `src/watchers/github_watcher.py`:
+
+```python
+"""GitHub watcher — polls notifications for watched repos and publishes alerts to Kafka."""
+
+import logging
+import re
+from typing import Optional
+
+import httpx
+
+from .schemas import WatchAlert, Source, Content
+
+logger = logging.getLogger(__name__)
+
+
+class GitHubWatcher:
+    def __init__(
+        self,
+        repos: list[str],
+        kafka_bootstrap: str,
+        kafka_topic: str,
+        github_token: Optional[str] = None,
+        poll_interval_seconds: int = 300,
+    ):
+        self.repos = repos
+        self.kafka_bootstrap = kafka_bootstrap
+        self.kafka_topic = kafka_topic
+        self.github_token = github_token
+        self.poll_interval_seconds = poll_interval_seconds
+        self._seen_ids: set[str] = set()
+
+    def _api_url_to_html_url(self, api_url: str) -> str:
+        """Convert GitHub API URL to human-readable HTML URL."""
+        return (
+            api_url.replace("api.github.com/repos/", "github.com/")
+            .replace("/pulls/", "/pull/")
+        )
+
+    def parse_notification(self, notification: dict) -> Optional[WatchAlert]:
+        """Parse a GitHub notification into a WatchAlert. Returns None if already seen."""
+        notif_id = notification["id"]
+
+        if notif_id in self._seen_ids:
+            return None
+        self._seen_ids.add(notif_id)
+
+        subject = notification["subject"]
+        repo = notification["repository"]["full_name"]
+        title = subject["title"]
+        subject_type = subject["type"]
+        api_url = subject.get("url", "")
+        html_url = self._api_url_to_html_url(api_url) if api_url else notification["repository"]["html_url"]
+
+        return WatchAlert(
+            source=Source(
+                platform="github",
+                channel=repo,
+                community="terasology",
+            ),
+            content=Content(
+                type=subject_type,
+                body=f"[{subject_type}] {title}",
+                url=html_url,
+            ),
+        )
+
+    async def fetch_notifications(self) -> list[WatchAlert]:
+        """Fetch recent GitHub notifications and return unseen alerts."""
+        headers = {"Accept": "application/vnd.github+json"}
+        if self.github_token:
+            headers["Authorization"] = f"Bearer {self.github_token}"
+
+        async with httpx.AsyncClient() as client:
+            response = await client.get(
+                "https://api.github.com/notifications",
+                headers=headers,
+                params={"participating": "false", "all": "false"},
+            )
+            response.raise_for_status()
+
+        alerts = []
+        for notification in response.json():
+            repo = notification["repository"]["full_name"]
+            if repo in self.repos:
+                alert = self.parse_notification(notification)
+                if alert is not None:
+                    alerts.append(alert)
+        return alerts
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd components/knarr && python -m pytest tests/test_github_watcher.py -v
+```
+
+Expected: 2 passed.
+
+- [ ] **Step 5: Commit**
+
+Write `.commits/08-github-watcher.md`:
+
+```markdown
+---
+add:
+  - src/watchers/github_watcher.py
+  - tests/test_github_watcher.py
+---
+
+feat: add GitHub notification watcher with deduplication
+
+Polls GitHub notifications API for watched repos, parses into
+WatchAlert events. Filters to configured repos only.
+```
+
+```bash
+bash scripts/ws commit knarr .commits/08-github-watcher.md
+```
+
+---
+
+## Task 9: Knarr Router Bot (Kafka → Matrix)
+
+**Files:**
+- Create: `knarr/src/router/__init__.py`
+- Create: `knarr/src/router/main.py`
+- Create: `knarr/src/router/kafka_consumer.py`
+- Create: `knarr/tests/test_router.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_router.py`:
+
+```python
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.router.kafka_consumer import format_alert_message
+from src.watchers.schemas import WatchAlert, Source, Content
+
+
+def test_format_reddit_alert():
+    alert = WatchAlert(
+        source=Source(platform="reddit", channel="r/Terasology", community="terasology"),
+        content=Content(
+            type="new_post",
+            body="**Cool build** by u/gamer42",
+            url="https://www.reddit.com/r/Terasology/comments/abc123/cool_build/",
+        ),
+    )
+
+    message = format_alert_message(alert)
+
+    assert "reddit" in message.lower() or "Reddit" in message
+    assert "r/Terasology" in message
+    assert "Cool build" in message
+    assert "reddit.com" in message
+
+
+def test_format_github_alert():
+    alert = WatchAlert(
+        source=Source(platform="github", channel="MovingBlocks/Terasology", community="terasology"),
+        content=Content(
+            type="Issue",
+            body="[Issue] Fix rendering bug on ARM Macs",
+            url="https://github.com/MovingBlocks/Terasology/issues/5678",
+        ),
+    )
+
+    message = format_alert_message(alert)
+
+    assert "GitHub" in message or "github" in message
+    assert "MovingBlocks/Terasology" in message
+    assert "Fix rendering bug" in message
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd components/knarr && python -m pytest tests/test_router.py -v
+```
+
+Expected: `ModuleNotFoundError: No module named 'src.router'`
+
+- [ ] **Step 3: Write the Kafka consumer and message formatter**
+
+Create `src/router/__init__.py` (empty file).
+
+Create `src/router/kafka_consumer.py`:
+
+```python
+"""Kafka consumer that reads watcher alerts and formats them for Matrix."""
+
+import json
+import logging
+from typing import Optional
+
+from ..watchers.schemas import WatchAlert
+
+logger = logging.getLogger(__name__)
+
+PLATFORM_EMOJI = {
+    "reddit": "\U0001f4e2",
+    "github": "\U0001f4bb",
+    "steam": "\U0001f3ae",
+    "twitter": "\U0001f426",
+    "youtube": "\U0001f3ac",
+}
+
+
+def format_alert_message(alert: WatchAlert) -> str:
+    """Format a WatchAlert into a human-readable Matrix message."""
+    emoji = PLATFORM_EMOJI.get(alert.source.platform, "\U0001f514")
+    platform = alert.source.platform.capitalize()
+
+    lines = [
+        f"{emoji} **{platform}** — {alert.source.channel}",
+        f"{alert.content.body}",
+    ]
+    if alert.content.url:
+        lines.append(f"\U0001f517 {alert.content.url}")
+
+    return "\n".join(lines)
+
+
+def deserialize_alert(raw: bytes) -> Optional[WatchAlert]:
+    """Deserialize a Kafka message value into a WatchAlert."""
+    try:
+        data = json.loads(raw)
+        return WatchAlert.from_kafka_dict(data)
+    except (json.JSONDecodeError, KeyError) as e:
+        logger.warning("Failed to deserialize alert: %s", e)
+        return None
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd components/knarr && python -m pytest tests/test_router.py -v
+```
+
+Expected: 2 passed.
+
+- [ ] **Step 5: Write the router bot main module**
+
+Create `src/router/main.py`:
+
+```python
+"""Knarr router bot — connects to Matrix and posts watcher alerts from Kafka.
+
+Usage:
+    python -m src.router.main
+
+Environment variables:
+    MATRIX_HOMESERVER   - Synapse URL (e.g. http://synapse:8008)
+    MATRIX_USER         - Bot user ID (e.g. @knarr-router:knarr.local)
+    MATRIX_PASSWORD     - Bot user password
+    MATRIX_ROOM_ID      - Room ID for #social-watch
+    KAFKA_BOOTSTRAP     - Kafka bootstrap servers
+    KAFKA_TOPIC         - Topic to consume (default: knarr.watch.alerts)
+"""
+
+import asyncio
+import json
+import logging
+import os
+import signal
+from threading import Thread
+
+from confluent_kafka import Consumer, KafkaError
+from nio import AsyncClient, LoginResponse
+
+from .kafka_consumer import format_alert_message, deserialize_alert
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+
+async def main():
+    homeserver = os.environ["MATRIX_HOMESERVER"]
+    user = os.environ["MATRIX_USER"]
+    password = os.environ["MATRIX_PASSWORD"]
+    room_id = os.environ["MATRIX_ROOM_ID"]
+    kafka_bootstrap = os.environ["KAFKA_BOOTSTRAP"]
+    kafka_topic = os.environ.get("KAFKA_TOPIC", "knarr.watch.alerts")
+
+    # Connect to Matrix
+    client = AsyncClient(homeserver, user)
+    response = await client.login(password)
+    if not isinstance(response, LoginResponse):
+        logger.error("Matrix login failed: %s", response)
+        return
+    logger.info("Logged into Matrix as %s", user)
+
+    # Set up Kafka consumer
+    consumer = Consumer({
+        "bootstrap.servers": kafka_bootstrap,
+        "group.id": "knarr-router",
+        "auto.offset.reset": "latest",
+    })
+    consumer.subscribe([kafka_topic])
+
+    running = True
+
+    def handle_signal(signum, frame):
+        nonlocal running
+        running = False
+
+    signal.signal(signal.SIGTERM, handle_signal)
+    signal.signal(signal.SIGINT, handle_signal)
+
+    logger.info("Router started — consuming from %s, posting to %s", kafka_topic, room_id)
+
+    try:
+        while running:
+            msg = consumer.poll(timeout=1.0)
+            if msg is None:
+                continue
+            if msg.error():
+                if msg.error().code() == KafkaError._PARTITION_EOF:
+                    continue
+                logger.error("Kafka error: %s", msg.error())
+                continue
+
+            alert = deserialize_alert(msg.value())
+            if alert is None:
+                continue
+
+            formatted = format_alert_message(alert)
+            await client.room_send(
+                room_id,
+                message_type="m.room.message",
+                content={
+                    "msgtype": "m.text",
+                    "body": formatted,
+                    "format": "org.matrix.custom.html",
+                    "formatted_body": formatted.replace("\n", "<br>"),
+                },
+            )
+            logger.info("Posted alert from %s/%s", alert.source.platform, alert.source.channel)
+    finally:
+        consumer.close()
+        await client.close()
+        logger.info("Router shut down")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+- [ ] **Step 6: Run all tests**
+
+```bash
+cd components/knarr && python -m pytest tests/ -v
+```
+
+Expected: all 6 tests pass (2 schema, 2 reddit, 2 router).
+
+- [ ] **Step 7: Commit**
+
+Write `.commits/09-router.md`:
+
+```markdown
+---
+add:
+  - src/router/__init__.py
+  - src/router/main.py
+  - src/router/kafka_consumer.py
+  - tests/test_router.py
+---
+
+feat: add Knarr router bot — Kafka watcher alerts to Matrix
+
+Consumes from knarr.watch.alerts Kafka topic, formats alerts
+with platform context, and posts to a Matrix #social-watch room.
+```
+
+```bash
+bash scripts/ws commit knarr .commits/09-router.md
+```
+
+---
+
+## Task 10: Containerize and Deploy Watchers + Router
+
+**Files:**
+- Create: `knarr/src/watchers/Dockerfile`
+- Create: `knarr/src/watchers/run.py`
+- Create: `knarr/src/router/Dockerfile`
+- Create: `knarr/k8s/watchers/reddit-github.yaml`
+- Create: `knarr/k8s/router/deployment.yaml`
+
+- [ ] **Step 1: Create the watcher runner**
+
+Create `src/watchers/run.py`:
+
+```python
+"""Watcher runner — polls platforms and publishes alerts to Kafka.
+
+Environment variables:
+    KAFKA_BOOTSTRAP       - Kafka bootstrap servers
+    KAFKA_TOPIC           - Target topic (default: knarr.watch.alerts)
+    REDDIT_SUBREDDIT      - Subreddit to watch (default: Terasology)
+    GITHUB_REPOS          - Comma-separated repo list (default: MovingBlocks/Terasology)
+    GITHUB_TOKEN          - GitHub personal access token (optional, for higher rate limits)
+    POLL_INTERVAL_SECONDS - Polling interval (default: 300)
+"""
+
+import asyncio
+import json
+import logging
+import os
+import signal
+
+from confluent_kafka import Producer
+
+from .reddit_watcher import RedditWatcher
+from .github_watcher import GitHubWatcher
+from .schemas import WatchAlert
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+
+def publish_alerts(producer: Producer, topic: str, alerts: list[WatchAlert]):
+    for alert in alerts:
+        producer.produce(
+            topic,
+            key=f"{alert.source.platform}:{alert.source.channel}",
+            value=json.dumps(alert.to_kafka_dict()),
+        )
+    producer.flush()
+
+
+async def main():
+    kafka_bootstrap = os.environ["KAFKA_BOOTSTRAP"]
+    kafka_topic = os.environ.get("KAFKA_TOPIC", "knarr.watch.alerts")
+    poll_interval = int(os.environ.get("POLL_INTERVAL_SECONDS", "300"))
+
+    reddit_sub = os.environ.get("REDDIT_SUBREDDIT", "Terasology")
+    github_repos = os.environ.get("GITHUB_REPOS", "MovingBlocks/Terasology").split(",")
+    github_token = os.environ.get("GITHUB_TOKEN")
+
+    reddit = RedditWatcher(
+        subreddit=reddit_sub,
+        kafka_bootstrap=kafka_bootstrap,
+        kafka_topic=kafka_topic,
+        poll_interval_seconds=poll_interval,
+    )
+    github = GitHubWatcher(
+        repos=github_repos,
+        kafka_bootstrap=kafka_bootstrap,
+        kafka_topic=kafka_topic,
+        github_token=github_token,
+        poll_interval_seconds=poll_interval,
+    )
+
+    producer = Producer({"bootstrap.servers": kafka_bootstrap})
+
+    running = True
+
+    def handle_signal(signum, frame):
+        nonlocal running
+        running = False
+
+    signal.signal(signal.SIGTERM, handle_signal)
+    signal.signal(signal.SIGINT, handle_signal)
+
+    logger.info(
+        "Watcher started — reddit: r/%s, github: %s, interval: %ds",
+        reddit_sub, github_repos, poll_interval,
+    )
+
+    while running:
+        try:
+            reddit_alerts = await reddit.fetch_new_posts()
+            if reddit_alerts:
+                publish_alerts(producer, kafka_topic, reddit_alerts)
+                logger.info("Published %d Reddit alerts", len(reddit_alerts))
+
+            github_alerts = await github.fetch_notifications()
+            if github_alerts:
+                publish_alerts(producer, kafka_topic, github_alerts)
+                logger.info("Published %d GitHub alerts", len(github_alerts))
+
+        except Exception:
+            logger.exception("Error during poll cycle")
+
+        await asyncio.sleep(poll_interval)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+- [ ] **Step 2: Create the watcher Dockerfile**
+
+Create `src/watchers/Dockerfile`:
+
+```dockerfile
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY src/ src/
+
+CMD ["python", "-m", "src.watchers.run"]
+```
+
+Note: This Dockerfile is built from the repo root, not from `src/watchers/`.
+
+- [ ] **Step 3: Create the router Dockerfile**
+
+Create `src/router/Dockerfile`:
+
+```dockerfile
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY src/ src/
+
+CMD ["python", "-m", "src.router.main"]
+```
+
+- [ ] **Step 4: Build and load images into k3d**
+
+```bash
+cd components/knarr
+
+docker build -f src/watchers/Dockerfile -t knarr-watchers:dev .
+docker build -f src/router/Dockerfile -t knarr-router:dev .
+
+k3d image import knarr-watchers:dev knarr-router:dev -c nordri-test
+```
+
+Expected: images imported successfully.
+
+- [ ] **Step 5: Create the router bot Matrix user**
+
+```bash
+kubectl --context k3d-nordri-test exec -n knarr deploy/synapse -- \
+  register_new_matrix_user -c /config/homeserver.yaml \
+  -u knarr-router -p <choose-a-password> \
+  http://localhost:8008
+```
+
+Not an admin user (no `-a` flag). Record the password.
+
+Then, from Element as admin, invite `@knarr-router:knarr.local` to the `#social-watch` room and accept the invite (or set the room to auto-accept). Note the room's internal ID (starts with `!`) — you can find it in Element room settings under "Advanced".
+
+- [ ] **Step 6: Create the watcher + router deployments**
+
+Create `k8s/watchers/reddit-github.yaml`:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: knarr-watchers
+  namespace: knarr
+  labels:
+    app: knarr-watchers
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: knarr-watchers
+  template:
+    metadata:
+      labels:
+        app: knarr-watchers
+    spec:
+      containers:
+        - name: watchers
+          image: knarr-watchers:dev
+          imagePullPolicy: Never
+          env:
+            - name: KAFKA_BOOTSTRAP
+              value: "KAFKA_BOOTSTRAP_SVC:9092"
+            - name: KAFKA_TOPIC
+              value: "knarr.watch.alerts"
+            - name: REDDIT_SUBREDDIT
+              value: "Terasology"
+            - name: GITHUB_REPOS
+              value: "MovingBlocks/Terasology"
+            - name: POLL_INTERVAL_SECONDS
+              value: "300"
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              memory: 128Mi
+```
+
+Replace `KAFKA_BOOTSTRAP_SVC` with the actual Kafka bootstrap service name from Task 4 Step 4 (e.g. `knarr-kafka-kafka-bootstrap.kafka.svc.cluster.local`).
+
+Create `k8s/router/deployment.yaml`:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: knarr-router
+  namespace: knarr
+  labels:
+    app: knarr-router
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: knarr-router
+  template:
+    metadata:
+      labels:
+        app: knarr-router
+    spec:
+      containers:
+        - name: router
+          image: knarr-router:dev
+          imagePullPolicy: Never
+          env:
+            - name: MATRIX_HOMESERVER
+              value: "http://synapse.knarr.svc.cluster.local:8008"
+            - name: MATRIX_USER
+              value: "@knarr-router:knarr.local"
+            - name: MATRIX_PASSWORD
+              value: "ROUTER_BOT_PASSWORD"
+            - name: MATRIX_ROOM_ID
+              value: "SOCIAL_WATCH_ROOM_ID"
+            - name: KAFKA_BOOTSTRAP
+              value: "KAFKA_BOOTSTRAP_SVC:9092"
+            - name: KAFKA_TOPIC
+              value: "knarr.watch.alerts"
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              memory: 128Mi
+```
+
+Replace `ROUTER_BOT_PASSWORD`, `SOCIAL_WATCH_ROOM_ID`, and `KAFKA_BOOTSTRAP_SVC` with actual values from previous steps.
+
+- [ ] **Step 7: Deploy watchers and router**
+
+```bash
+kubectl --context k3d-nordri-test apply -f k8s/watchers/
+kubectl --context k3d-nordri-test apply -f k8s/router/
+```
+
+- [ ] **Step 8: Verify everything is running**
+
+```bash
+kubectl --context k3d-nordri-test get pods -n knarr
+```
+
+Expected: synapse, mautrix-discord, knarr-watchers, knarr-router all `Running`.
+
+Check watcher logs:
+
+```bash
+kubectl --context k3d-nordri-test logs -n knarr -l app=knarr-watchers --tail=20
+```
+
+Expected: "Watcher started" log line, then periodic poll activity.
+
+Check router logs:
+
+```bash
+kubectl --context k3d-nordri-test logs -n knarr -l app=knarr-router --tail=20
+```
+
+Expected: "Logged into Matrix" and "Router started" log lines.
+
+- [ ] **Step 9: End-to-end test**
+
+Wait for the watcher to complete a poll cycle (up to 5 minutes with default interval). If there are any recent posts on r/Terasology, they should flow through:
+
+1. Watcher polls Reddit → publishes to `knarr.watch.alerts` Kafka topic
+2. Router consumes from Kafka → posts formatted alert to `#social-watch` Matrix room
+3. You see the alert in Element
+
+If nothing appears after one cycle, check:
+- Watcher logs for errors
+- Kafka topic has messages: `kubectl --context k3d-nordri-test exec -n kafka <kafka-pod> -- bin/kafka-console-consumer.sh --bootstrap-server localhost:9092 --topic knarr.watch.alerts --from-beginning --max-messages 5`
+- Router logs for Kafka consumption or Matrix posting errors
+
+- [ ] **Step 10: Commit**
+
+Write `.commits/10-deploy.md`:
+
+```markdown
+---
+add:
+  - src/watchers/Dockerfile
+  - src/watchers/run.py
+  - src/router/Dockerfile
+  - k8s/watchers/reddit-github.yaml
+  - k8s/router/deployment.yaml
+---
+
+feat: containerize and deploy watchers + router to k3d
+
+Reddit and GitHub watchers poll and publish to Kafka.
+Router bot consumes alerts and posts to Matrix #social-watch room.
+```
+
+```bash
+bash scripts/ws commit knarr .commits/10-deploy.md
+```
+
+---
+
+## Summary
+
+After completing all 10 tasks, the running system looks like:
+
+```mermaid
+flowchart TB
+    subgraph "External"
+        discord["Terasology Discord"]
+        reddit["r/Terasology"]
+        github["GitHub Notifications"]
+        element["Element (phone/desktop)"]
+    end
+
+    subgraph "k3d-nordri-test / knarr namespace"
+        synapse["Synapse"]
+        bridge["mautrix-discord"]
+        watchers["Watchers (Reddit + GitHub)"]
+        router["Router Bot"]
+    end
+
+    subgraph "k3d-nordri-test / kafka namespace"
+        kafka["Kafka (knarr.watch.alerts)"]
+    end
+
+    subgraph "k3d-nordri-test / knarr namespace"
+        pg["PostgreSQL (Synapse DB)"]
+    end
+
+    discord <--> bridge <--> synapse
+    reddit --> watchers
+    github --> watchers
+    watchers --> kafka
+    kafka --> router
+    router --> synapse
+    synapse <--> element
+    pg --> synapse
+```
+
+**What you get:**
+- Private Matrix homeserver accessible from Element on phone and desktop
+- Bidirectional Discord bridge for Terasology channels
+- Reddit and GitHub alerts appearing in `#social-watch`
+- Kafka event bus ready for Phase 2+ (routing engine, approval workflows, more bridges)


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @Cervator via GDD.

## Summary

- Add Knarr design spec covering the full communication hub architecture built over iterative brainstorming sessions
- Identity and subscription model: Keycloak-backed user identity, platform account attributes, per-user notification preferences, self-service opt-in via SMS/email, Valkey cache for fast lookups
- Bridge limitations: documented graceful degradation for reactions and threads across rich (Discord/Matrix) and thin (SMS/email) channels
- Alert batching with threaded digest display for high-volume sources, configurable per room
- Feeds hierarchy with nested sub-spaces per community, cross-room linking ("link, don't mirror"), AI highlights channel
- Future explorations: web-searchable chat archive (Scribe), blog commenting via Cactus Comments + Matrix rooms
- Federation and multi-instance growth model: 4 stages from single instance to community kit, 4 open-ended options for what federates vs stays local

## Test plan

- [ ] Design spec renders correctly in Markdown preview
- [ ] Mermaid diagrams render (sequence diagrams, flowcharts)
- [ ] No broken internal links within the design doc
