### PR TITLE
Skill content hygiene: extract ws hoard cadence; trim duplication

### DIFF
--- a/.agent/skills/gdd-orientation/SKILL.md
+++ b/.agent/skills/gdd-orientation/SKILL.md
@@ -79,67 +79,42 @@ override is read by `ws_resolve_machine_name` in `scripts/ws-hoard.sh`.
 
 ### Step 0a: Thalamus commit-cadence nudge
 
-If Step 0 resolved an active thalami hoard, check whether the
-per-machine thalamus file has uncommitted changes that have been
-sitting around longer than `commit_staleness_days` (frontmatter
-field; defaults to 2 if unset). This is a separate cadence from
-the audit `staleness_days` in Step 3.
+If Step 0 resolved an active thalami hoard, run `ws hoard cadence`
+and react to its `status:` line. The script handles dirty-detection,
+timestamp lookup, threshold comparison (`commit_staleness_days` from
+the thalamus frontmatter; default 2), and edge cases (file missing,
+file untracked) — the skill just decides what to surface based on
+the reported status. This is a separate cadence from the audit
+`staleness_days` in Step 3.
 
-Mechanism:
+Status-to-action mapping:
 
-1. Detect file-level dirty state for the per-machine thalamus
-   specifically — not just hoard-wide dirty state, since `ws status`
-   could report the hoard as dirty for unrelated reasons (other
-   machine's thalamus, scratch notes, etc.). Use porcelain status
-   (NOT `diff --quiet`, which returns "clean" for untracked files
-   and would silently skip first-time machines):
+| `status:` | What to do |
+|-----------|------------|
+| `clean` | Silent. No nudge. |
+| `dirty-fresh` | Silent. Within threshold; user is mid-cadence. |
+| `dirty-stale` | Surface the nudge below with elapsed time. |
+| `never-committed` | Surface a "first commit for this machine's thalamus — commit now?" prompt. |
+| `no-active-hoard` | Silent. Nothing to check. |
+| `no-thalamus-file` | Silent unless the user is clearly mid-setup; then offer to copy `templates/thalamus.md` into place. |
 
-   ```bash
-   git -C hoards/<thalami-hoard> status --porcelain -- <machine>-thalamus.md
-   ```
+Nudge wording for `dirty-stale`:
 
-   Empty output = clean (skip the rest of the check); non-empty
-   output = dirty, including the untracked case (continue).
+> "Thalamus has uncommitted changes. Last commit was `<elapsed_days>`
+> days, `<elapsed_hours>` hours ago (threshold:
+> `commit_staleness_days = <threshold_days>`). Want me to commit
+> these before we start, or save for later?"
 
-2. If dirty, get its last-commit timestamp:
-
-   ```bash
-   last_commit_timestamp=$(git -C hoards/<thalami-hoard> log -1 --format=%ct -- <machine>-thalamus.md)
-   ```
-
-3. Handle the "no prior commit" case (new file never committed):
-   if `last_commit_timestamp` is empty, surface a different nudge
-   ("first commit for this machine's thalamus — commit now?") and
-   skip the elapsed-time math. Otherwise compute:
-
-   ```bash
-   elapsed_seconds=$(( $(date +%s) - last_commit_timestamp ))
-   threshold_seconds=$(( commit_staleness_days * 86400 ))
-   ```
-
-4. If `elapsed_seconds > threshold_seconds`, surface a soft nudge:
-
-   > "Thalamus: <N> uncommitted observations. Last commit was
-   > <X> days, <Y> hours ago (threshold: commit_staleness_days =
-   > <Z>). Want me to commit these before we start, or save for
-   > later?"
-
-   Where `<N>` is the line count from the same file-scoped
-   `git status --porcelain -- <machine>-thalamus.md` used in Step 1
-   (so it excludes unrelated hoard-wide changes), `<X>` / `<Y>` are
-   elapsed days / hours, `<Z>` is the configured threshold. Reports
-   honest elapsed time — not rounded to "calendar days," which
-   would false-positive across midnight.
+Substitute the values from the `ws hoard cadence` output (it emits
+`elapsed_days:`, `elapsed_hours:`, `threshold_days:` as key-value
+lines below the status). Reports honest elapsed time — not rounded
+to "calendar days," which would false-positive across midnight.
 
 If the user agrees to commit now, walk them through writing a
 bodyfile and run `ws commit thalami-<user> <bodyfile>` (do NOT
 auto-stage; the bodyfile's `add:` list is explicit per the cadence
 preference captured elsewhere in the Thalamus). If they defer,
 proceed silently.
-
-Below threshold or working tree clean: silent. No mention at all in
-orientation. The threshold is the only signal — no nudge means no
-need to think about it.
 
 ### Step 1: Check for Thalamus.md
 

--- a/.agent/skills/gdd-orientation/SKILL.md
+++ b/.agent/skills/gdd-orientation/SKILL.md
@@ -79,8 +79,9 @@ override is read by `ws_resolve_machine_name` in `scripts/ws-hoard.sh`.
 
 ### Step 0a: Thalamus commit-cadence nudge
 
-If Step 0 resolved an active thalami hoard, run `ws hoard cadence`
-and react to its `status:` line. The script handles dirty-detection,
+If Step 0 resolved an active thalami hoard, run `bash scripts/ws hoard cadence`
+(or `ws hoard cadence` if `ws` is on PATH) and react to its
+`status:` line. The script handles dirty-detection,
 timestamp lookup, threshold comparison (`commit_staleness_days` from
 the thalamus frontmatter; default 2), and edge cases (file missing,
 file untracked) — the skill just decides what to surface based on

--- a/.agent/skills/permissions-management/SKILL.md
+++ b/.agent/skills/permissions-management/SKILL.md
@@ -33,23 +33,20 @@ patterns at once), invoke `fewer-permission-prompts` instead.
 
 ## Pattern-form decision tree
 
-Before adding any pattern:
+The full decision tree is in `docs/gdd/permissions.md` § 5
+("When to widen vs narrow patterns"). Read that for the full
+reasoning before adding any non-trivial pattern.
 
-1. **Already auto-allowed?** Many commands are auto-allowed by Claude
-   Code without an explicit pattern (`cat`, `ls`, `pwd`, plain `git
-   status`, plain `git log`, `gh pr view`, etc.). If yes: don't add a
-   pattern — it's redundant.
-2. **Subcommand has mutating flag-forms?**
-   - **No** (e.g. `git show`, `git diff`, `git ls-tree`): a prefix
-     wildcard is fine: `Bash(git -C * show *)`.
-   - **Yes** (e.g. `git branch -d`, `git remote add`): pin to the
-     exact safe form: `Bash(git -C * branch --show-current)`,
-     `Bash(git -C * remote -v)`.
-3. **Arbitrary-execution shell?** (`bash *`, `python *`, `node *`,
-   `npx *`, `bunx *`, `uvx *`, `make *`, `npm run *`, `gh api *`.)
-   Never widen. Exact forms only, if at all.
-4. **Writes to a shared system?** (push, deploy, publish, send.)
-   Don't allow at all. Side-effect-tier per `docs/ws-cli-guide.md`.
+Operational shortcuts when you've already read the doc:
+
+- **Already auto-allowed by Claude Code?** Don't add — redundant.
+- **Subcommand has no mutating flag-form?** Prefix wildcard is fine.
+- **Subcommand has mutating flag-forms?** Pin to the exact safe form.
+- **Wrapping an interpreter or task runner** (`bash`, `python`,
+  `node`, `make`, `npm run`, `gh api`, etc.)? **Never widen.**
+- **Writes to a shared system** (push, deploy, publish, send)?
+  Don't allowlist at all — side-effect-tier per
+  `docs/ws-cli-guide.md`.
 
 When in doubt, narrower wins.
 

--- a/scripts/ws-hoard.sh
+++ b/scripts/ws-hoard.sh
@@ -127,6 +127,108 @@ ws_hoard_help() {
     echo "                                  Move root Thalamus.md into the new hoard" >&2
     echo "  <git-url>                Clone an existing hoard" >&2
     echo "  list                     Show hoards and which thalami hoard is active" >&2
+    echo "  cadence                  Report dirty/staleness of the active per-machine" >&2
+    echo "                           thalamus file (used by gdd-orientation Step 0a)" >&2
+}
+
+# Read commit_staleness_days from a thalamus file's YAML frontmatter.
+# Defaults to 2 if the field is absent or the file doesn't exist yet.
+ws_hoard_read_staleness_days() {
+    local file="$1"
+    [[ -f "$file" ]] || { echo 2; return; }
+    # Pull the value from the leading `---` frontmatter block. awk
+    # toggles `n` on the `---` markers; we read fields only inside
+    # the first such block.
+    local value
+    value="$(awk '
+        /^---$/ { n++; next }
+        n == 1 && /^commit_staleness_days:[[:space:]]*[0-9]+/ {
+            sub(/^commit_staleness_days:[[:space:]]*/, "")
+            sub(/[[:space:]].*$/, "")
+            print
+            exit
+        }
+    ' "$file")"
+    echo "${value:-2}"
+}
+
+# Report cadence state for the active per-machine thalamus file.
+# Output is key=value lines on stdout — easy for the orientation
+# skill (or any caller) to grep. Always exit 0 except on tooling
+# failure; "nothing to check" is a status, not an error.
+#
+# Statuses:
+#   clean             — file exists, has no uncommitted changes
+#   dirty-fresh       — dirty, last commit within threshold (no nudge)
+#   dirty-stale       — dirty, last commit older than threshold (nudge!)
+#   never-committed   — dirty, no prior commit for this file at all
+#   no-active-hoard   — no thalami-* hoard found
+#   no-thalamus-file  — active hoard but expected file isn't on disk
+ws_hoard_cadence() {
+    local hoard
+    hoard="$(ws_detect_thalami_hoard)"
+    if [[ -z "$hoard" ]]; then
+        echo "status: no-active-hoard"
+        return 0
+    fi
+
+    local thalamus_path
+    thalamus_path="$(ws_resolve_thalamus_path)"
+    local machine_file
+    machine_file="$(basename "$thalamus_path")"
+    local hoard_path="$HOARDS_DIR/$hoard"
+
+    if [[ ! -f "$thalamus_path" ]]; then
+        # Could legitimately mean "first session on this machine,
+        # template-copy hasn't happened yet." Caller decides what to
+        # do; we just report.
+        echo "status: no-thalamus-file"
+        echo "file: $thalamus_path"
+        return 0
+    fi
+
+    local threshold_days
+    threshold_days="$(ws_hoard_read_staleness_days "$thalamus_path")"
+    local threshold_seconds=$(( threshold_days * 86400 ))
+
+    # File-scoped dirty check via porcelain. Empty output = clean;
+    # non-empty (including untracked `??`) = dirty.
+    local porcelain
+    porcelain="$(git -C "$hoard_path" status --porcelain -- "$machine_file" 2>/dev/null)"
+
+    if [[ -z "$porcelain" ]]; then
+        echo "status: clean"
+        echo "file: $thalamus_path"
+        echo "threshold_days: $threshold_days"
+        return 0
+    fi
+
+    # Dirty. Need timestamp to classify fresh vs stale vs never.
+    local last_commit_ts
+    last_commit_ts="$(git -C "$hoard_path" log -1 --format=%ct -- "$machine_file" 2>/dev/null)"
+
+    if [[ -z "$last_commit_ts" ]]; then
+        echo "status: never-committed"
+        echo "file: $thalamus_path"
+        echo "threshold_days: $threshold_days"
+        return 0
+    fi
+
+    local now_ts
+    now_ts="$(date +%s)"
+    local elapsed_seconds=$(( now_ts - last_commit_ts ))
+    local elapsed_days=$(( elapsed_seconds / 86400 ))
+    local elapsed_hours=$(( (elapsed_seconds % 86400) / 3600 ))
+
+    local status="dirty-fresh"
+    [[ "$elapsed_seconds" -gt "$threshold_seconds" ]] && status="dirty-stale"
+
+    echo "status: $status"
+    echo "file: $thalamus_path"
+    echo "elapsed_days: $elapsed_days"
+    echo "elapsed_hours: $elapsed_hours"
+    echo "threshold_days: $threshold_days"
+    echo "last_commit_unix: $last_commit_ts"
 }
 
 # ws_hoard_init [template] [template-args...]
@@ -349,6 +451,9 @@ case "$SUBCMD" in
         ;;
     list)
         ws_hoard_list
+        ;;
+    cadence)
+        ws_hoard_cadence
         ;;
     *)
         ws_hoard_clone_url "$SUBCMD"

--- a/scripts/ws-hoard.sh
+++ b/scripts/ws-hoard.sh
@@ -142,8 +142,8 @@ ws_hoard_read_staleness_days() {
     local value
     value="$(awk '
         /^---$/ { n++; next }
-        n == 1 && /^commit_staleness_days:[[:space:]]*[0-9]+/ {
-            sub(/^commit_staleness_days:[[:space:]]*/, "")
+        n == 1 && /^[[:space:]]*commit_staleness_days:[[:space:]]*[0-9]+/ {
+            sub(/^[[:space:]]*commit_staleness_days:[[:space:]]*/, "")
             sub(/[[:space:]].*$/, "")
             print
             exit
@@ -153,7 +153,7 @@ ws_hoard_read_staleness_days() {
 }
 
 # Report cadence state for the active per-machine thalamus file.
-# Output is key=value lines on stdout — easy for the orientation
+# Output is `key: value` lines on stdout — easy for the orientation
 # skill (or any caller) to grep. Always exit 0 except on tooling
 # failure; "nothing to check" is a status, not an error.
 #
@@ -192,9 +192,15 @@ ws_hoard_cadence() {
     local threshold_seconds=$(( threshold_days * 86400 ))
 
     # File-scoped dirty check via porcelain. Empty output = clean;
-    # non-empty (including untracked `??`) = dirty.
+    # non-empty (including untracked `??`) = dirty. Capture git's
+    # exit status explicitly — without the `if !` guard, a tooling
+    # failure (corrupt repo, permission denied, etc.) would yield an
+    # empty `$porcelain` and we'd misreport `clean`.
     local porcelain
-    porcelain="$(git -C "$hoard_path" status --porcelain -- "$machine_file" 2>/dev/null)"
+    if ! porcelain="$(git -C "$hoard_path" status --porcelain -- "$machine_file" 2>/dev/null)"; then
+        echo "ERROR: failed to read git status for '$machine_file' in '$hoard_path'." >&2
+        return 1
+    fi
 
     if [[ -z "$porcelain" ]]; then
         echo "status: clean"
@@ -204,8 +210,13 @@ ws_hoard_cadence() {
     fi
 
     # Dirty. Need timestamp to classify fresh vs stale vs never.
+    # Same exit-status guard as the porcelain call above — otherwise
+    # a git failure would silently look like "no prior commit."
     local last_commit_ts
-    last_commit_ts="$(git -C "$hoard_path" log -1 --format=%ct -- "$machine_file" 2>/dev/null)"
+    if ! last_commit_ts="$(git -C "$hoard_path" log -1 --format=%ct -- "$machine_file" 2>/dev/null)"; then
+        echo "ERROR: failed to read git history for '$machine_file' in '$hoard_path'." >&2
+        return 1
+    fi
 
     if [[ -z "$last_commit_ts" ]]; then
         echo "status: never-committed"

--- a/scripts/ws-hoard.sh
+++ b/scripts/ws-hoard.sh
@@ -172,11 +172,14 @@ ws_hoard_cadence() {
         return 0
     fi
 
-    local thalamus_path
-    thalamus_path="$(ws_resolve_thalamus_path)"
-    local machine_file
-    machine_file="$(basename "$thalamus_path")"
+    # Build the thalamus path from the already-resolved $hoard rather
+    # than calling ws_resolve_thalamus_path() (which re-runs hoard
+    # detection internally). Keeps this function single-pass.
+    local machine
+    machine="$(ws_resolve_machine_name)"
+    local machine_file="${machine}-thalamus.md"
     local hoard_path="$HOARDS_DIR/$hoard"
+    local thalamus_path="$hoard_path/$machine_file"
 
     if [[ ! -f "$thalamus_path" ]]; then
         # Could legitimately mean "first session on this machine,


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @Cervator via [GDD](https://github.com/SiliconSaga/yggdrasil).

## Summary

Iteration on the skill content shape that landed in PR #47, motivated by the principle: **skills carry decision-making; scripts carry execution; docs carry reference**. PR #47's first pass left technical bash recipes embedded directly in skill prose, which is brittle (agent can miss steps, get the bash wrong, etc.) and made the orientation skill heavier than it needed to be.

Three changes:

1. **`ws hoard cadence` utility subcommand** (`scripts/ws-hoard.sh`). Extracts the dirty-detection + timestamp lookup + threshold comparison + edge-case handling that orientation Step 0a previously walked the agent through inline. Reports state as key=value lines (`status:`, `elapsed_days:`, `elapsed_hours:`, `threshold_days:`, `last_commit_unix:`). Six possible statuses cover all branches: `clean`, `dirty-fresh`, `dirty-stale`, `never-committed`, `no-active-hoard`, `no-thalamus-file`. Reads `commit_staleness_days` from the thalamus YAML frontmatter (default 2).

2. **gdd-orientation Step 0a slim**. Replaced ~50 lines of bash recipe with ~30 lines of status-to-action decision table + nudge wording. The skill now says *when* to surface and *what wording* to use; the script says *how* to detect it. Same observable behavior; less brittle execution path.

3. **permissions-management decision-tree trim**. The skill's Pattern-form decision tree duplicated `docs/gdd/permissions.md` § 5 verbatim — exactly the drift risk the doc's own § 6 cross-reference rule warns about. Replaced the 4-point numbered tree with a pointer at the doc plus an operational shortcuts list. Other skill sections ("Don't ask again" judgment table, scope-narrowing checklist, cross-reference rule, pointers) all stay — genuinely operational content.

## Commits

- `698858d` — feat(ws-hoard): add `ws hoard cadence` and slim Step 0a to use it
- `164fa4d` — refactor(skill): trim permissions-management decision tree to point at doc § 5

## Test plan

- [x] `bash -n` clean on `scripts/ws`, `scripts/ws-hoard.sh`, `scripts/ws-realm.sh`, `scripts/ws-component.sh`.
- [x] `ws hoard cadence` from a clean active thalami hoard reports `status: clean` with the file path and threshold.
- [ ] `ws hoard cadence` reports `status: dirty-fresh` when the thalamus has unstaged edits within threshold (manual touch + revert).
- [ ] `ws hoard cadence` reports `status: dirty-stale` when the thalamus has unstaged edits older than `commit_staleness_days`.
- [ ] `ws hoard cadence` reports `status: never-committed` for a brand-new untracked thalamus file.
- [ ] `ws hoard cadence` reports `status: no-active-hoard` from a workspace without a thalami hoard.
- [ ] CodeRabbit review.

## Notes for reviewers

- The `awk` frontmatter parser in `ws_hoard_read_staleness_days` handles both the canonical case (`commit_staleness_days: 2`) and a missing field (returns default 2). It only inspects the first `---`-delimited frontmatter block, ignoring any later horizontal-rule `---` lines in the body.
- Step 0a's status table includes a `no-thalamus-file` row — the script reports this when the active hoard exists but the per-machine file hasn't been created yet (e.g., first session on a new machine before `cp templates/thalamus.md` runs). Skill defaults to silent here unless the user is clearly mid-setup.
- Skill→script extraction is meant as a model for future cleanups: any time a skill walks the agent through `git ... && compute && compare`, that's a candidate for becoming a `ws <subcommand>`.

## Related

- Predecessor: PR #47 (the introduction of Step 0a; this PR refactors its mechanism).
- Future: `ws permissions check <pattern>` is the obvious next utility extraction (slim the permissions-management skill further); not in this PR's scope.
