### PR TITLE
scribe role design + assorted ws CLI improvements

### DIFF
--- a/docs/gdd/access.md
+++ b/docs/gdd/access.md
@@ -22,7 +22,7 @@ agent contributions cleanly attributed.
 
 ## 1. Two identities, one workspace
 
-A GDD session typically has **two** Git identities in play:
+A GDD session can have **two** Git identities in play:
 
 - **The human contributor** (you). Your GitHub/GitLab username, your
   PAT for any commands you run interactively. Used for committing
@@ -106,24 +106,34 @@ the human's account on every machine.
 ## 4. Token scopes in practice
 
 The agent PAT's scope set determines what it can do remotely. The
-common-case minimum:
+recommended baseline is one write scope plus three read scopes —
+all the read scopes are low-risk additions that just remove
+recurring papercuts in routine PR/review operations:
 
 | Scope | What it enables |
 |-------|-----------------|
-| `repo` | Full read/write on accessible repos. PRs, issues, releases, code, branches. |
-| `read:org` | Read org membership / discussion (needed for some `gh pr edit` operations on org-owned repos). |
+| `repo` | Full read/write on accessible repos. PRs, issues, releases, code, branches. The one *write* scope. |
+| `read:org` | Read org membership. `gh pr edit` and several other org-aware operations need this. |
+| `read:discussion` | Read discussion threads. `gh pr edit` checks this. |
+| `read:project` | Read GitHub Projects (boards, items). `gh pr edit --body-file` checks this. |
 
 `workflow` scope is needed only if the agent edits files under
 `.github/workflows/`. Most GDD work doesn't touch CI definitions.
 
-**Known scope-friction case:** `gh pr edit --title <title>` on an
-org-owned repo requires `read:org` and `read:discussion`. If your
-agent PAT doesn't have those scopes, the workaround is `gh api -X
-PATCH repos/<owner>/<repo>/pulls/<n> --input <file>` with just
-`repo` scope (`gh api` expects the HTTP method via `-X`/`--method`,
-not as a positional argument). On Windows Git Bash, drop the
-leading `/` from the API path to avoid MSYS path conversion
-rewriting it as a Windows filesystem path.
+The three `read:*` scopes don't grant any mutation power and don't
+unlock any code the agent can't already reach via `repo` — they're
+metadata reads that gate routine `gh pr edit`-shaped operations.
+Compromise of the agent token isn't meaningfully expanded by adding
+them; declining them just means hitting the `gh api PATCH` fallback
+below for every PR-edit-shaped call.
+
+**Strict-minimum** (when org policy or paranoia gates the read
+scopes): `repo` alone, with the `gh api -X PATCH
+repos/<owner>/<repo>/pulls/<n> --input <file>` workaround for
+PR-edit operations. `gh api` expects the HTTP method via
+`-X`/`--method`, not as a positional argument. On Windows Git
+Bash, drop the leading `/` from the API path to avoid MSYS path
+conversion rewriting it as a Windows filesystem path.
 
 When in doubt about whether a token covers an operation, run
 `ws diagnose <component>` — it reports per-component remote
@@ -192,7 +202,7 @@ practice. Notes from real workflows on self-hosted GitLab:
 **fork's** API — the `--repo` flag looks like a target but the
 actual POST goes through the fork project. Consequence: the **fork
 write token**, not the upstream reporter token, is the one needed
-for MR creation, even though the MR targets upstream. This catches
+for MR creation, even though the MR targets upstream. This may catch
 people the first time.
 
 **Two-token model.** Every fork-based GitLab operation needs two

--- a/docs/gdd/features.md
+++ b/docs/gdd/features.md
@@ -13,7 +13,7 @@ first.
 
 ## The workspace and the `ws` CLI
 
-Yggdrasil is a *workspace* — a top-level directory that contains a
+Yggdrasil is a *meta workspace* — a top-level directory that contains a
 shared CLI (`scripts/ws`), a workspace-level ecosystem config, and
 everything else (realms, hoards, components, templates, docs) hanging
 off it. Sessions run from the workspace root; all path references are

--- a/docs/git-provider-setup.md
+++ b/docs/git-provider-setup.md
@@ -38,7 +38,19 @@ Settings:
 | Scope | Why |
 |-------|-----|
 | `repo` | Full repo access — PRs, issues, code, cross-org forks |
+| `read:org` | Read org membership — needed by `gh pr edit` and other org-aware ops |
+| `read:discussion` | Read discussion threads — also checked by `gh pr edit` |
+| `read:project` | Read GitHub Projects — checked by `gh pr edit --body-file` |
 | `workflow` | Only if you modify `.github/workflows` files |
+
+The three `read:*` scopes are the recommended baseline alongside
+`repo`. They don't grant any mutation power — they just remove
+recurring papercuts where `gh pr edit`-shaped operations would
+otherwise fail with a scopes error and need the `gh api PATCH`
+workaround documented in [`docs/gdd/access.md`](gdd/access.md) § 4.
+If org policy or token-issuance rules block adding them, the
+strict-minimum (`repo` alone) still works — you'll just hit the
+fallback path more often.
 
 > **Why classic and not fine-grained?** Fine-grained PATs have known
 > limitations with cross-org pull requests and workflow file access.

--- a/docs/plans/2026-05-01-scribe-role-and-vault-templates-design.md
+++ b/docs/plans/2026-05-01-scribe-role-and-vault-templates-design.md
@@ -1,0 +1,454 @@
+# Scribe Role and Vault Templates — Design
+
+**Status:** Draft, awaiting review
+**Date:** 2026-05-01
+**Owner:** Rasmus Praestholm
+**Related:** [Realms and Hoards Design](2026-04-24-realms-and-hoards-design.md), [Component Templates Design](2026-04-25-component-templates-design.md)
+
+## Overview
+
+Add first-class support for working with Obsidian-style vaults from within a
+Guardian Driven Development (GDD) workspace. Two flavors of vault are supported:
+plain Obsidian and [Claudesidian](https://github.com/heyitsnoah/claudesidian)
+(Noah Brier's Claude-Code-friendly Obsidian starter kit). Vaults live as
+hoards under `hoards/<name>/`, classified by a new deterministic scanner, and
+operated against by a new `scribe` role with two layered skills.
+
+The user can run a single Claude session from the yggdrasil root and treat any
+vault as a workflow surface — including invoking Claudesidian-style commands
+in plain text (e.g. *"do a weekly synthesis"*) — without the harness having to
+load Claudesidian's `.claude/` directory natively. Running Claude standalone
+inside a Claudesidian hoard remains supported and is documented as the
+"native experience" for users who prefer it.
+
+## Goals
+
+1. **Single-session vault work** — operate on any vault from yggdrasil root
+   without `cd`-ing or restarting Claude
+2. **Lightweight bridge** — no harness-level integration (no copying hooks,
+   no symlinking commands into `~/.claude/commands/`); rely on plain-text
+   invocation and on-demand file reads
+3. **Two-template scaffold** — `obsidian-vault` (vendored, vanilla) and
+   `claudesidian-vault` (thin wrapper that clones upstream on init)
+4. **Respectful vendoring** — Claudesidian is referenced by URL with
+   attribution and license preservation, not vendored wholesale
+5. **Agent-agnostic** — primary instructions live in agent-neutral files
+   (`AGENTS.md`, skill `SKILL.md` files) so non-Claude agents (e.g. Gemini)
+   can also operate the same workflow
+6. **Composable with existing GDD** — scribe is a peer role to developer /
+   designer / reviewer; modes (zen/quick/flow/mentoring) compose orthogonally;
+   no new mode required
+7. **Deterministic discovery** — vault detection and classification go through
+   a `ws` subcommand with structured output, not skill prose
+
+## Non-goals
+
+The following are explicitly out of scope for v1:
+
+- `ws hoard inspect <name>` — single-hoard deep-dive subcommand
+- `ws template upgrade` — full template-refresh tooling (likely
+  Backstage-backed in a future iteration; separate brainstorm)
+- MCP wiring for the Gemini Vision server bundled with Claudesidian
+- Multi-Thalamus-per-workspace or multi-workspace-per-machine handling
+- Curated Obsidian plugin presets in the plain-vault template
+- Commit-cadence reminders for vault hoards (different model from thalami sync)
+- Cross-vault search or a unified vault index
+
+These are acknowledged as legitimate future concerns; the v1 surface should
+not preclude any of them.
+
+## Role and mode framing
+
+GDD's mode/role split is formalized as part of this design:
+
+| Axis | Question it answers | Examples | Persistence |
+|------|---------------------|----------|-------------|
+| **Mode** | *How* the session runs — ceremony level, ritual depth | zen, quick, flow, mentoring, autonomous | Thalamus default + in-memory override |
+| **Role** | *What* domain you're focused on — which skill bundle is loaded | developer, designer, reviewer, **scribe** | Same — Thalamus default + ad-hoc swap |
+
+Modes and roles compose. "Flow + scribe" and "zen + developer" are both
+valid. The scribe role auto-loads its skill bundle at orientation; other
+roles can dip into the scribe skill on keyword detection without formally
+swapping role.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  AGENTS.md          (skill table rows + hoards section) │
+│   └─ "scribe" role; keyword triggers documented         │
+├─────────────────────────────────────────────────────────┤
+│  Orientation skill  (new vault-scan step in Step 6)     │
+│   └─ Calls `ws hoard scan`; surfaces vault inventory    │
+├─────────────────────────────────────────────────────────┤
+│  scribe skill                                           │
+│   └─ Vault discovery (via `ws hoard scan`), PARA,       │
+│      frontmatter, daily notes, wikilinks, inbox loop    │
+├─────────────────────────────────────────────────────────┤
+│  scribe-claudesidian skill (extends scribe)             │
+│   └─ Reads vault's CLAUDE.md, surfaces command          │
+│      manifest, lazy-loads commands/skills via direct    │
+│      file reads                                         │
+├─────────────────────────────────────────────────────────┤
+│  ws hoard scan          (NEW deterministic scanner)     │
+│   └─ Outputs YAML inventory of hoards w/ flavor tags    │
+├─────────────────────────────────────────────────────────┤
+│  templates/hoards/obsidian-vault/      (vendored)       │
+│  templates/hoards/claudesidian-vault/  (thin wrapper)   │
+└─────────────────────────────────────────────────────────┘
+```
+
+Skills are layered: `scribe-claudesidian` explicitly loads `scribe` first.
+Templates are independent of the skills; they produce hoards whose shape
+the skills already know how to recognize.
+
+## Components
+
+### `scripts/ws-hoard.sh` — `scan` subcommand
+
+New subcommand. Iterates `hoards/*/` and applies three classifiers
+independently — flavors stack:
+
+- **`thalami`** — directory name matches `thalami-*` (existing convention,
+  via `ws_detect_thalami_hoard()` which is reused, not rewritten)
+- **`obsidian`** — has a `.obsidian/` subdirectory
+- **`claudesidian`** — has `.obsidian/` AND `.claude/` AND a top-level
+  `CLAUDE.md` whose first ~30 lines reference Claudesidian or PARA
+  conventions (multi-signal to avoid false positives on unrelated `.claude/`
+  directories)
+
+Output (YAML, multi-record, machine-readable):
+
+```yaml
+- name: borgr
+  path: /Users/cervator/dev/git_ws/yggdrasil/hoards/borgr
+  flavors: [obsidian, claudesidian]
+- name: nonclaudesidian
+  path: /Users/cervator/dev/git_ws/yggdrasil/hoards/nonclaudesidian
+  flavors: [obsidian]
+- name: thalami-Cervator
+  path: /Users/cervator/dev/git_ws/yggdrasil/hoards/thalami-Cervator
+  flavors: [thalami]
+```
+
+Flags:
+
+- `--flavor <name>` — filter to hoards containing the named flavor
+- `--names-only` — emit just hoard names, one per line, for shell-friendly use
+
+The existing human-friendly `ws hoard list` is unchanged. `scan` is the
+machine-consumable counterpart that skills call.
+
+### `.agent/skills/scribe/SKILL.md`
+
+Content sections (~150 lines):
+
+1. **When to load** — role=scribe at orientation, OR keyword detection
+   mid-session for dip-in
+2. **Vault discovery** — call `ws hoard scan --flavor obsidian`, parse YAML,
+   apply binding rules (see "Vault binding sub-flow" below)
+3. **PARA conventions** — folder roles for `00_Inbox`/`01_Projects`/
+   `02_Areas`/`03_Resources`/`04_Archive`/`05_Attachments`/`06_Metadata`
+4. **Frontmatter habits** — YAML frontmatter for new notes (created date,
+   tags, status)
+5. **Wikilinks and embeds** — `[[link]]`, `![[embed]]`, alias syntax
+6. **Daily notes** — `YYYY-MM-DD - Topic` pattern, where they live
+7. **Inbox processing** — capture-process-organize loop, the "<20 items"
+   guideline
+8. **Claudesidian extension hand-off** — if scan reports `claudesidian`
+   flavor on the bound vault, also load `scribe-claudesidian/SKILL.md`
+9. **Keyword calibration** — only trigger on phrases implying capture intent
+   (*"jot this down"*, *"add to my inbox"*) rather than bare keyword matches
+   (*"note that this fails on Windows"*)
+
+The skill description in frontmatter advertises trigger keywords:
+`vault, note, journal, inbox, daily note, obsidian, PARA, wikilink,
+frontmatter, capture, jot, weekly review, thinking partner, weekly synthesis,
+research assistant`. The last three are Claudesidian command names — including
+them lets keyword dip-in trigger correctly when a user says *"thinking partner
+mode"* without first formally entering scribe role.
+
+### `.agent/skills/scribe-claudesidian/SKILL.md`
+
+Content sections (~100 lines):
+
+1. **Loads scribe first** — explicit dependency: this skill builds on the
+   scribe skill's PARA/frontmatter/wikilink content
+2. **Read vault CLAUDE.md once** — prefer `<vault>/CLAUDE.md`; fall back to
+   `<vault>/CLAUDE-BOOTSTRAP.md` if `CLAUDE.md` is absent or its frontmatter
+   looks generic. Either path works; the latter just has less personal context
+3. **Command manifest** — read `<vault>/.claude/claude_config.json` to
+   enumerate commands and shortcuts. Surface inventory once on activation:
+   *"Claudesidian commands available: thinking-partner, inbox-processor,
+   weekly-synthesis, … Type or describe any in plain text."*
+4. **Plain-text invocation pattern** — when the user says e.g. *"do a weekly
+   synthesis"*, read `<vault>/.claude/commands/weekly-synthesis.md` and
+   follow it verbatim, citing the file path so the user can see what was
+   loaded
+5. **Skill manifest** — list of `.claude/skills/*/SKILL.md` available;
+   lazy-read on relevance (e.g. `obsidian-bases` skill loaded only when the
+   user works with Obsidian Bases)
+6. **What is intentionally not adopted** — `.claude/settings.json` hooks,
+   the `skill-discovery.sh` UserPromptSubmit hook (functionality replaced
+   by surfacing the manifest at activation), MCP servers (handled
+   separately if user opts in)
+
+### `AGENTS.md` additions
+
+Three small touches:
+
+1. **Skills table** — append two rows for the new skills with one-line
+   descriptions and SKILL.md links
+2. **Hoards section** — append one line: *"Hoard templates ship under
+   `templates/hoards/<flavor>/`. Current flavors: `thalami`, `basic`,
+   `obsidian-vault`, `claudesidian-vault`."*
+3. **Role list** — add `scribe` to the authoritative role list (in
+   `.agent/skills/gdd/SKILL.md` per existing GDD structure)
+
+### `.agent/skills/gdd-orientation/SKILL.md` change
+
+One small addition to the existing Step 6 (component scan): also call
+`ws hoard scan` and surface vault flavors. *"Detected vaults: borgr
+(claudesidian), nonclaudesidian (obsidian). Want to start in scribe role?"*
+
+The prompt only surfaces if at least one obsidian-flavored hoard exists
+AND the Thalamus frontmatter `role:` is null. If `role: scribe` is already
+set, the orientation skill loads the scribe skill directly per existing
+Step 5 logic.
+
+## Vault binding sub-flow
+
+Called by all four trigger paths.
+
+```
+1. Run: ws hoard scan --flavor obsidian
+   → returns YAML list of obsidian-flavored hoards
+
+2. Count obsidian-flavored hoards:
+   • 0  → tell user: "No vaults found. Want me to `ws hoard init
+                     obsidian-vault` or `ws hoard init claudesidian-vault`?"
+          → offer template choice → exit binding flow if declined
+   • 1  → auto-bind (in-memory pin for session)
+   • >1 → check Thalamus frontmatter for `active_vault: <name>`
+          • set & matches a scanned hoard → use it (no prompt)
+          • not set or mismatched → ask user which vault for this session
+
+3. After binding, re-check that hoard's flavor list:
+   • Contains `claudesidian` → also load scribe-claudesidian/SKILL.md
+   • Otherwise → continue with vanilla scribe
+```
+
+Binding is **session-scoped, in-memory** by default. The optional
+`active_vault: <name>` Thalamus frontmatter field provides persistence for
+users with multiple vaults who don't want to be asked every session.
+
+## Trigger paths
+
+### Path A — Orientation, `role: scribe` in frontmatter
+
+1. `gdd-orientation` Step 5 reads `role: scribe` → loads `.agent/skills/scribe/SKILL.md`
+2. Skill runs vault-binding sub-flow
+3. If bound vault has `claudesidian` flavor → also load `scribe-claudesidian/SKILL.md`
+
+The "session named borgr / I'm in vault mode today" path. Persistent default.
+
+### Path B — Orientation, `role: null`, vault detected
+
+1. `gdd-orientation` Step 6 calls `ws hoard scan` as part of the new
+   vault-detection addition
+2. Scan reports at least one obsidian-flavored hoard
+3. Role question to the user includes the discovery: *"role is null. Detected
+   vault: borgr (claudesidian). Want scribe role, or another (developer /
+   designer / reviewer)?"*
+4. User picks → if scribe, follow Path A from step 1; if not, surface the
+   vault but don't load scribe
+
+### Path C — Mid-session keyword dip-in
+
+1. User in some other role (e.g. developer), working on something unrelated
+2. User says something matching scribe trigger keywords with capture intent:
+   *"let me jot this in my inbox"*, *"add a daily note about this"*,
+   *"capture this idea"*
+3. Agent recognizes the phrase set (advertised in AGENTS.md role row + scribe
+   skill frontmatter description)
+4. Agent loads `.agent/skills/scribe/SKILL.md` ad-hoc, runs vault-binding
+   sub-flow, performs the requested action
+5. No formal role switch. Scribe skill stays loaded for any subsequent
+   note actions in the session
+
+The most common case for sessions focused on non-vault work that occasionally
+need to capture something. Calibration emphasized in the skill itself to
+avoid false positives.
+
+**Multi-vault edge case:** if Path C triggers in a workspace with multiple
+obsidian-flavored hoards and no `active_vault:` set in Thalamus frontmatter,
+the binding sub-flow asks the user which vault — mid-conversation. The pin
+sticks for the rest of the session, so it's a one-time prompt, but users
+who frequently dip into capture from multi-vault workspaces should set
+`active_vault:` once to skip the question.
+
+### Path D — Explicit ask
+
+1. User says *"scribe role for this session"* or *"scribe on borgr"*
+2. Agent loads scribe skill, optionally pins the named vault directly
+3. Session-scoped, in-memory only — does NOT update Thalamus `role:` unless
+   user explicitly says *"make scribe my default"*
+
+## Templates
+
+### `templates/hoards/obsidian-vault/`
+
+Vendored, vanilla, no plugins. Aligned with the `00–06` PARA + supporting
+numbering for symmetry with the Claudesidian template (one set of scribe
+conventions covers both).
+
+```
+templates/hoards/obsidian-vault/
+├── README.md                  # what this is, install Obsidian, GDD usage
+├── .gitignore                 # .trash, workspace.json, .DS_Store
+├── .obsidian/                 # minimal vanilla config
+│   ├── app.json
+│   ├── appearance.json
+│   └── core-plugins.json      # file-explorer, search, daily-notes,
+│                              #  templates, command-palette only
+├── 00_Inbox/
+│   └── Welcome.md             # starter note with frontmatter + wikilinks
+├── 01_Projects/
+│   └── README.md              # one-line role description
+├── 02_Areas/
+│   └── README.md
+├── 03_Resources/
+│   └── README.md
+├── 04_Archive/
+│   └── README.md
+├── 05_Attachments/
+│   └── .gitkeep
+└── 06_Metadata/
+    └── Templates/
+        ├── daily-note.md      # YYYY-MM-DD - Topic + sections
+        ├── project-note.md    # goal, scope, deliverable, links
+        ├── meeting-note.md    # attendees, agenda, decisions, actions
+        ├── inbox-capture.md   # blank capture w/ frontmatter
+        └── weekly-review.md   # template for the weekly review pattern
+```
+
+`README.md` covers: what this is, PARA layout reminder, optional Obsidian
+install instructions, how GDD's scribe skill operates against the vault,
+template usage, pointer to the Claudesidian variant.
+
+`Templates/*.md` use Obsidian's built-in template syntax (`{{date:YYYY-MM-DD}}`)
+so they work both with Obsidian's Templates plugin and with the scribe skill
+when creating notes via Claude.
+
+### `templates/hoards/claudesidian-vault/`
+
+Thin wrapper. No upstream files vendored.
+
+```
+templates/hoards/claudesidian-vault/
+├── README.md                  # install instructions, attribution,
+│                              #  optional /init-bootstrap step (see below)
+├── template.yaml              # manifest:
+│                              #   upstream: https://github.com/heyitsnoah/claudesidian
+│                              #   pin: <commit-or-tag>
+│                              #   fallback: https://github.com/SiliconSaga/claudesidian-fork
+│                              #             (placeholder for future fork)
+│                              #   post_clone:
+│                              #     - copy gdd-bridge/* into vault root
+│                              #     - rm -rf .git
+└── gdd-bridge/
+    ├── AGENTS.md              # ~20 lines: notes that this vault sits in a
+    │                          #  GDD workspace; scribe-claudesidian provides
+    │                          #  equivalent functionality from yggdrasil root
+    └── README.md              # explains the bridge layer for humans
+```
+
+#### Init flow
+
+`ws hoard init claudesidian-vault <name>` extends the existing init logic:
+
+1. Read `template.yaml`
+2. `git clone <upstream> hoards/<name>` — try `upstream` first, fall back to
+   `fallback` if upstream fails
+3. `rm -rf hoards/<name>/.git` so subsequent `ws hoard init` flow can re-init
+   it as the user's own repo per existing convention
+4. Copy `gdd-bridge/*` into `hoards/<name>/` (no name conflicts — the bridge
+   files use distinct names)
+5. Print the README's "optional `/init-bootstrap`" tip
+
+Implementation: small extension to `scripts/ws-hoard.sh`'s init path, reading
+`template.yaml` when present (~40 lines).
+
+#### README content sketch
+
+The `README.md` includes an "Optional: run the Claudesidian onboarding once"
+section:
+
+> ### Optional: run the Claudesidian onboarding once
+>
+> The bridge GDD provides covers core Claudesidian conventions out of the
+> box, but Claudesidian's upstream `/init-bootstrap` command builds a
+> personalized `CLAUDE.md` (writing style, custom context, optionally pulled
+> from public profiles). If you want that, do it once standalone:
+>
+> ```bash
+> cd hoards/claudesidian-vault
+> claude
+> /init-bootstrap
+> ```
+>
+> Then exit and resume in your usual GDD-rooted Claude session — the
+> scribe-claudesidian skill picks up the personalized `CLAUDE.md`
+> automatically.
+>
+> Skip this if you're happy with the generic conventions; nothing important
+> breaks.
+
+Plus attribution to Noah Brier / Alephic with link to the upstream repo, MIT
+license note, and a brief "install Obsidian" section pointing at obsidian.md.
+
+#### The fallback fork
+
+`template.yaml`'s `fallback` field is a placeholder for a SiliconSaga-org
+fork of Claudesidian that doesn't yet exist. The field documents the
+intent; the fork can be created and the URL filled in whenever convenient.
+This protects against upstream availability issues without requiring any
+work today.
+
+## Open questions
+
+None blocking implementation. The following are intentionally deferred to
+future iterations:
+
+- **Plugin curation for the plain Obsidian template** — the user has plugins
+  configured on another system; a curated preset can be added once the base
+  template proves out
+- **Multi-vault Thalamus contention** — flagged as a real concern but
+  separable from this design
+- **Backstage-backed `ws template upgrade`** — its own brainstorm, will
+  cover obsidian-vault, claudesidian-vault, and component templates uniformly
+
+## Implementation surface summary
+
+| File | Change | Size estimate |
+|------|--------|---------------|
+| `scripts/ws-hoard.sh` | Add `scan` subcommand; extend `init` for `template.yaml` | ~90 lines added |
+| `.agent/skills/scribe/SKILL.md` | New file | ~150 lines |
+| `.agent/skills/scribe-claudesidian/SKILL.md` | New file | ~100 lines |
+| `.agent/skills/gdd-orientation/SKILL.md` | Add vault-scan step in Step 6 | ~15 lines added |
+| `.agent/skills/gdd/SKILL.md` | Add `scribe` to role list | ~5 lines added |
+| `AGENTS.md` | Two new skill table rows + hoards section line | ~5 lines added |
+| `templates/hoards/obsidian-vault/` | New directory tree | ~15 small files |
+| `templates/hoards/claudesidian-vault/` | New directory (thin wrapper) | 4 files |
+| `templates/thalamus.md` | Document optional `active_vault:` frontmatter | ~3 lines added |
+
+Total: roughly 350 lines of code/script changes, plus ~20 small markdown
+files for templates and skills.
+
+## References
+
+- Claudesidian upstream: <https://github.com/heyitsnoah/claudesidian>
+  (MIT, by Noah Brier / Alephic)
+- [Realms and Hoards Design](2026-04-24-realms-and-hoards-design.md)
+- [Component Templates Design](2026-04-25-component-templates-design.md)
+- [PARA Method](https://fortelabs.com/blog/para/)

--- a/docs/plans/2026-05-01-scribe-role-and-vault-templates-design.md
+++ b/docs/plans/2026-05-01-scribe-role-and-vault-templates-design.md
@@ -73,7 +73,7 @@ swapping role.
 
 ## Architecture
 
-```
+```text
 ┌─────────────────────────────────────────────────────────┐
 │  AGENTS.md          (skill table rows + hoards section) │
 │   └─ "scribe" role; keyword triggers documented         │
@@ -220,7 +220,7 @@ Step 5 logic.
 
 Called by all four trigger paths.
 
-```
+```text
 1. Run: ws hoard scan --flavor obsidian
    → returns YAML list of obsidian-flavored hoards
 
@@ -302,7 +302,7 @@ Vendored, vanilla, no plugins. Aligned with the `00–06` PARA + supporting
 numbering for symmetry with the Claudesidian template (one set of scribe
 conventions covers both).
 
-```
+```text
 templates/hoards/obsidian-vault/
 ├── README.md                  # what this is, install Obsidian, GDD usage
 ├── .gitignore                 # .trash, workspace.json, .DS_Store
@@ -344,7 +344,7 @@ when creating notes via Claude.
 
 Thin wrapper. No upstream files vendored.
 
-```
+```text
 templates/hoards/claudesidian-vault/
 ├── README.md                  # install instructions, attribution,
 │                              #  optional /init-bootstrap step (see below)

--- a/docs/plans/2026-05-01-scribe-role-and-vault-templates-design.md
+++ b/docs/plans/2026-05-01-scribe-role-and-vault-templates-design.md
@@ -106,8 +106,9 @@ the skills already know how to recognize.
 
 ### `scripts/ws-hoard.sh` — `scan` subcommand
 
-New subcommand. Iterates `hoards/*/` and applies three classifiers
-independently — flavors stack:
+New subcommand. Iterates `hoards/*/` (sorted by name ascending under
+`LC_ALL=C` so the output order is stable across filesystems) and applies
+three classifiers independently — flavors stack:
 
 - **`thalami`** — directory name matches `thalami-*` (existing convention,
   via `ws_detect_thalami_hoard()` which is reused, not rewritten)
@@ -392,7 +393,7 @@ section:
 > from public profiles). If you want that, do it once standalone:
 >
 > ```bash
-> cd hoards/claudesidian-vault
+> cd hoards/<your-vault-name>   # the name you passed to --name (or the default)
 > claude
 > /init-bootstrap
 > ```

--- a/docs/plans/2026-05-01-scribe-role-and-vault-templates-plan.md
+++ b/docs/plans/2026-05-01-scribe-role-and-vault-templates-plan.md
@@ -1,0 +1,2019 @@
+# Scribe Role and Vault Templates Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the design in `docs/plans/2026-05-01-scribe-role-and-vault-templates-design.md`: a new `scribe` role with two layered skills (`scribe`, `scribe-claudesidian`), a deterministic `ws hoard scan` subcommand, two new hoard templates (`obsidian-vault` vendored, `claudesidian-vault` thin wrapper), and minimal AGENTS.md / orientation-skill wiring.
+
+**Architecture:** Five sequential phases — scanner first (skills depend on it), then templates (independent of skills), then skills (consume scanner), then wiring (small additions to AGENTS.md / orientation / role list / thalamus template), then end-to-end verification. Each phase ends in a single `ws commit` so intermediate states are landing-ready and the history reads as logical units of work.
+
+**Tech Stack:** Bash (ws CLI), `yq` v4 (Mike Farah, used for `template.yaml` parsing), `git` (clone-on-init), markdown documentation.
+
+---
+
+## Conventions for executing this plan
+
+- The repo lives at `/Users/cervator/dev/git_ws/yggdrasil` on this machine. Adjust absolute paths if running on Windows or another machine.
+- The user has `<workspace>/scripts/` on PATH so `ws <cmd>` works as a bare command. **Don't prepend `bash scripts/ws`** in commit messages or smoke-test commands; in code blocks here we use the bare form.
+- Always commit via `ws commit yggdrasil <bodyfile>` — never raw `git add` / `git commit`. Bodyfiles live in `.commits/<name>.md` (gitignored). The format is in `templates/commit.md`.
+- Don't chain `ws commit && ws push` — run separately so each can be reviewed and approved independently.
+- Stay on branch `hodgepodge` (or create a fresh `feat/scribe-role` topic branch — the user's call) for the duration. The design spec is in `docs/plans/2026-05-01-scribe-role-and-vault-templates-design.md` and gets committed alongside Phase A.
+- yggdrasil has no shell-test framework. Verification is `bash -n` syntax checks + runtime smoke tests against the existing `hoards/` directory (which already has known content: `borgr` = obsidian+claudesidian, `nonclaudesidian` = obsidian, `thalami-Cervator` = thalami).
+- Skill markdown files don't have automated tests; verification is by reading the file and confirming structure matches the spec.
+
+---
+
+## Files Changed Overview
+
+### Phase A — Scanner
+
+- **Modify** `scripts/ws-hoard.sh` — add `ws_classify_hoard()` helper, `ws_hoard_scan()` subcommand, dispatch entry, help-text entry (~80 lines added)
+
+### Phase B — Templates
+
+- **Create** `templates/hoards/obsidian-vault/` directory tree (~15 small files)
+- **Create** `templates/hoards/claudesidian-vault/` directory (4 files: `template.yaml`, `README.md`, `gdd-bridge/AGENTS.md`, `gdd-bridge/README.md`)
+- **Modify** `scripts/ws-hoard.sh` — extend `ws_hoard_init()` to detect `template.yaml` and run the clone-on-init flow (~50 lines added)
+
+### Phase C — Skills
+
+- **Create** `.agent/skills/scribe/SKILL.md` (~150 lines)
+- **Create** `.agent/skills/scribe-claudesidian/SKILL.md` (~100 lines)
+
+### Phase D — Wiring
+
+- **Modify** `.agent/skills/gdd-orientation/SKILL.md` — add vault-scan step in Step 6 (~15 lines added)
+- **Modify** `.agent/skills/gdd/SKILL.md` — add `scribe` to role list (~5 lines added)
+- **Modify** `AGENTS.md` — two new skill table rows + hoards section line (~5 lines added)
+- **Modify** `templates/thalamus.md` — document optional `active_vault:` frontmatter (~3 lines added)
+
+### Phase E — Verification
+
+- No new files. End-to-end smoke test, then commit the full feature branch.
+
+---
+
+# Phase A — Scanner
+
+Lands `ws hoard scan` end-to-end against the existing `hoards/` directory. Skills in Phase C will consume its YAML output.
+
+### Task A1: Add `ws_classify_hoard()` and `ws_hoard_scan()` to `ws-hoard.sh`
+
+**Files:**
+- Modify: `/Users/cervator/dev/git_ws/yggdrasil/scripts/ws-hoard.sh`
+
+- [ ] **Step 1: Establish the smoke-test scenario**
+
+The existing `hoards/` directory has three known fixtures we'll use as the synthetic test:
+
+```
+hoards/borgr              → obsidian + claudesidian
+hoards/nonclaudesidian    → obsidian
+hoards/thalami-Cervator   → thalami
+```
+
+After implementation, `ws hoard scan` should emit exactly three records with those flavor lists.
+
+- [ ] **Step 2: Run the not-yet-implemented command, verify it fails**
+
+```bash
+ws hoard scan
+```
+
+Expected: `Usage: ws hoard <subcommand>` help dump or "Unknown subcommand" — `scan` doesn't exist yet.
+
+- [ ] **Step 3: Add the classifier helper before `ws_hoard_help()`**
+
+Insert this block just before the `ws_hoard_help()` definition (around line 143 in current `ws-hoard.sh`). Keep the surrounding code unchanged:
+
+```bash
+# Classify a hoard directory by flavor.
+# Echoes a comma-separated list of flavors, or empty if none.
+# Argument is the hoard directory path. Flavors stack — a hoard can be
+# both `obsidian` and `claudesidian`.
+#
+# Detection rules:
+#   thalami      — directory name matches `thalami-*`
+#   obsidian     — has a `.obsidian/` subdirectory
+#   claudesidian — has `.obsidian/` AND `.claude/` AND a top-level
+#                  CLAUDE.md whose first 30 lines reference Claudesidian
+#                  or PARA conventions (multi-signal — avoids
+#                  false-positives on unrelated `.claude/` directories)
+ws_classify_hoard() {
+    local hoard_path="$1"
+    local hoard_name
+    hoard_name="$(basename "$hoard_path")"
+    local flavors=()
+
+    # thalami: name pattern (matches existing ws_detect_thalami_hoard convention)
+    if [[ "$hoard_name" == thalami-* ]]; then
+        flavors+=("thalami")
+    fi
+
+    # obsidian: .obsidian/ directory present
+    if [[ -d "$hoard_path/.obsidian" ]]; then
+        flavors+=("obsidian")
+    fi
+
+    # claudesidian: obsidian + .claude/ + signature in CLAUDE.md
+    if [[ -d "$hoard_path/.obsidian" ]] && \
+       [[ -d "$hoard_path/.claude" ]] && \
+       [[ -f "$hoard_path/CLAUDE.md" ]]; then
+        # Multi-signal: read first 30 lines, look for either
+        # "Claudesidian" (the kit's name) or "PARA Method" (its
+        # organizational scheme) — case-insensitive.
+        if head -n 30 "$hoard_path/CLAUDE.md" 2>/dev/null | \
+           grep -qiE 'claudesidian|PARA Method'; then
+            flavors+=("claudesidian")
+        fi
+    fi
+
+    if [[ ${#flavors[@]} -eq 0 ]]; then
+        echo ""
+    else
+        local IFS=,
+        echo "${flavors[*]}"
+    fi
+}
+```
+
+- [ ] **Step 4: Add the `ws_hoard_scan()` function**
+
+Append this immediately after `ws_classify_hoard()`. It iterates `$HOARDS_DIR`, applies the classifier, and emits YAML:
+
+```bash
+# Iterate hoards/ and emit a YAML inventory with flavor classification.
+# Optional flags:
+#   --flavor <name>   Only emit hoards containing the named flavor
+#   --names-only      Emit just hoard names (one per line) — for shell pipelines
+ws_hoard_scan() {
+    local filter_flavor=""
+    local names_only=false
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --flavor)
+                if [[ -z "${2:-}" ]]; then
+                    echo "ERROR: --flavor requires a value" >&2
+                    return 2
+                fi
+                filter_flavor="$2"
+                shift 2
+                ;;
+            --names-only)
+                names_only=true
+                shift
+                ;;
+            -h|--help)
+                echo "Usage: ws hoard scan [--flavor <name>] [--names-only]" >&2
+                echo "" >&2
+                echo "Emit a YAML inventory of hoards/ classified by flavor." >&2
+                echo "" >&2
+                echo "Flavors detected:" >&2
+                echo "  thalami       — directory name matches thalami-*" >&2
+                echo "  obsidian      — contains .obsidian/" >&2
+                echo "  claudesidian  — contains .obsidian/ + .claude/ + Claudesidian-signed CLAUDE.md" >&2
+                return 0
+                ;;
+            *)
+                echo "ERROR: Unknown flag: $1" >&2
+                return 2
+                ;;
+        esac
+    done
+
+    [[ -d "$HOARDS_DIR" ]] || return 0
+
+    local d hoard_name flavors_csv
+    for d in "$HOARDS_DIR"/*/; do
+        [[ -d "$d" ]] || continue
+        hoard_name="$(basename "$d")"
+        flavors_csv="$(ws_classify_hoard "$d")"
+
+        # Apply --flavor filter
+        if [[ -n "$filter_flavor" ]]; then
+            local found=false
+            local IFS=,
+            for f in $flavors_csv; do
+                if [[ "$f" == "$filter_flavor" ]]; then
+                    found=true
+                    break
+                fi
+            done
+            $found || continue
+        fi
+
+        if $names_only; then
+            echo "$hoard_name"
+        else
+            echo "- name: $hoard_name"
+            # Strip trailing slash from path for cleanliness
+            echo "  path: ${d%/}"
+            if [[ -z "$flavors_csv" ]]; then
+                echo "  flavors: []"
+            else
+                # Convert "a,b" → "[a, b]" for inline YAML list form
+                local yaml_list="${flavors_csv//,/, }"
+                echo "  flavors: [$yaml_list]"
+            fi
+        fi
+    done
+}
+```
+
+- [ ] **Step 5: Wire `scan` into the dispatcher**
+
+In the `case "$SUBCMD" in` block at the bottom of the file (around line 571), add a `scan)` clause. The full updated block:
+
+```bash
+case "$SUBCMD" in
+    ""|--help|-h)
+        ws_hoard_help
+        ;;
+    init)
+        ws_hoard_init "$@"
+        ;;
+    list)
+        ws_hoard_list
+        ;;
+    scan)
+        ws_hoard_scan "$@"
+        ;;
+    cadence)
+        ws_hoard_cadence
+        ;;
+    thalamus-path)
+        ws_resolve_thalamus_path
+        ;;
+    *)
+        ws_hoard_clone_url "$SUBCMD" "$@"
+        ;;
+esac
+```
+
+- [ ] **Step 6: Add `scan` to `ws_hoard_help()` output**
+
+In `ws_hoard_help()` (around line 143), insert the `scan` line just below `list`:
+
+```bash
+    echo "  scan [--flavor <name>] [--names-only]" >&2
+    echo "                           Emit a YAML inventory of hoards classified by" >&2
+    echo "                           flavor (thalami / obsidian / claudesidian)" >&2
+```
+
+- [ ] **Step 7: Run `bash -n` syntax check**
+
+```bash
+bash -n /Users/cervator/dev/git_ws/yggdrasil/scripts/ws-hoard.sh
+```
+
+Expected: no output (clean syntax). Any error → fix and re-run.
+
+- [ ] **Step 8: Run the full scan and verify the output matches expectations**
+
+```bash
+ws hoard scan
+```
+
+Expected output (order may vary depending on filesystem enumeration):
+
+```yaml
+- name: borgr
+  path: /Users/cervator/dev/git_ws/yggdrasil/hoards/borgr
+  flavors: [obsidian, claudesidian]
+- name: nonclaudesidian
+  path: /Users/cervator/dev/git_ws/yggdrasil/hoards/nonclaudesidian
+  flavors: [obsidian]
+- name: thalami-Cervator
+  path: /Users/cervator/dev/git_ws/yggdrasil/hoards/thalami-Cervator
+  flavors: [thalami]
+```
+
+If any record is wrong, recheck the classifier rules (especially the multi-signal claudesidian detection — verify `borgr/CLAUDE.md` has "Claudesidian" or "PARA" in its first 30 lines).
+
+- [ ] **Step 9: Verify `--flavor` filter**
+
+```bash
+ws hoard scan --flavor obsidian
+```
+
+Expected: two records (`borgr`, `nonclaudesidian`). `thalami-Cervator` filtered out.
+
+```bash
+ws hoard scan --flavor claudesidian
+```
+
+Expected: one record (`borgr`).
+
+```bash
+ws hoard scan --flavor thalami
+```
+
+Expected: one record (`thalami-Cervator`).
+
+- [ ] **Step 10: Verify `--names-only` flag**
+
+```bash
+ws hoard scan --names-only
+```
+
+Expected: three lines, each a bare hoard name (`borgr`, `nonclaudesidian`, `thalami-Cervator`).
+
+```bash
+ws hoard scan --flavor obsidian --names-only
+```
+
+Expected: two lines (`borgr`, `nonclaudesidian`).
+
+- [ ] **Step 11: Verify error handling**
+
+```bash
+ws hoard scan --flavor
+```
+
+Expected: stderr `ERROR: --flavor requires a value`, exit 2.
+
+```bash
+ws hoard scan --bogus
+```
+
+Expected: stderr `ERROR: Unknown flag: --bogus`, exit 2.
+
+- [ ] **Step 12: Write the commit bodyfile**
+
+Create `/Users/cervator/dev/git_ws/yggdrasil/.commits/phase-a-scan.md`:
+
+```markdown
+---
+message: |
+  feat(ws-hoard): add scan subcommand for vault classification
+
+  Iterates hoards/ and emits a YAML inventory tagging each with one or
+  more flavors (thalami, obsidian, claudesidian). Multi-signal detection
+  for claudesidian (.obsidian + .claude + signed CLAUDE.md) avoids
+  false-positives on unrelated .claude/ dirs.
+
+  Used by the new scribe skill for deterministic vault discovery.
+  Companion to the design + plan committed separately on this branch.
+add:
+  - scripts/ws-hoard.sh
+---
+```
+
+- [ ] **Step 13: Commit Phase A**
+
+```bash
+ws commit yggdrasil .commits/phase-a-scan.md
+```
+
+Verify the commit lands cleanly and includes the spec + plan files.
+
+---
+
+# Phase B — Templates
+
+Adds `templates/hoards/obsidian-vault/` (vendored, vanilla) and `templates/hoards/claudesidian-vault/` (thin wrapper that clones upstream on init), plus extends `ws hoard init` to detect `template.yaml` and follow the clone-on-init flow.
+
+### Task B1: Build `templates/hoards/obsidian-vault/` directory structure
+
+**Files:**
+- Create: `/Users/cervator/dev/git_ws/yggdrasil/templates/hoards/obsidian-vault/.gitignore`
+- Create: `/Users/cervator/dev/git_ws/yggdrasil/templates/hoards/obsidian-vault/.obsidian/app.json`
+- Create: `/Users/cervator/dev/git_ws/yggdrasil/templates/hoards/obsidian-vault/.obsidian/appearance.json`
+- Create: `/Users/cervator/dev/git_ws/yggdrasil/templates/hoards/obsidian-vault/.obsidian/core-plugins.json`
+- Create: `/Users/cervator/dev/git_ws/yggdrasil/templates/hoards/obsidian-vault/01_Projects/README.md`
+- Create: `/Users/cervator/dev/git_ws/yggdrasil/templates/hoards/obsidian-vault/02_Areas/README.md`
+- Create: `/Users/cervator/dev/git_ws/yggdrasil/templates/hoards/obsidian-vault/03_Resources/README.md`
+- Create: `/Users/cervator/dev/git_ws/yggdrasil/templates/hoards/obsidian-vault/04_Archive/README.md`
+- Create: `/Users/cervator/dev/git_ws/yggdrasil/templates/hoards/obsidian-vault/05_Attachments/.gitkeep`
+
+- [ ] **Step 1: Verify the parent directory exists**
+
+```bash
+ls /Users/cervator/dev/git_ws/yggdrasil/templates/hoards/
+```
+
+Expected: `basic` and `thalami` directories already exist.
+
+- [ ] **Step 2: Create the `.gitignore`**
+
+Write `/Users/cervator/dev/git_ws/yggdrasil/templates/hoards/obsidian-vault/.gitignore`:
+
+```
+# Obsidian local state — not vault content
+.obsidian/workspace.json
+.obsidian/workspace-mobile.json
+.trash/
+
+# Common OS / editor cruft
+.DS_Store
+Thumbs.db
+*.swp
+```
+
+- [ ] **Step 3: Create minimal `.obsidian/` config files**
+
+Write `/Users/cervator/dev/git_ws/yggdrasil/templates/hoards/obsidian-vault/.obsidian/app.json`:
+
+```json
+{
+  "promptDelete": true,
+  "alwaysUpdateLinks": true,
+  "newFileLocation": "folder",
+  "newFileFolderPath": "00_Inbox",
+  "useMarkdownLinks": false,
+  "newLinkFormat": "shortest",
+  "attachmentFolderPath": "05_Attachments"
+}
+```
+
+Write `/Users/cervator/dev/git_ws/yggdrasil/templates/hoards/obsidian-vault/.obsidian/appearance.json`:
+
+```json
+{
+  "theme": "obsidian",
+  "baseFontSize": 16
+}
+```
+
+Write `/Users/cervator/dev/git_ws/yggdrasil/templates/hoards/obsidian-vault/.obsidian/core-plugins.json`:
+
+```json
+[
+  "file-explorer",
+  "global-search",
+  "switcher",
+  "graph",
+  "backlink",
+  "outgoing-link",
+  "tag-pane",
+  "page-preview",
+  "daily-notes",
+  "templates",
+  "command-palette",
+  "markdown-importer",
+  "outline",
+  "word-count",
+  "file-recovery"
+]
+```
+
+(No community plugins. User installs what they want.)
+
+- [ ] **Step 4: Create the per-folder README files**
+
+Each PARA folder gets a one-line description so the empty folders survive git and explain themselves to anyone browsing.
+
+Write `/Users/cervator/dev/git_ws/yggdrasil/templates/hoards/obsidian-vault/01_Projects/README.md`:
+
+```markdown
+# 01_Projects
+
+Time-bound initiatives with a clear completion criterion. Each project
+lives in its own subfolder. When complete, move the folder to `04_Archive/`.
+```
+
+Write `/Users/cervator/dev/git_ws/yggdrasil/templates/hoards/obsidian-vault/02_Areas/README.md`:
+
+```markdown
+# 02_Areas
+
+Ongoing responsibilities without an end date — health, finances, work,
+relationships. Notes here are maintained over time, not completed.
+```
+
+Write `/Users/cervator/dev/git_ws/yggdrasil/templates/hoards/obsidian-vault/03_Resources/README.md`:
+
+```markdown
+# 03_Resources
+
+Reference material organized by topic — research notes, articles, snippets.
+Not tied to any specific project.
+```
+
+Write `/Users/cervator/dev/git_ws/yggdrasil/templates/hoards/obsidian-vault/04_Archive/README.md`:
+
+```markdown
+# 04_Archive
+
+Completed projects and inactive notes. Preserved for reference but no
+longer actively maintained.
+```
+
+- [ ] **Step 5: Create the attachments placeholder**
+
+Write `/Users/cervator/dev/git_ws/yggdrasil/templates/hoards/obsidian-vault/05_Attachments/.gitkeep` (empty file). Keeps the folder tracked even when empty.
+
+- [ ] **Step 6: Verify directory structure**
+
+```bash
+find /Users/cervator/dev/git_ws/yggdrasil/templates/hoards/obsidian-vault -type f | sort
+```
+
+Expected: 9 files at this point (`.gitignore`, three `.obsidian/*.json`, four folder READMEs, one `.gitkeep`). Welcome.md, Templates, and the top-level README come in next tasks.
+
+### Task B2: Add `obsidian-vault` content (Welcome.md, Templates/, top-level README)
+
+**Files:**
+- Create: `/Users/cervator/dev/git_ws/yggdrasil/templates/hoards/obsidian-vault/00_Inbox/Welcome.md`
+- Create: `/Users/cervator/dev/git_ws/yggdrasil/templates/hoards/obsidian-vault/06_Metadata/Templates/daily-note.md`
+- Create: `/Users/cervator/dev/git_ws/yggdrasil/templates/hoards/obsidian-vault/06_Metadata/Templates/project-note.md`
+- Create: `/Users/cervator/dev/git_ws/yggdrasil/templates/hoards/obsidian-vault/06_Metadata/Templates/meeting-note.md`
+- Create: `/Users/cervator/dev/git_ws/yggdrasil/templates/hoards/obsidian-vault/06_Metadata/Templates/inbox-capture.md`
+- Create: `/Users/cervator/dev/git_ws/yggdrasil/templates/hoards/obsidian-vault/06_Metadata/Templates/weekly-review.md`
+
+- [ ] **Step 1: Create `00_Inbox/Welcome.md`**
+
+Write `/Users/cervator/dev/git_ws/yggdrasil/templates/hoards/obsidian-vault/00_Inbox/Welcome.md`:
+
+```markdown
+---
+created: {{date:YYYY-MM-DD}}
+tags: [welcome]
+status: active
+---
+
+# Welcome to your vault
+
+This is a plain Obsidian vault scaffolded by GDD using the
+`obsidian-vault` template.
+
+## Getting started
+
+The folders use the [PARA Method](https://fortelabs.com/blog/para/):
+
+- [[01_Projects/README|Projects]] — time-bound initiatives
+- [[02_Areas/README|Areas]] — ongoing responsibilities
+- [[03_Resources/README|Resources]] — reference material
+- [[04_Archive/README|Archive]] — completed or inactive
+
+New captures go in `00_Inbox/`. Process them weekly, moving each note
+into its proper PARA folder or deleting it.
+
+## Templates
+
+`06_Metadata/Templates/` has starter notes for daily, project, meeting,
+inbox-capture, and weekly-review patterns. Obsidian's built-in Templates
+plugin can insert them via the Command Palette.
+
+## Working from GDD
+
+If you're using this from a GDD workspace, the `scribe` skill handles
+PARA conventions, frontmatter habits, and capture-process-organize
+workflows automatically. Just say things like *"jot this in my inbox"*
+or *"start a daily note"* and the workspace agent will follow this
+vault's conventions.
+
+You can also run Claude Code directly inside this vault — useful if you
+want to operate the vault standalone without the surrounding GDD
+workspace context.
+```
+
+- [ ] **Step 2: Create `06_Metadata/Templates/daily-note.md`**
+
+Write the file:
+
+```markdown
+---
+created: {{date:YYYY-MM-DD}}
+tags: [daily]
+status: active
+---
+
+# {{date:YYYY-MM-DD}} — Daily Note
+
+## Today
+
+## Captures
+
+## Links
+
+```
+
+- [ ] **Step 3: Create `06_Metadata/Templates/project-note.md`**
+
+Write the file:
+
+```markdown
+---
+created: {{date:YYYY-MM-DD}}
+tags: [project]
+status: active
+deadline:
+---
+
+# {{title}}
+
+## Goal
+
+What does done look like?
+
+## Scope
+
+What's in, what's out.
+
+## Deliverable
+
+The single artifact this project produces.
+
+## Research
+
+## Drafts
+
+## Output
+
+## Links
+
+```
+
+- [ ] **Step 4: Create `06_Metadata/Templates/meeting-note.md`**
+
+Write the file:
+
+```markdown
+---
+created: {{date:YYYY-MM-DD}}
+tags: [meeting]
+status: active
+attendees: []
+---
+
+# Meeting — {{title}} — {{date:YYYY-MM-DD}}
+
+## Agenda
+
+## Discussion
+
+## Decisions
+
+## Action items
+
+- [ ] 
+
+## Links
+
+```
+
+- [ ] **Step 5: Create `06_Metadata/Templates/inbox-capture.md`**
+
+Write the file:
+
+```markdown
+---
+created: {{date:YYYY-MM-DD}}
+tags: [inbox]
+status: unprocessed
+---
+
+# {{title}}
+
+```
+
+- [ ] **Step 6: Create `06_Metadata/Templates/weekly-review.md`**
+
+Write the file:
+
+```markdown
+---
+created: {{date:YYYY-MM-DD}}
+tags: [weekly-review]
+status: active
+---
+
+# Weekly Review — week of {{date:YYYY-MM-DD}}
+
+## Inbox processed
+
+How many items, where they went.
+
+## Active projects
+
+What progressed, what stalled.
+
+## Areas check
+
+Any area need attention?
+
+## Resources captured
+
+What new material is worth keeping.
+
+## Archive candidates
+
+What can move to `04_Archive/`.
+
+## Next week
+
+```
+
+- [ ] **Step 7: Verify Templates folder structure**
+
+```bash
+ls /Users/cervator/dev/git_ws/yggdrasil/templates/hoards/obsidian-vault/06_Metadata/Templates/
+```
+
+Expected: 5 files (`daily-note.md`, `inbox-capture.md`, `meeting-note.md`, `project-note.md`, `weekly-review.md`).
+
+### Task B3: Add `obsidian-vault/README.md`
+
+**Files:**
+- Create: `/Users/cervator/dev/git_ws/yggdrasil/templates/hoards/obsidian-vault/README.md`
+
+- [ ] **Step 1: Write the README**
+
+Write the file:
+
+```markdown
+# Plain Obsidian Vault
+
+A vanilla Obsidian vault scaffolded by `ws hoard init obsidian-vault`,
+ready to use as a personal hoard inside a GDD workspace.
+
+## What's here
+
+Folders follow the [PARA Method](https://fortelabs.com/blog/para/):
+
+| Folder | Purpose |
+|--------|---------|
+| `00_Inbox/` | Temporary capture point. Process weekly. |
+| `01_Projects/` | Time-bound initiatives with a clear completion criterion. |
+| `02_Areas/` | Ongoing responsibilities without an end date. |
+| `03_Resources/` | Reference material organized by topic. |
+| `04_Archive/` | Completed or inactive items. |
+| `05_Attachments/` | Images, PDFs, and other binary attachments. |
+| `06_Metadata/Templates/` | Reusable note templates (daily, project, meeting, etc.). |
+
+## Optional: install Obsidian
+
+The vault is fully usable from Claude Code alone, but installing
+[Obsidian](https://obsidian.md) gives you graph view, search, and
+plugin support.
+
+1. Download Obsidian from <https://obsidian.md>
+2. Open Obsidian → "Open vault as folder"
+3. Point it at this directory
+
+The included `.obsidian/` config sets a few sensible defaults (new
+notes go to `00_Inbox/`, attachments go to `05_Attachments/`,
+shortest-form wikilinks). No community plugins are pre-installed —
+add what you need.
+
+## Working from GDD
+
+When you operate this vault from a GDD-rooted Claude session:
+
+- The `scribe` skill in the workspace knows this vault's conventions
+- Say things like *"jot this in my inbox"* or *"start a daily note about
+  X"* — the agent will create files following the templates here
+- Use `ws hoard list` from the workspace root to see your hoards
+- The vault is its own git repo; commit and push it like any other repo
+
+You can also run Claude Code directly inside this vault — useful if you
+want a standalone Obsidian session decoupled from the surrounding
+workspace.
+
+## Want richer Claude integration?
+
+If you want Claude-Code-specific commands (`/thinking-partner`,
+`/inbox-processor`, etc.) and the broader Claudesidian ecosystem,
+consider the `claudesidian-vault` template instead:
+
+```bash
+ws hoard init claudesidian-vault <name>
+```
+
+It clones [Claudesidian](https://github.com/heyitsnoah/claudesidian)
+(MIT, by Noah Brier / Alephic) on init and adds GDD bridge files. The
+GDD `scribe-claudesidian` skill provides equivalent functionality from
+the workspace root, so you can use it without `cd`-ing into the vault.
+```
+
+- [ ] **Step 2: Verify the obsidian-vault template is complete**
+
+```bash
+find /Users/cervator/dev/git_ws/yggdrasil/templates/hoards/obsidian-vault -type f | sort
+```
+
+Expected file list (15 files):
+
+```
+.../obsidian-vault/.gitignore
+.../obsidian-vault/.obsidian/app.json
+.../obsidian-vault/.obsidian/appearance.json
+.../obsidian-vault/.obsidian/core-plugins.json
+.../obsidian-vault/00_Inbox/Welcome.md
+.../obsidian-vault/01_Projects/README.md
+.../obsidian-vault/02_Areas/README.md
+.../obsidian-vault/03_Resources/README.md
+.../obsidian-vault/04_Archive/README.md
+.../obsidian-vault/05_Attachments/.gitkeep
+.../obsidian-vault/06_Metadata/Templates/daily-note.md
+.../obsidian-vault/06_Metadata/Templates/inbox-capture.md
+.../obsidian-vault/06_Metadata/Templates/meeting-note.md
+.../obsidian-vault/06_Metadata/Templates/project-note.md
+.../obsidian-vault/06_Metadata/Templates/weekly-review.md
+.../obsidian-vault/README.md
+```
+
+### Task B4: Build `templates/hoards/claudesidian-vault/` thin wrapper
+
+**Files:**
+- Create: `/Users/cervator/dev/git_ws/yggdrasil/templates/hoards/claudesidian-vault/template.yaml`
+- Create: `/Users/cervator/dev/git_ws/yggdrasil/templates/hoards/claudesidian-vault/README.md`
+- Create: `/Users/cervator/dev/git_ws/yggdrasil/templates/hoards/claudesidian-vault/gdd-bridge/AGENTS.md`
+- Create: `/Users/cervator/dev/git_ws/yggdrasil/templates/hoards/claudesidian-vault/gdd-bridge/README.md`
+
+- [ ] **Step 1: Write `template.yaml`**
+
+Write the file:
+
+```yaml
+# Claudesidian wrapper template
+#
+# This template doesn't vendor upstream files — it clones Claudesidian
+# from GitHub at init time. The clone-on-init flow is implemented in
+# scripts/ws-hoard.sh's ws_hoard_init() function (Task B5).
+
+# Upstream source. Required.
+upstream: https://github.com/heyitsnoah/claudesidian
+
+# Pinned commit or tag. Re-vendor by bumping this when upstream releases
+# a version worth picking up. Empty string = follow default branch.
+pin: ""
+
+# Fallback URL if upstream clone fails (e.g. GitHub outage, repo moved).
+# Currently a placeholder — the SiliconSaga fork doesn't yet exist.
+# Populate when the fork is created.
+fallback: ""
+
+# Post-clone steps applied in order:
+#   strip_git    — rm -rf .git so ws hoard init can re-init the clone
+#                  as the user's own repo
+#   apply_bridge — copy gdd-bridge/* into the cloned vault
+post_clone:
+  - strip_git
+  - apply_bridge
+```
+
+- [ ] **Step 2: Write `README.md`**
+
+Write the file:
+
+```markdown
+# Claudesidian Vault (GDD Wrapper)
+
+A thin wrapper around [Claudesidian](https://github.com/heyitsnoah/claudesidian)
+— Noah Brier and Alephic's Claude-Code-friendly Obsidian starter kit
+(MIT licensed). When you run `ws hoard init claudesidian-vault <name>`,
+GDD clones the upstream repo into `hoards/<name>/`, strips its `.git`
+directory, and overlays a small `gdd-bridge/` set of files that wire
+the vault into the surrounding workspace.
+
+## Attribution
+
+- **Upstream:** <https://github.com/heyitsnoah/claudesidian>
+- **License:** MIT (see `LICENSE` in the cloned vault)
+- **Built by:** Noah Brier — see <https://every.to/podcast/how-to-use-claude-code-as-a-thinking-partner>
+- **Maintained by:** [Alephic](https://alephic.com)
+
+This template is a pointer, not a fork. The full Claudesidian
+experience and any updates to it come from upstream.
+
+## What `ws hoard init claudesidian-vault` does
+
+1. Clones the upstream repo into `hoards/<name>/`
+2. Removes the cloned `.git/` directory so the hoard can be re-init'd
+   as your own repo (per existing `ws hoard init` convention)
+3. Copies files from this template's `gdd-bridge/` into the new vault
+   (currently `AGENTS.md` and a small `README.md` explaining the bridge)
+4. Initializes a fresh git repo for the hoard
+5. Prints the optional `/init-bootstrap` tip below
+
+## Optional: run the Claudesidian onboarding once
+
+The bridge GDD provides covers core Claudesidian conventions out of
+the box, but Claudesidian's upstream `/init-bootstrap` command builds
+a personalized `CLAUDE.md` (writing style, custom context, optionally
+pulled from public profiles). If you want that, do it once standalone:
+
+```bash
+cd hoards/<your-vault-name>
+claude
+/init-bootstrap
+```
+
+Then exit and resume in your usual GDD-rooted Claude session — the
+`scribe-claudesidian` skill picks up the personalized `CLAUDE.md`
+automatically.
+
+Skip this if you're happy with the generic Claudesidian conventions;
+nothing important breaks. Even without `/init-bootstrap`, the
+`CLAUDE-BOOTSTRAP.md` shipped by upstream provides the core PARA and
+vault-handling guidance that `scribe-claudesidian` reads as a fallback.
+
+## Optional: install Obsidian
+
+The vault works fine from Claude Code alone, but
+[Obsidian](https://obsidian.md) provides graph view, search, plugin
+ecosystem, and the visual interface most Obsidian workflows assume.
+Open the cloned vault folder as an Obsidian vault.
+
+## Working from GDD vs. running Claude inside the hoard
+
+This template's main purpose is letting you operate the vault from a
+single Claude session rooted at your yggdrasil workspace, instead of
+having to `cd` into the vault and start a new session there. The
+`scribe-claudesidian` skill (in
+`.agent/skills/scribe-claudesidian/SKILL.md`) provides equivalent
+plain-text invocation of Claudesidian commands like
+`/thinking-partner` and `/weekly-synthesis` from the workspace root.
+
+If you prefer the standalone Claudesidian experience — slash-command
+auto-completion, hooks, MCP servers wired up natively — just `cd` into
+the hoard and run `claude` there. Both modes coexist; `gdd-bridge/`
+files don't interfere with standalone use.
+```
+
+- [ ] **Step 3: Write `gdd-bridge/AGENTS.md`**
+
+This file lands inside the cloned vault. It tells any agent operating
+*from inside* the hoard that the parent workspace provides a richer
+context, while keeping the standalone experience functional.
+
+Write the file:
+
+```markdown
+# Agent Notes — Claudesidian Vault (GDD-bridged)
+
+This vault was scaffolded via `ws hoard init claudesidian-vault` from
+a GDD workspace. It can run standalone (just start `claude` here) or
+be operated from the workspace root, where the `scribe-claudesidian`
+skill provides equivalent functionality.
+
+## Standalone use
+
+Everything Claudesidian ships works as upstream intended — slash
+commands like `/thinking-partner`, the `init-bootstrap` wizard,
+MCP servers (if configured), and hooks. See `CLAUDE.md` (or
+`CLAUDE-BOOTSTRAP.md` if you haven't run `/init-bootstrap` yet) for
+the operational guide.
+
+## Bridged use (from the GDD workspace)
+
+When you operate this vault from a session rooted at the parent
+yggdrasil workspace:
+
+- The `scribe` skill loads first (PARA, frontmatter, wikilinks)
+- The `scribe-claudesidian` skill loads on top, reading this vault's
+  `CLAUDE.md` (or `CLAUDE-BOOTSTRAP.md`) and surfacing the command
+  manifest from `.claude/claude_config.json`
+- You invoke commands in plain text: *"do a weekly synthesis"* →
+  the agent reads `.claude/commands/weekly-synthesis.md` and follows
+  it
+- Hooks and MCP servers from `.claude/settings.json` and
+  `.claude/mcp-servers/` are NOT activated in bridged use; they only
+  fire when Claude Code is launched from this directory
+
+## Which mode should I use?
+
+- **Bridged (workspace-rooted):** when you also need the broader GDD
+  context — multi-repo work, components, realm config
+- **Standalone (this directory):** when you want pure Claudesidian
+  ergonomics, especially the native slash-command palette and any
+  configured hooks
+```
+
+- [ ] **Step 4: Write `gdd-bridge/README.md`**
+
+Write the file:
+
+```markdown
+# `gdd-bridge/` — Why this directory is here
+
+This is a small overlay of files that GDD adds to a freshly cloned
+Claudesidian vault. They land in the vault root after the clone:
+
+- `AGENTS.md` — explains the bridged-vs-standalone distinction to
+  any agent operating from inside the vault
+- `README.md` (this file) — explains why `gdd-bridge/` exists, kept
+  for human navigation
+
+Nothing here modifies upstream Claudesidian files. If you ever
+re-vendor by re-cloning upstream, the bridge files will be re-applied
+automatically by `ws hoard init`.
+```
+
+- [ ] **Step 5: Verify the claudesidian-vault template structure**
+
+```bash
+find /Users/cervator/dev/git_ws/yggdrasil/templates/hoards/claudesidian-vault -type f | sort
+```
+
+Expected (4 files):
+
+```
+.../claudesidian-vault/README.md
+.../claudesidian-vault/gdd-bridge/AGENTS.md
+.../claudesidian-vault/gdd-bridge/README.md
+.../claudesidian-vault/template.yaml
+```
+
+### Task B5: Extend `ws_hoard_init()` to handle `template.yaml`
+
+**Files:**
+- Modify: `/Users/cervator/dev/git_ws/yggdrasil/scripts/ws-hoard.sh`
+
+- [ ] **Step 1: Identify the insertion points**
+
+Read the existing `ws_hoard_init()` function (around lines 304–466). The plan inserts a new helper before it and a detection branch inside it just before the `cp -R "$template_dir" "$target"` line (around line 422).
+
+- [ ] **Step 2: Add the `ws_hoard_init_from_yaml()` helper**
+
+Insert this just before `ws_hoard_init()`:
+
+```bash
+# Init a hoard from a template that uses `template.yaml` for clone-on-init
+# semantics (instead of the standard cp -R). Returns 0 on success, 1 if
+# the template doesn't have a template.yaml (caller should fall back to
+# the standard flow), or exits non-zero on actual failure.
+#
+# Args:
+#   $1 — template directory (e.g. templates/hoards/claudesidian-vault)
+#   $2 — target hoard directory (e.g. hoards/my-vault)
+ws_hoard_init_from_yaml() {
+    local template_dir="$1"
+    local target="$2"
+    local manifest="$template_dir/template.yaml"
+
+    [[ -f "$manifest" ]] || return 1   # Not a yaml-driven template
+
+    local upstream pin fallback
+    upstream="$(yq '.upstream // ""' "$manifest" 2>/dev/null)"
+    pin="$(yq '.pin // ""' "$manifest" 2>/dev/null)"
+    fallback="$(yq '.fallback // ""' "$manifest" 2>/dev/null)"
+
+    [[ "$upstream" == "null" ]] && upstream=""
+    [[ "$pin" == "null" ]] && pin=""
+    [[ "$fallback" == "null" ]] && fallback=""
+
+    if [[ -z "$upstream" ]]; then
+        echo "ERROR: $manifest is missing the 'upstream' field." >&2
+        exit 1
+    fi
+
+    echo "Cloning $upstream into $target..."
+    if ! git clone "$upstream" "$target" 2>/dev/null; then
+        if [[ -n "$fallback" ]]; then
+            echo "  Upstream clone failed; trying fallback: $fallback" >&2
+            if ! git clone "$fallback" "$target"; then
+                echo "ERROR: both upstream and fallback clones failed." >&2
+                exit 1
+            fi
+        else
+            echo "ERROR: upstream clone failed and no fallback configured." >&2
+            echo "  Check network access or update the manifest:" >&2
+            echo "    $manifest" >&2
+            exit 1
+        fi
+    fi
+
+    # Honor the pin if set
+    if [[ -n "$pin" ]]; then
+        (cd "$target" && git checkout -q "$pin") || {
+            echo "WARNING: failed to check out pin '$pin'; staying on default branch." >&2
+        }
+    fi
+
+    # Strip cloned .git so the upcoming git init in ws_hoard_init() can
+    # re-init this as the user's own repo (matches the standard flow's
+    # post-condition).
+    rm -rf "$target/.git"
+
+    # Apply gdd-bridge/* if present (overlay into vault root)
+    if [[ -d "$template_dir/gdd-bridge" ]]; then
+        # cp -R the gdd-bridge contents (not the directory itself) into target
+        cp -R "$template_dir/gdd-bridge/." "$target/"
+        echo "Applied gdd-bridge overlay."
+    fi
+
+    # Print optional /init-bootstrap tip if the cloned vault advertises one
+    # in its README. We grep loosely so this works for any future template
+    # that wants to surface a similar tip.
+    local clone_readme="$target/README.md"
+    if [[ -f "$clone_readme" ]] && grep -qiE 'init-bootstrap|bootstrap wizard' "$clone_readme" 2>/dev/null; then
+        echo ""
+        echo "Tip: this vault has an optional onboarding wizard. To run it:"
+        echo "  cd $target"
+        echo "  claude"
+        echo "  /init-bootstrap"
+        echo ""
+    fi
+
+    return 0
+}
+```
+
+- [ ] **Step 3: Branch in `ws_hoard_init()` to call the YAML helper when present**
+
+Find the existing line in `ws_hoard_init()` that does the standard copy:
+
+```bash
+    # Copy template directory
+    mkdir -p "$HOARDS_DIR"
+    cp -R "$template_dir" "$target"
+```
+
+Replace those three lines with:
+
+```bash
+    # Copy template directory — UNLESS this is a yaml-driven template,
+    # in which case follow the clone-on-init flow instead.
+    mkdir -p "$HOARDS_DIR"
+    if ws_hoard_init_from_yaml "$template_dir" "$target"; then
+        : # YAML-driven flow handled the clone + post-clone steps
+    else
+        # Standard flow: copy template files verbatim
+        cp -R "$template_dir" "$target"
+    fi
+```
+
+The exit code from `ws_hoard_init_from_yaml` distinguishes "not a yaml template, go fall back" (1) from "yaml flow ran successfully" (0). On actual failure, the helper exits the script directly.
+
+- [ ] **Step 4: Update the templates list in help text**
+
+In `ws_hoard_help()` (around line 151), update the line listing available templates:
+
+Existing:
+```bash
+    echo "                           Available templates: thalami, basic" >&2
+```
+
+Replace with:
+```bash
+    echo "                           Available templates: thalami, basic, obsidian-vault, claudesidian-vault" >&2
+```
+
+- [ ] **Step 5: Run `bash -n` syntax check**
+
+```bash
+bash -n /Users/cervator/dev/git_ws/yggdrasil/scripts/ws-hoard.sh
+```
+
+Expected: clean (no output).
+
+- [ ] **Step 6: Smoke test — init the obsidian-vault template**
+
+```bash
+cd /tmp
+rm -rf test-yggdrasil-init
+mkdir test-yggdrasil-init && cd test-yggdrasil-init
+mkdir -p hoards
+HOARDS_DIR=$PWD/hoards ROOT_DIR=/Users/cervator/dev/git_ws/yggdrasil \
+    ws hoard init obsidian-vault --name test-vault
+```
+
+(Note: this assumes `identity.human_account` is resolvable from the workspace's `ecosystem.local.yaml`. If it errors with "identity.human_account is not set", set it temporarily or run from the actual workspace.)
+
+Expected:
+- `/tmp/test-yggdrasil-init/hoards/test-vault/` is created
+- Contains the 15 files from Task B3
+- Has its own `.git/` (re-init'd by the standard flow's git init step)
+
+```bash
+ls /tmp/test-yggdrasil-init/hoards/test-vault/
+```
+
+Expected: `00_Inbox  01_Projects  02_Areas  03_Resources  04_Archive  05_Attachments  06_Metadata  README.md` (.gitignore + .obsidian/ also present but may not show with default `ls`).
+
+- [ ] **Step 7: Smoke test — init the claudesidian-vault template (network required)**
+
+This requires network access to clone the upstream repo. If the test machine is offline, skip and verify visually.
+
+```bash
+cd /tmp/test-yggdrasil-init
+HOARDS_DIR=$PWD/hoards ROOT_DIR=/Users/cervator/dev/git_ws/yggdrasil \
+    ws hoard init claudesidian-vault --name test-claudesidian
+```
+
+Expected output includes:
+```
+Cloning https://github.com/heyitsnoah/claudesidian into ...
+Applied gdd-bridge overlay.
+Tip: this vault has an optional onboarding wizard...
+```
+
+Then:
+```bash
+ls /tmp/test-yggdrasil-init/hoards/test-claudesidian/
+```
+
+Expected: contents of upstream Claudesidian (CLAUDE-BOOTSTRAP.md, README.md, 00_Inbox/, etc.) PLUS `AGENTS.md` from `gdd-bridge/`.
+
+```bash
+test -d /tmp/test-yggdrasil-init/hoards/test-claudesidian/.git && echo "FAIL: .git not stripped"
+test -f /tmp/test-yggdrasil-init/hoards/test-claudesidian/AGENTS.md || echo "FAIL: gdd-bridge AGENTS.md not applied"
+```
+
+Expected: no FAIL output. (The standard flow re-inits its own .git after the helper returns; that's correct.)
+
+- [ ] **Step 8: Clean up smoke-test fixtures**
+
+```bash
+rm -rf /tmp/test-yggdrasil-init
+```
+
+- [ ] **Step 9: Write the commit bodyfile**
+
+Create `/Users/cervator/dev/git_ws/yggdrasil/.commits/phase-b-templates.md`:
+
+```markdown
+---
+message: |
+  feat(hoards): add obsidian-vault and claudesidian-vault templates
+
+  obsidian-vault is a vendored vanilla Obsidian vault with PARA layout
+  (00-06), minimal .obsidian/ config, and starter templates for daily
+  notes, projects, meetings, weekly review, and inbox capture.
+
+  claudesidian-vault is a thin wrapper that clones upstream Claudesidian
+  on init and overlays a small gdd-bridge/ folder. ws_hoard_init now
+  detects template.yaml and follows the clone-on-init flow when present.
+
+  Per design in docs/plans/2026-05-01-scribe-role-and-vault-templates-design.md.
+add:
+  - templates/hoards/obsidian-vault/
+  - templates/hoards/claudesidian-vault/
+  - scripts/ws-hoard.sh
+---
+```
+
+- [ ] **Step 10: Commit Phase B**
+
+```bash
+ws commit yggdrasil .commits/phase-b-templates.md
+```
+
+---
+
+# Phase C — Skills
+
+The two new skill files. Each is plain markdown — verification is by reading and confirming structure matches the spec.
+
+### Task C1: Create `.agent/skills/scribe/SKILL.md`
+
+**Files:**
+- Create: `/Users/cervator/dev/git_ws/yggdrasil/.agent/skills/scribe/SKILL.md`
+
+- [ ] **Step 1: Write the skill file**
+
+```markdown
+---
+name: scribe
+description: >
+  Obsidian vault conventions: PARA, frontmatter, daily notes, wikilinks,
+  inbox capture loop. Auto-loaded for `role: scribe`. Other roles can
+  dip in on keyword detection — vault, note, journal, inbox, daily note,
+  obsidian, PARA, wikilink, frontmatter, capture, jot, weekly review,
+  thinking partner, weekly synthesis, research assistant — when the
+  phrase implies capture intent, not bare keyword matches.
+---
+
+# Scribe Skill
+
+Operates against Obsidian-style vaults stored as hoards under
+`hoards/<name>/`. Vendor-flavor agnostic — handles plain Obsidian
+vaults directly. If a vault is detected as Claudesidian-flavored,
+hands off to `scribe-claudesidian` for extension behavior.
+
+## When to Load
+
+- **Path A — `role: scribe` in Thalamus frontmatter** — orientation
+  loads this skill automatically per the standard role-default flow
+- **Path B — orientation discovers a vault, role is null** — orientation
+  surfaces the vault and offers scribe role; if user accepts, this skill
+  loads
+- **Path C — mid-session keyword dip-in** — user says something matching
+  capture intent (*"jot this in my inbox"*, *"add a daily note"*,
+  *"capture this idea"*) while in another role; load this skill ad-hoc
+  and perform the requested action without formally swapping role
+- **Path D — explicit user ask** — *"scribe role for this session"* or
+  *"scribe on borgr"*
+
+## Vault Discovery and Binding
+
+Run `ws hoard scan --flavor obsidian` and parse the YAML inventory.
+Then apply binding rules:
+
+| Match count | Action |
+|-------------|--------|
+| 0 | Tell the user no obsidian-flavored hoards exist. Offer `ws hoard init obsidian-vault` or `ws hoard init claudesidian-vault`. Exit binding flow if declined. |
+| 1 | Auto-bind to the single match. In-memory pin for the session. |
+| >1 | Check Thalamus frontmatter for `active_vault: <name>`. If set and matches a scanned hoard, use it silently. Otherwise ask the user which vault for this session. |
+
+After binding, re-check the bound hoard's flavor list. If it contains
+`claudesidian`, also load `.agent/skills/scribe-claudesidian/SKILL.md`
+to layer on the extension behavior.
+
+The pin is **session-local, in-memory**. Don't write the binding to
+Thalamus unless the user explicitly says *"make it permanent"* — in
+which case set `active_vault: <name>` in frontmatter.
+
+## PARA Conventions
+
+Folder roles in a vault scaffolded by GDD's templates (`obsidian-vault`
+or `claudesidian-vault` after `/init-bootstrap`):
+
+| Folder | Role |
+|--------|------|
+| `00_Inbox/` | Temporary capture point. Process weekly to <20 items. |
+| `01_Projects/` | Time-bound initiatives with a clear completion criterion. Each project lives in its own subfolder. |
+| `02_Areas/` | Ongoing responsibilities without an end date. |
+| `03_Resources/` | Reference material organized by topic. |
+| `04_Archive/` | Completed projects and inactive notes. Move whole project folders here when done. |
+| `05_Attachments/` | Binary attachments (images, PDFs). |
+| `06_Metadata/Templates/` | Reusable note templates. |
+
+When creating notes:
+- New captures default to `00_Inbox/`
+- Move to PARA folders when processing (capture → process → organize)
+- Keep folder depth shallow — projects get one subfolder, not nested trees
+
+## Frontmatter Habits
+
+Every new note opens with YAML frontmatter:
+
+```yaml
+---
+created: YYYY-MM-DD
+tags: [...]
+status: active   # or 'unprocessed' for inbox captures, 'archived' for done items
+---
+```
+
+Substitute the actual date — the templates in `06_Metadata/Templates/`
+use Obsidian's `{{date:YYYY-MM-DD}}` syntax that gets replaced when
+inserted via Obsidian's Templates plugin. When creating notes via
+Claude (not Obsidian's UI), substitute the literal date.
+
+## Wikilinks and Embeds
+
+| Syntax | Result |
+|--------|--------|
+| `[[Note Name]]` | Link to another note in the vault |
+| `[[Note Name\|Display Text]]` | Wikilink with custom display text |
+| `![[Note Name]]` | Embed (transclude) another note's content |
+| `![[image.png]]` | Embed an image |
+| `[[Note Name#Heading]]` | Link to a specific heading |
+
+Prefer wikilinks over markdown links inside the vault — they survive
+note renames and Obsidian auto-updates them.
+
+## Daily Notes
+
+Naming pattern: `YYYY-MM-DD - Topic.md`. Lives in `01_Projects/Daily/`
+or `02_Areas/Journal/` — your call, but pick one and be consistent.
+
+When the user says *"start a daily note"* or *"jot something for today"*,
+use the `06_Metadata/Templates/daily-note.md` shape if it exists,
+otherwise create with this minimal frontmatter:
+
+```yaml
+---
+created: YYYY-MM-DD
+tags: [daily]
+status: active
+---
+
+# YYYY-MM-DD — <Topic>
+
+## Today
+
+## Captures
+
+## Links
+
+```
+
+## Inbox Processing
+
+The capture-process-organize loop:
+
+1. **Capture** — anything new lands in `00_Inbox/` with `status: unprocessed`
+2. **Process** — weekly (or on demand), go through inbox items:
+   - Delete anything no longer needed
+   - Move project material to `01_Projects/<name>/`
+   - Move ongoing-responsibility notes to `02_Areas/<area>/`
+   - Move reference material to `03_Resources/<topic>/`
+   - Update each moved note's frontmatter (`status: active`, add tags)
+   - Update wikilinks if names change
+3. **Organize** — keep `00_Inbox/` under 20 items; if it's growing,
+   processing cadence is too slow
+
+When processing, never auto-delete user content silently. Move into a
+subfolder under `04_Archive/` if uncertain.
+
+## Claudesidian Extension Hand-off
+
+After binding to a vault, check if `claudesidian` appears in its flavor
+list (from `ws hoard scan` output). If yes, also load
+`.agent/skills/scribe-claudesidian/SKILL.md`. That skill layers
+plain-text invocation of Claudesidian commands (`/thinking-partner`,
+`/inbox-processor`, `/weekly-synthesis`, etc.) on top of the core PARA
+behavior in this skill.
+
+## Keyword Calibration
+
+Trigger keywords advertised in this skill's frontmatter description
+include `note`, `journal`, `inbox`, `capture`, `jot`, etc. — but
+those words appear in many non-vault contexts.
+
+**Trigger this skill only on phrases implying capture intent:**
+
+| Trigger | Don't trigger |
+|---------|---------------|
+| *"jot this in my inbox"* | *"note that this fails on Windows"* |
+| *"capture this idea"* | *"capture group in the regex"* |
+| *"add a daily note about X"* | *"daily standups are at 10"* |
+| *"start a meeting note"* | *"meeting notes from 2025 are gone"* |
+| *"do a weekly synthesis"* (Claudesidian) | *"weekly all-hands"* |
+
+When in doubt, ask: *"sounds like you want to capture this — should I
+add it to your vault inbox?"* before loading the skill and binding to
+a vault.
+
+## Multi-vault Edge Case
+
+If Path C (keyword dip-in) triggers in a workspace with multiple
+obsidian-flavored hoards and no `active_vault:` is set, the binding
+sub-flow asks the user which vault — mid-conversation. The pin sticks
+for the rest of the session, so it's a one-time prompt. Users who
+frequently dip into capture from multi-vault workspaces should set
+`active_vault:` in Thalamus frontmatter once to skip the question.
+
+## What This Skill Does NOT Do
+
+- Set `role: scribe` in Thalamus permanently — only the user can do
+  that
+- Auto-commit the vault — vault hoards are independent git repos;
+  the user commits when they want
+- Modify `00–06` numbered folder names — those are PARA structural
+  invariants
+- Force any specific filename pattern beyond the daily-note convention
+```
+
+- [ ] **Step 2: Verify the file structure**
+
+```bash
+ls /Users/cervator/dev/git_ws/yggdrasil/.agent/skills/scribe/
+```
+
+Expected: `SKILL.md`.
+
+```bash
+head -10 /Users/cervator/dev/git_ws/yggdrasil/.agent/skills/scribe/SKILL.md
+```
+
+Expected: frontmatter with `name: scribe` and the description starting with "Obsidian vault conventions".
+
+### Task C2: Create `.agent/skills/scribe-claudesidian/SKILL.md`
+
+**Files:**
+- Create: `/Users/cervator/dev/git_ws/yggdrasil/.agent/skills/scribe-claudesidian/SKILL.md`
+
+- [ ] **Step 1: Write the skill file**
+
+```markdown
+---
+name: scribe-claudesidian
+description: >
+  Extension to the scribe skill for Claudesidian-flavored vaults.
+  Reads the vault's CLAUDE.md (or CLAUDE-BOOTSTRAP.md fallback),
+  surfaces the command manifest from .claude/claude_config.json, and
+  lets the user invoke Claudesidian commands like /thinking-partner
+  or /weekly-synthesis in plain text. Auto-loaded by scribe when the
+  bound vault has the `claudesidian` flavor.
+---
+
+# Scribe Claudesidian Extension Skill
+
+Layers Claudesidian-specific behavior on top of the core `scribe`
+skill's PARA / frontmatter / wikilink content. Used when a bound vault
+has the `claudesidian` flavor (per `ws hoard scan`).
+
+## Loads `scribe` First
+
+This skill is an extension, not a replacement. The scribe skill must
+be loaded first — its content covers vault discovery, PARA conventions,
+frontmatter habits, daily notes, and the inbox-processing loop.
+
+If for any reason this skill is invoked without scribe loaded, load
+scribe first via `Read .agent/skills/scribe/SKILL.md`, then continue
+here.
+
+## Read the Vault's CLAUDE.md
+
+On activation, read the bound vault's instruction file:
+
+1. **Prefer `<vault>/CLAUDE.md`** — if it exists, read it. After upstream
+   `/init-bootstrap` runs, this file contains personalized vault
+   conventions (writing style, primary uses, custom context, tools
+   configured).
+2. **Fall back to `<vault>/CLAUDE-BOOTSTRAP.md`** — if `CLAUDE.md` is
+   absent or its content looks generic (no name, no custom context,
+   matches the upstream template verbatim), read `CLAUDE-BOOTSTRAP.md`
+   instead. The bootstrap file ships with the upstream Claudesidian
+   repo and provides the core PARA / vault-handling guidance.
+
+Either path works. The fallback just means less personalized context —
+nothing important breaks.
+
+## Surface the Command Manifest
+
+Read `<vault>/.claude/claude_config.json`. It declares Claudesidian
+commands like:
+
+```json
+{
+  "commands": {
+    "thinking-partner": { "description": "...", "file": "commands/thinking-partner.md" },
+    "inbox-processor":  { "description": "...", "file": "commands/inbox-processor.md" },
+    "weekly-synthesis": { "description": "...", "file": "commands/weekly-synthesis.md" },
+    ...
+  },
+  "shortcuts": {
+    "tp": "thinking-partner",
+    ...
+  }
+}
+```
+
+On first activation in a session, surface the inventory once briefly:
+
+> "Claudesidian-flavored vault detected. Commands available:
+> thinking-partner, inbox-processor, weekly-synthesis, daily-review,
+> research-assistant, de-ai-ify, pull-request, release. Invoke any in
+> plain text — e.g. *'do a weekly synthesis'* — and I'll follow the
+> matching instruction file."
+
+If `.claude/claude_config.json` is missing (older Claudesidian or
+manually trimmed), fall back to enumerating `.claude/commands/*.md`
+files directly and report just the filename stems.
+
+## Plain-Text Invocation Pattern
+
+When the user references a Claudesidian command in plain text:
+
+1. Match the request against the command names from the manifest.
+   Match leniently — *"do a weekly synthesis"*, *"weekly synthesis"*,
+   *"run the weekly synthesis command"* all map to `weekly-synthesis`.
+   Shortcuts (e.g. `ws` → `weekly-synthesis`) also count.
+2. Read the matching command file (`<vault>/.claude/commands/<cmd>.md`)
+3. Cite the file path so the user can see what was loaded:
+   *"Following `<vault>/.claude/commands/weekly-synthesis.md`..."*
+4. Follow the instructions in the file verbatim, treating them as
+   authoritative for that command's behavior
+
+If multiple commands could match, ask the user which one they meant
+rather than guessing.
+
+## Skill Manifest
+
+Read `<vault>/.claude/skills/` to enumerate available Claudesidian
+skills (each is a directory with a `SKILL.md`). Common ones include
+`obsidian-markdown`, `obsidian-bases`, `git-worktrees`, `json-canvas`,
+`skill-creator`, `systematic-debugging`.
+
+**Lazy-load these skills.** Don't read them all on activation — the
+inventory list is enough. Read individual `SKILL.md` files only when
+the user's request makes them relevant:
+
+- User mentions "wikilinks" or "callouts" → read
+  `<vault>/.claude/skills/obsidian-markdown/SKILL.md`
+- User mentions "Obsidian Bases" → read
+  `<vault>/.claude/skills/obsidian-bases/SKILL.md`
+- User asks for canvas / `.canvas` files → read
+  `<vault>/.claude/skills/json-canvas/SKILL.md`
+
+## What This Skill Does NOT Do
+
+The following are intentionally NOT adopted from upstream Claudesidian:
+
+- **`.claude/settings.json` hooks** — the SessionStart welcome banner
+  and the `skill-discovery.sh` UserPromptSubmit hook are replaced by
+  this skill's once-on-activation manifest surfacing
+- **`CLAUDE-BOOTSTRAP.md` as primary** — only used as a fallback when
+  `CLAUDE.md` is absent or generic
+- **MCP server registration** — the upstream Gemini Vision MCP isn't
+  auto-wired. If the user wants it, they explicitly add it to
+  yggdrasil's `.mcp.json` (handled separately, out of scope for this
+  skill)
+- **`pnpm` / `npm` install** — Claudesidian's helper scripts and
+  attachment management need a Node toolchain. If the user wants them,
+  they run `pnpm install` themselves inside the vault. The bridge skill
+  doesn't gate on it.
+- **`/upgrade` command bookkeeping** — Claudesidian's self-upgrade
+  command is for users running it standalone. From the bridge, treat
+  the vault as upstream-managed; if it needs refreshing, that's a user
+  decision.
+
+## Composition with `scribe`
+
+In normal flow:
+
+1. User triggers vault binding (any of paths A–D from the scribe skill)
+2. Scribe skill calls `ws hoard scan --flavor obsidian`
+3. The bound vault's flavor list contains `claudesidian` → scribe
+   instructs the agent to also load this skill
+4. This skill reads `<vault>/CLAUDE.md` and surfaces the command
+   manifest
+5. Subsequent vault interactions use scribe's PARA/frontmatter
+   conventions PLUS this skill's command-invocation behavior
+
+For plain Obsidian vaults without `.claude/`, this skill is never
+loaded; scribe's vanilla content is sufficient.
+```
+
+- [ ] **Step 2: Verify the file structure**
+
+```bash
+ls /Users/cervator/dev/git_ws/yggdrasil/.agent/skills/scribe-claudesidian/
+```
+
+Expected: `SKILL.md`.
+
+```bash
+head -10 /Users/cervator/dev/git_ws/yggdrasil/.agent/skills/scribe-claudesidian/SKILL.md
+```
+
+Expected: frontmatter with `name: scribe-claudesidian`.
+
+### Task C3: Commit Phase C
+
+- [ ] **Step 1: Write the commit bodyfile**
+
+Create `/Users/cervator/dev/git_ws/yggdrasil/.commits/phase-c-skills.md`:
+
+```markdown
+---
+message: |
+  feat(skills): add scribe and scribe-claudesidian skills
+
+  scribe handles plain Obsidian vault conventions: PARA layout,
+  frontmatter habits, wikilinks, daily notes, inbox capture loop.
+  Calls `ws hoard scan` for vault discovery. Auto-loads for
+  `role: scribe`; other roles dip in on capture-intent keywords.
+
+  scribe-claudesidian extends scribe for Claudesidian-flavored vaults.
+  Reads vault CLAUDE.md (or CLAUDE-BOOTSTRAP.md fallback), surfaces
+  the command manifest from .claude/claude_config.json, and lets the
+  user invoke /thinking-partner, /weekly-synthesis, etc. in plain
+  text from the workspace root.
+
+  Per design in docs/plans/2026-05-01-scribe-role-and-vault-templates-design.md.
+add:
+  - .agent/skills/scribe/SKILL.md
+  - .agent/skills/scribe-claudesidian/SKILL.md
+---
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+ws commit yggdrasil .commits/phase-c-skills.md
+```
+
+---
+
+# Phase D — Wiring
+
+Small additions to AGENTS.md, the orientation skill, the gdd skill role list, and the thalamus template. Each is a few-line edit.
+
+### Task D1: Update `gdd-orientation/SKILL.md` with vault-scan step
+
+**Files:**
+- Modify: `/Users/cervator/dev/git_ws/yggdrasil/.agent/skills/gdd-orientation/SKILL.md`
+
+- [ ] **Step 1: Read the existing Step 6 section**
+
+Find the section "### Step 6: Trust Verification of Realms and Nested Components" with subsections 6a (active realm) and 6b (cloned components).
+
+- [ ] **Step 2: Add a new subsection 6c for vault scan**
+
+After subsection 6b (cloned components), insert this new subsection:
+
+```markdown
+#### 6c: Hoard vault scan
+
+If `Thalamus.md` frontmatter has `role: null`, also call `ws hoard scan
+--flavor obsidian` to detect any Obsidian or Claudesidian-flavored
+hoards. The output is YAML; parse the entries and surface a brief
+summary alongside the role question:
+
+> "role is null. Detected vault: borgr (claudesidian), nonclaudesidian
+> (obsidian). Want scribe role for vault work, or another (developer
+> / designer / reviewer)?"
+
+If `role: scribe` is already set in frontmatter, skip the question —
+Step 5's role-default handling already loads the scribe skill, which
+runs its own vault-binding sub-flow.
+
+If `ws hoard scan` errors or is unavailable, note the failure and
+continue — don't block orientation on it.
+
+The vault scan is informational at orientation time only. Actual
+binding (and any prompt for "which vault?") happens later, when the
+scribe skill loads — driven by user intent, not orientation.
+```
+
+- [ ] **Step 3: Verify the change**
+
+```bash
+grep -A2 "6c: Hoard vault scan" /Users/cervator/dev/git_ws/yggdrasil/.agent/skills/gdd-orientation/SKILL.md
+```
+
+Expected: the new subsection header and first lines.
+
+### Task D2: Update `gdd/SKILL.md` to add `scribe` to the role list
+
+**Files:**
+- Modify: `/Users/cervator/dev/git_ws/yggdrasil/.agent/skills/gdd/SKILL.md`
+
+- [ ] **Step 1: Locate the role list**
+
+```bash
+grep -n "developer\|designer\|reviewer" /Users/cervator/dev/git_ws/yggdrasil/.agent/skills/gdd/SKILL.md | head -10
+```
+
+Find the section that enumerates roles (per the existing GDD design,
+likely a definition list or table with developer / designer /
+reviewer).
+
+- [ ] **Step 2: Add `scribe` after `reviewer`**
+
+Add a new entry following the same style as the existing roles:
+
+```markdown
+- **scribe** — Note-taking and vault work. Auto-loads
+  `.agent/skills/scribe/SKILL.md` for PARA conventions, frontmatter
+  habits, daily notes, and the capture-process-organize loop. Other
+  roles can dip into the scribe skill on capture-intent keywords.
+```
+
+(Adjust the exact markdown style — bullets vs. table row vs. heading —
+to match the surrounding entries.)
+
+- [ ] **Step 3: Verify**
+
+```bash
+grep -A2 "scribe" /Users/cervator/dev/git_ws/yggdrasil/.agent/skills/gdd/SKILL.md | head -5
+```
+
+Expected: the new role entry visible.
+
+### Task D3: Update `AGENTS.md`
+
+**Files:**
+- Modify: `/Users/cervator/dev/git_ws/yggdrasil/AGENTS.md`
+
+- [ ] **Step 1: Add two rows to the Skills table**
+
+Find the existing Skills table (around line 67–84). After the existing
+rows for the GDD modes, add:
+
+```markdown
+| **Scribe** | Obsidian vault conventions: PARA, frontmatter, daily notes, wikilinks, inbox capture. Auto-loads for `role: scribe`; other roles dip in on capture-intent keywords. | [SKILL.md](./.agent/skills/scribe/SKILL.md) |
+| **Scribe Claudesidian** | Extension for Claudesidian-flavored vaults: reads vault CLAUDE.md, surfaces command manifest, plain-text invocation of /thinking-partner / /weekly-synthesis / etc. Auto-loaded by scribe when the bound vault has `claudesidian` flavor. | [SKILL.md](./.agent/skills/scribe-claudesidian/SKILL.md) |
+```
+
+The two rows go between the existing GDD-mode rows and the BDD rows
+(maintain alphabetical-ish grouping by feature area).
+
+- [ ] **Step 2: Update the Hoards section**
+
+Find the "## Hoards (personal containers)" section. Append one line at
+the end mentioning the new templates:
+
+```markdown
+Hoard templates ship under `templates/hoards/<flavor>/`. Current
+flavors: `thalami`, `basic`, `obsidian-vault` (vanilla Obsidian),
+`claudesidian-vault` (thin wrapper around upstream
+[Claudesidian](https://github.com/heyitsnoah/claudesidian)).
+```
+
+- [ ] **Step 3: Verify**
+
+```bash
+grep -c "Scribe" /Users/cervator/dev/git_ws/yggdrasil/AGENTS.md
+```
+
+Expected: at least 2 (the two skill table rows). Likely also one in
+the description text.
+
+```bash
+grep "obsidian-vault\|claudesidian-vault" /Users/cervator/dev/git_ws/yggdrasil/AGENTS.md
+```
+
+Expected: the new line in the Hoards section.
+
+### Task D4: Update `templates/thalamus.md`
+
+**Files:**
+- Modify: `/Users/cervator/dev/git_ws/yggdrasil/templates/thalamus.md`
+
+- [ ] **Step 1: Read the existing frontmatter**
+
+```bash
+head -12 /Users/cervator/dev/git_ws/yggdrasil/templates/thalamus.md
+```
+
+- [ ] **Step 2: Add the optional `active_vault:` field with a comment**
+
+In the frontmatter block, add the new field with a comment:
+
+```yaml
+active_vault: null  # name of the obsidian-flavored hoard scribe should
+                    # auto-bind to (skip the "which vault?" prompt when
+                    # multiple vaults exist). Leave null to be asked.
+```
+
+Place it after the existing role-related field, before the
+`staleness_days` line.
+
+- [ ] **Step 3: Verify**
+
+```bash
+grep "active_vault" /Users/cervator/dev/git_ws/yggdrasil/templates/thalamus.md
+```
+
+Expected: one match showing the new field.
+
+### Task D5: Commit Phase D
+
+- [ ] **Step 1: Write the commit bodyfile**
+
+Create `/Users/cervator/dev/git_ws/yggdrasil/.commits/phase-d-wiring.md`:
+
+```markdown
+---
+message: |
+  feat(gdd): wire scribe role + skills into orientation, AGENTS.md, thalamus
+
+  - gdd-orientation: new Step 6c surfaces detected vaults during the
+    role question when role is null
+  - gdd skill: adds scribe to the role list alongside developer /
+    designer / reviewer
+  - AGENTS.md: two new skill table rows + hoards section line listing
+    obsidian-vault and claudesidian-vault flavors
+  - templates/thalamus.md: documents optional active_vault: frontmatter
+    field for users with multiple vaults
+
+  Per design in docs/plans/2026-05-01-scribe-role-and-vault-templates-design.md.
+add:
+  - .agent/skills/gdd-orientation/SKILL.md
+  - .agent/skills/gdd/SKILL.md
+  - AGENTS.md
+  - templates/thalamus.md
+---
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+ws commit yggdrasil .commits/phase-d-wiring.md
+```
+
+---
+
+# Phase E — Verification
+
+End-to-end smoke test of the full feature. No new files; just confirm everything works in concert before declaring the feature done.
+
+### Task E1: End-to-end smoke test
+
+- [ ] **Step 1: Verify `ws hoard scan` against current hoards**
+
+```bash
+cd /Users/cervator/dev/git_ws/yggdrasil
+ws hoard scan
+```
+
+Expected (order may vary): three records — borgr (obsidian, claudesidian), nonclaudesidian (obsidian), thalami-Cervator (thalami).
+
+- [ ] **Step 2: Verify the help output**
+
+```bash
+ws hoard help
+```
+
+Or:
+```bash
+ws hoard --help
+```
+
+Expected: `scan` listed; `Available templates: thalami, basic, obsidian-vault, claudesidian-vault`.
+
+- [ ] **Step 3: Verify orientation flow surfaces vaults**
+
+Open a fresh Claude session in the workspace and ask "what's available
+to work on today?" or similar. The orientation skill should run, call
+`ws hoard scan`, and surface the detected vaults.
+
+Expected: agent mentions detected vaults (borgr, nonclaudesidian) in
+its session-start summary.
+
+If `Thalamus.md` frontmatter has `role: null`, the agent should also
+offer scribe role explicitly during the role question.
+
+- [ ] **Step 4: Verify scribe skill loads on dip-in**
+
+In an existing session in a non-scribe role, say:
+*"jot a quick note that the deploy was rolled back to v1.2.3 today"*
+
+Expected: agent recognizes capture intent, loads the scribe skill,
+runs vault-binding (auto-binds to the single obsidian vault if you
+have one, or asks if multiple), creates a note in `00_Inbox/` with
+proper frontmatter and date.
+
+- [ ] **Step 5: Verify scribe-claudesidian extension loads**
+
+After Step 4 (or independently), verify the extension activates when
+binding to a claudesidian-flavored vault. Say:
+*"do a weekly synthesis on borgr"*
+
+Expected: agent loads scribe + scribe-claudesidian, reads
+`hoards/borgr/.claude/commands/weekly-synthesis.md`, cites the file
+path, and follows its instructions.
+
+- [ ] **Step 6: Verify template init still works for existing flavors**
+
+Make sure the YAML branching didn't break the standard flow:
+
+```bash
+cd /tmp && rm -rf yggdrasil-init-test && mkdir yggdrasil-init-test && cd yggdrasil-init-test
+mkdir hoards
+HOARDS_DIR=$PWD/hoards ROOT_DIR=/Users/cervator/dev/git_ws/yggdrasil \
+    ws hoard init basic --name test-basic
+```
+
+Expected: standard cp -R flow runs, `hoards/test-basic/` created from
+`templates/hoards/basic/`. No errors.
+
+```bash
+rm -rf /tmp/yggdrasil-init-test
+```
+
+- [ ] **Step 7: Verify the design + plan docs are committed**
+
+```bash
+git -C /Users/cervator/dev/git_ws/yggdrasil log --oneline | head -8
+```
+
+Expected: see commits for phases A, B, C, D each with their
+descriptive messages.
+
+- [ ] **Step 8: Final check — pre-existing tests still pass**
+
+If yggdrasil has any test suite (pytest, bats, etc.), run it:
+
+```bash
+cd /Users/cervator/dev/git_ws/yggdrasil
+ws test 2>/dev/null || echo "no test target detected — skipping"
+```
+
+Expected: pass, or "no test target" if none configured.
+
+- [ ] **Step 9: Optional — push the branch**
+
+If everything looks clean and you want to land it:
+
+```bash
+ws push yggdrasil
+```
+
+Then open a CR / PR for review.
+
+---
+
+## Self-Review Checklist (run before declaring complete)
+
+After implementation, do a fresh-eyes pass:
+
+1. **Spec coverage** — go through `docs/plans/2026-05-01-scribe-role-and-vault-templates-design.md` section by section. Every requirement should map to at least one task in this plan. Known mappings:
+   - Goals 1-7 → covered across all phases
+   - Architecture diagram → Phases A, B, C, D collectively implement each box
+   - `ws hoard scan` component → Phase A
+   - scribe / scribe-claudesidian skills → Phase C
+   - Templates → Phase B
+   - AGENTS.md / orientation / role list / thalamus updates → Phase D
+   - Vault binding sub-flow → encoded in scribe SKILL.md (Phase C, Task C1)
+   - Trigger paths A-D → encoded in scribe SKILL.md "When to Load" section
+   - Multi-vault edge case → encoded in scribe SKILL.md
+   - Optional `/init-bootstrap` step → in claudesidian-vault README.md (Phase B, Task B4) and scribe-claudesidian SKILL.md (Phase C, Task C2)
+   - Out-of-scope items → none of those should appear in any task
+
+2. **Placeholder scan** — search the implemented files for `TBD`, `TODO`, `fill in`, `placeholder` (other than the intentional `fallback: ""` placeholder in `template.yaml` and the `<your-vault-name>` instruction in the README).
+
+3. **Type / signature consistency** — `ws_classify_hoard()` returns CSV; `ws_hoard_scan()` parses by splitting on comma. `ws_hoard_init_from_yaml()` returns 1 for "not yaml" and 0 for "ran"; the caller branches on that.
+
+4. **Cross-file references** — the scribe SKILL.md references `ws hoard scan` (delivered in Phase A) and `.agent/skills/scribe-claudesidian/SKILL.md` (delivered in Phase C). The orientation SKILL.md references `ws hoard scan`. AGENTS.md references both skill files. All these come together by end of Phase D.
+
+If issues surface, fix them inline and re-run the affected smoke tests.

--- a/scripts/git-push.sh
+++ b/scripts/git-push.sh
@@ -75,14 +75,18 @@ if [[ -n "$FORCE" ]] && [[ "$BRANCH" == "main" || "$BRANCH" == "master" ]]; then
   exit 1
 fi
 
-# Detect whether this branch already has an upstream tracking ref
-# pointing at the same remote we're about to push to. If not, add
-# `-u` so the first push wires up tracking automatically — without
-# this, a later `ws pull <name>` would skip the repo as "no upstream
-# tracking branch." Caller can still re-push later without args
-# because tracking is now set.
+# Detect whether $BRANCH already has an upstream tracking ref pointing
+# at the same remote we're about to push to. If not, add `-u` so the
+# first push wires up tracking automatically — without this, a later
+# `ws pull <name>` would skip the repo as "no upstream tracking
+# branch." Caller can still re-push later without args because tracking
+# is now set.
+#
+# Important: scope the upstream lookup to ${BRANCH}@{upstream}, not the
+# bare @{upstream} (which is the *current* branch's upstream). When the
+# caller passes an explicit branch name, those can differ.
 SET_UPSTREAM=""
-if ! current_upstream=$(git rev-parse --abbrev-ref --symbolic-full-name "@{upstream}" 2>/dev/null); then
+if ! current_upstream=$(git rev-parse --abbrev-ref --symbolic-full-name "${BRANCH}@{upstream}" 2>/dev/null); then
   SET_UPSTREAM="--set-upstream"
 elif [[ "$current_upstream" != "$REMOTE_NAME/$BRANCH" ]]; then
   # Tracking exists but points elsewhere (e.g. branch was created

--- a/scripts/git-push.sh
+++ b/scripts/git-push.sh
@@ -75,10 +75,26 @@ if [[ -n "$FORCE" ]] && [[ "$BRANCH" == "main" || "$BRANCH" == "master" ]]; then
   exit 1
 fi
 
+# Detect whether this branch already has an upstream tracking ref
+# pointing at the same remote we're about to push to. If not, add
+# `-u` so the first push wires up tracking automatically — without
+# this, a later `ws pull <name>` would skip the repo as "no upstream
+# tracking branch." Caller can still re-push later without args
+# because tracking is now set.
+SET_UPSTREAM=""
+if ! current_upstream=$(git rev-parse --abbrev-ref --symbolic-full-name "@{upstream}" 2>/dev/null); then
+  SET_UPSTREAM="--set-upstream"
+elif [[ "$current_upstream" != "$REMOTE_NAME/$BRANCH" ]]; then
+  # Tracking exists but points elsewhere (e.g. branch was created
+  # tracking origin and we're now pushing to a fork remote). Re-aim
+  # it so future `git pull` / `ws pull` flows the right way.
+  SET_UPSTREAM="--set-upstream"
+fi
+
 if [[ -n "$FORCE" ]]; then
   echo "Force pushing $BRANCH → $REMOTE_NAME ($ORG_REPO)"
-  git push --force "$REMOTE_NAME" "$BRANCH"
+  git push --force ${SET_UPSTREAM:+$SET_UPSTREAM} "$REMOTE_NAME" "$BRANCH"
 else
   echo "Pushing $BRANCH → $REMOTE_NAME ($ORG_REPO)"
-  git push "$REMOTE_NAME" "$BRANCH"
+  git push ${SET_UPSTREAM:+$SET_UPSTREAM} "$REMOTE_NAME" "$BRANCH"
 fi

--- a/scripts/ws
+++ b/scripts/ws
@@ -25,7 +25,7 @@
 #   realm <url>       Clone a community realm
 #   realm use <name>  Set active realm
 #   realm list        Show available realms
-#   hoard init [template]      Scaffold a new hoard (default: thalami)
+#   hoard init [template] [--name <name>]   Scaffold a new hoard (default template: thalami)
 #   hoard <url>                Clone an existing hoard
 #   hoard list                 Show hoards and which thalami hoard is active
 #   component init <flavor> [name]   Scaffold a new component from a template

--- a/scripts/ws-hoard.sh
+++ b/scripts/ws-hoard.sh
@@ -144,7 +144,11 @@ ws_hoard_help() {
     echo "Usage: ws hoard <subcommand> [args...]" >&2
     echo "" >&2
     echo "Subcommands:" >&2
-    echo "  init [template] [args]   Scaffold a new hoard locally (default: thalami)" >&2
+    echo "  init [template] [--name <name>] [template-args]" >&2
+    echo "                           Scaffold a new hoard locally (default template: thalami)" >&2
+    echo "                           --name overrides the directory name" >&2
+    echo "                           (default: <template>-<username>)" >&2
+    echo "                           Available templates: thalami, basic" >&2
     echo "                           Per-template args:" >&2
     echo "                             thalami --from-thalamus" >&2
     echo "                                  Move root Thalamus.md into the new hoard" >&2
@@ -292,8 +296,9 @@ ws_hoard_cadence() {
     echo "last_commit_unix: $last_commit_ts"
 }
 
-# ws_hoard_init [template] [template-args...]
+# ws_hoard_init [template] [--name <hoard-name>] [template-args...]
 # Default template: thalami.
+# --name overrides the hoard directory name (default: <template>-<username>).
 # Per-template args:
 #   thalami --from-thalamus    Move root Thalamus.md into the new hoard
 ws_hoard_init() {
@@ -319,30 +324,61 @@ ws_hoard_init() {
 
     local who
     who="$(ws_resolve_human_account)"
-    local target="$HOARDS_DIR/${template}-${who}"
+
+    # Parse --name and per-template args from remaining args
+    local custom_name=""
+    local from_thalamus=false
+    local remaining_args=()
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --name)
+                [[ -z "${2:-}" ]] && { echo "ERROR: --name requires a value." >&2; exit 2; }
+                custom_name="$2"
+                shift 2
+                ;;
+            --name=*)
+                custom_name="${1#--name=}"
+                shift
+                ;;
+            --from-thalamus)
+                from_thalamus=true
+                shift
+                ;;
+            *)
+                remaining_args+=("$1")
+                shift
+                ;;
+        esac
+    done
+
+    if [[ ${#remaining_args[@]} -gt 0 ]]; then
+        echo "ERROR: unexpected args for '$template' template: ${remaining_args[*]}" >&2
+        exit 2
+    fi
+
+    # Validate custom name if given
+    if [[ -n "$custom_name" ]]; then
+        if [[ ! "$custom_name" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
+            echo "ERROR: --name must be a safe directory name (got: $custom_name)." >&2
+            exit 2
+        fi
+    fi
+
+    # Resolve target directory: <name>-<username> or <template>-<username>
+    local hoard_prefix="${custom_name:-$template}"
+    local target="$HOARDS_DIR/${hoard_prefix}-${who}"
     if [[ -d "$target" ]]; then
         echo "ERROR: Hoard already exists at $target." >&2
         echo "  Remove it first if you want to start over." >&2
         exit 1
     fi
 
-    # Per-template arg handling
-    local from_thalamus=false
+    # thalami-specific validation
     case "$template" in
-        thalami)
-            for arg in "$@"; do
-                case "$arg" in
-                    --from-thalamus) from_thalamus=true ;;
-                    *)
-                        echo "ERROR: unknown arg for thalami template: '$arg'." >&2
-                        exit 2
-                        ;;
-                esac
-            done
-            ;;
+        thalami) ;;  # --from-thalamus already parsed above
         *)
-            if [[ $# -gt 0 ]]; then
-                echo "ERROR: template '$template' does not accept extra args (got: $*)." >&2
+            if [[ "$from_thalamus" == true ]]; then
+                echo "ERROR: --from-thalamus is only valid for the thalami template." >&2
                 exit 2
             fi
             ;;
@@ -413,14 +449,14 @@ ws_hoard_init() {
         git init -q -b main
         git add .
         git -c user.name="$commit_name" -c user.email="$commit_email" \
-            commit -q -m "Initial commit (${template} hoard for ${who})"
+            commit -q -m "Initial commit (${hoard_prefix} hoard for ${who})"
     )
 
     echo ""
     echo "Hoard initialized: $target"
     echo ""
     echo "Push to your own remote when ready, e.g.:"
-    echo "  gh repo create ${who}/${template}-${who} --private --source=${target#"$ROOT_DIR"/} --remote=${who} --push"
+    echo "  gh repo create ${who}/${hoard_prefix}-${who} --private --source=${target#"$ROOT_DIR"/} --remote=${who} --push"
     echo ""
     echo "Or set up the remote manually (using ${who} as the remote name —"
     echo "the workspace convention is to avoid generic 'origin'):"
@@ -431,18 +467,37 @@ ws_hoard_init() {
 
 ws_hoard_clone_url() {
     local url="$1"
+    shift
     if [[ ! "$url" =~ ^(https?://|git@) ]]; then
         echo "ERROR: Unknown subcommand or invalid URL '$url'." >&2
         echo "  Run 'ws hoard' for usage." >&2
         exit 1
     fi
 
-    # Derive hoard directory name from the URL's repo basename
+    # Parse --name from remaining args
+    local custom_name=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --name)
+                [[ -z "${2:-}" ]] && { echo "ERROR: --name requires a value." >&2; exit 2; }
+                custom_name="$2"; shift 2 ;;
+            --name=*)
+                custom_name="${1#--name=}"; shift ;;
+            *)
+                echo "ERROR: unexpected arg for hoard clone: '$1'." >&2; exit 2 ;;
+        esac
+    done
+
+    # Derive hoard directory name from --name or the URL's repo basename
     local repo_name
-    repo_name="${url##*/}"
-    repo_name="${repo_name%.git}"
+    if [[ -n "$custom_name" ]]; then
+        repo_name="$custom_name"
+    else
+        repo_name="${url##*/}"
+        repo_name="${repo_name%.git}"
+    fi
     if [[ ! "$repo_name" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
-        echo "ERROR: hoard repo name must be a safe directory name (got: $repo_name)." >&2
+        echo "ERROR: hoard name must be a safe directory name (got: $repo_name)." >&2
         exit 1
     fi
 
@@ -456,8 +511,7 @@ ws_hoard_clone_url() {
     echo "CLONE: hoard -> $target"
     git clone "$url" "$target"
     echo ""
-    echo "Hoard cloned. If this is a thalami hoard, the active machine's thalamus"
-    echo "file is at $target/$(ws_resolve_machine_name)-thalamus.md (created on first session if absent)."
+    echo "Hoard cloned: $target"
 }
 
 ws_hoard_list() {
@@ -534,6 +588,6 @@ case "$SUBCMD" in
         ws_resolve_thalamus_path
         ;;
     *)
-        ws_hoard_clone_url "$SUBCMD"
+        ws_hoard_clone_url "$SUBCMD" "$@"
         ;;
 esac

--- a/scripts/ws-hoard.sh
+++ b/scripts/ws-hoard.sh
@@ -343,6 +343,7 @@ ws_hoard_init() {
                 ;;
             --name=*)
                 custom_name="${1#--name=}"
+                [[ -z "$custom_name" ]] && { echo "ERROR: --name requires a value." >&2; exit 2; }
                 shift
                 ;;
             --from-thalamus)
@@ -366,6 +367,23 @@ ws_hoard_init() {
         if [[ ! "$custom_name" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
             echo "ERROR: --name must be a safe directory name (got: $custom_name)." >&2
             exit 2
+        fi
+    fi
+
+    # Warn if a thalami hoard is being created with a non-conforming name.
+    # ws_detect_thalami_hoard() globs `thalami` and `thalami-*`; anything
+    # else won't be auto-detected as the active thalami without an explicit
+    # selector in ecosystem.local.yaml. Warn rather than reject — the
+    # selector is a perfectly valid escape hatch and the user may be doing
+    # this on purpose.
+    if [[ "$template" == "thalami" && -n "$custom_name" ]]; then
+        if [[ "$custom_name" != "thalami" && "$custom_name" != thalami-* ]]; then
+            echo "WARNING: --name '$custom_name' won't be auto-detected as the active thalami." >&2
+            echo "  ws_detect_thalami_hoard() globs 'thalami' or 'thalami-*' only." >&2
+            echo "  To use this hoard as the active thalami, set in ecosystem.local.yaml:" >&2
+            echo "    hoards:" >&2
+            echo "      thalami: $custom_name" >&2
+            echo "" >&2
         fi
     fi
 
@@ -491,7 +509,9 @@ ws_hoard_clone_url() {
                 [[ -z "${2:-}" ]] && { echo "ERROR: --name requires a value." >&2; exit 2; }
                 custom_name="$2"; shift 2 ;;
             --name=*)
-                custom_name="${1#--name=}"; shift ;;
+                custom_name="${1#--name=}"
+                [[ -z "$custom_name" ]] && { echo "ERROR: --name requires a value." >&2; exit 2; }
+                shift ;;
             *)
                 echo "ERROR: unexpected arg for hoard clone: '$1'." >&2; exit 2 ;;
         esac

--- a/scripts/ws-hoard.sh
+++ b/scripts/ws-hoard.sh
@@ -26,7 +26,11 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/ws-realm.sh"   # for ws_resolve_ecosystem
 
 # Resolve identity.human_account from merged ecosystem config.
-# Errors with guidance if unset — required for hoard naming.
+# Errors with guidance if unset — used for the initial commit
+# attribution, the printed `gh repo create` URL, and the recommended
+# remote name when scaffolding a hoard. Hoard *directory* names no
+# longer carry a username suffix, so this is no longer needed for the
+# directory itself, but the three uses above still depend on it.
 ws_resolve_human_account() {
     local eco
     eco="$(ws_resolve_ecosystem)"
@@ -34,8 +38,9 @@ ws_resolve_human_account() {
     who="$(yq '.identity.human_account // ""' "$eco" 2>/dev/null)"
     if [[ -z "$who" || "$who" == "null" ]]; then
         echo "ERROR: identity.human_account is not set." >&2
-        echo "  Set it in ecosystem.local.yaml so hoard names can be generated." >&2
-        echo "  Example:" >&2
+        echo "  Set it in ecosystem.local.yaml — used for the initial commit" >&2
+        echo "  attribution, the printed gh repo create URL, and the" >&2
+        echo "  recommended remote name. Example:" >&2
         echo "    identity:" >&2
         echo "      human_account: cervator" >&2
         exit 1
@@ -541,6 +546,25 @@ ws_hoard_clone_url() {
     git clone "$url" "$target"
     echo ""
     echo "Hoard cloned: $target"
+
+    # Post-clone heuristic: if the cloned hoard looks like a thalami
+    # (has at least one <machine>-thalamus.md file at its root) but the
+    # local directory name won't be auto-detected by
+    # ws_detect_thalami_hoard()'s `thalami` / `thalami-*` glob, point
+    # the user at the explicit selector. We can't know it's a thalami
+    # until after the clone, so the warning lives here rather than
+    # pre-flight.
+    if compgen -G "$target/*-thalamus.md" >/dev/null 2>&1; then
+        if [[ "$repo_name" != "thalami" && "$repo_name" != thalami-* ]]; then
+            echo "" >&2
+            echo "NOTE: $target appears to be a thalami hoard (contains *-thalamus.md)" >&2
+            echo "  but its name '$repo_name' won't be auto-detected as the active thalami." >&2
+            echo "  ws_detect_thalami_hoard() globs 'thalami' or 'thalami-*' only." >&2
+            echo "  To use this hoard as the active thalami, set in ecosystem.local.yaml:" >&2
+            echo "    hoards:" >&2
+            echo "      thalami: $repo_name" >&2
+        fi
+    fi
 }
 
 ws_hoard_list() {

--- a/scripts/ws-hoard.sh
+++ b/scripts/ws-hoard.sh
@@ -87,7 +87,9 @@ ws_resolve_machine_name() {
 #
 # Discovery rule:
 #   1. ecosystem.local.yaml `hoards.thalami:` selector
-#   2. Single thalami-* directory in hoards/
+#   2. Single `thalami` or `thalami-*` directory in hoards/
+#      (current default is plain `thalami`; legacy `thalami-<user>` form
+#      stays supported indefinitely)
 #   3. None
 ws_detect_thalami_hoard() {
     local local_file="${ECOSYSTEM_LOCAL:-$ROOT_DIR/ecosystem.local.yaml}"
@@ -110,7 +112,10 @@ ws_detect_thalami_hoard() {
 
     local candidates=()
     if [[ -d "$HOARDS_DIR" ]]; then
-        for d in "$HOARDS_DIR"/thalami-*/; do
+        # Match the current `thalami` default and the legacy `thalami-*`
+        # form. Both globs are evaluated; the [[ -d ]] guard filters out
+        # any literal that didn't expand.
+        for d in "$HOARDS_DIR"/thalami "$HOARDS_DIR"/thalami-*/; do
             [[ -d "$d" ]] || continue
             candidates+=("$(basename "$d")")
         done
@@ -120,7 +125,7 @@ ws_detect_thalami_hoard() {
         0) echo "" ;;
         1) echo "${candidates[0]}" ;;
         *)
-            echo "ERROR: Multiple thalami-* hoards found in hoards/: ${candidates[*]}." >&2
+            echo "ERROR: Multiple thalami hoards found in hoards/: ${candidates[*]}." >&2
             echo "  Set 'hoards.thalami: <name>' in ecosystem.local.yaml to pick one." >&2
             exit 1
             ;;
@@ -147,7 +152,7 @@ ws_hoard_help() {
     echo "  init [template] [--name <name>] [template-args]" >&2
     echo "                           Scaffold a new hoard locally (default template: thalami)" >&2
     echo "                           --name overrides the directory name" >&2
-    echo "                           (default: <template>-<username>)" >&2
+    echo "                           (default: <template> — same as the template name)" >&2
     echo "                           Available templates: thalami, basic" >&2
     echo "                           Per-template args:" >&2
     echo "                             thalami --from-thalamus" >&2
@@ -213,7 +218,7 @@ ws_hoard_read_staleness_days() {
 #   dirty-fresh       — dirty, last commit within threshold (no nudge)
 #   dirty-stale       — dirty, last commit older than threshold (nudge!)
 #   never-committed   — dirty, no prior commit for this file at all
-#   no-active-hoard   — no thalami-* hoard found
+#   no-active-hoard   — no thalami hoard found
 #   no-thalamus-file  — active hoard but expected file isn't on disk
 ws_hoard_cadence() {
     local hoard
@@ -298,7 +303,7 @@ ws_hoard_cadence() {
 
 # ws_hoard_init [template] [--name <hoard-name>] [template-args...]
 # Default template: thalami.
-# --name overrides the hoard directory name (default: <template>-<username>).
+# --name overrides the hoard directory name (default: <template>).
 # Per-template args:
 #   thalami --from-thalamus    Move root Thalamus.md into the new hoard
 ws_hoard_init() {
@@ -364,9 +369,13 @@ ws_hoard_init() {
         fi
     fi
 
-    # Resolve target directory: <name>-<username> or <template>-<username>
-    local hoard_prefix="${custom_name:-$template}"
-    local target="$HOARDS_DIR/${hoard_prefix}-${who}"
+    # Resolve target directory: --name override, else <template>.
+    # No username suffix — hoards live under hoards/ which is already
+    # per-developer (gitignored), so an extra owner suffix is redundant
+    # and forces an awkward name on whatever the user actually wants
+    # to call this hoard.
+    local hoard_name="${custom_name:-$template}"
+    local target="$HOARDS_DIR/$hoard_name"
     if [[ -d "$target" ]]; then
         echo "ERROR: Hoard already exists at $target." >&2
         echo "  Remove it first if you want to start over." >&2
@@ -449,14 +458,14 @@ ws_hoard_init() {
         git init -q -b main
         git add .
         git -c user.name="$commit_name" -c user.email="$commit_email" \
-            commit -q -m "Initial commit (${hoard_prefix} hoard for ${who})"
+            commit -q -m "Initial commit ($hoard_name hoard for ${who})"
     )
 
     echo ""
     echo "Hoard initialized: $target"
     echo ""
     echo "Push to your own remote when ready, e.g.:"
-    echo "  gh repo create ${who}/${hoard_prefix}-${who} --private --source=${target#"$ROOT_DIR"/} --remote=${who} --push"
+    echo "  gh repo create ${who}/${hoard_name} --private --source=${target#"$ROOT_DIR"/} --remote=${who} --push"
     echo ""
     echo "Or set up the remote manually (using ${who} as the remote name —"
     echo "the workspace convention is to avoid generic 'origin'):"
@@ -531,7 +540,7 @@ ws_hoard_list() {
                 marker="  * "
             fi
             local label=""
-            if [[ "$dname" == thalami-* && "$dname" == "$active_thalami" ]]; then
+            if [[ -n "$active_thalami" && "$dname" == "$active_thalami" ]]; then
                 label=" (active thalami)"
             fi
             echo "${marker}${dname}${label}"

--- a/scripts/ws-realm.sh
+++ b/scripts/ws-realm.sh
@@ -29,7 +29,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 : "${COMPONENTS_DIR:="$ROOT_DIR/components"}"
 
 _RESOLVED_ECOSYSTEM=""
-COMPONENT_DIR=""  # Set by ws_validate_component
+# Initialize only if unset so callers that set COMPONENT_DIR before sourcing
+# this file (e.g. git-issue.sh) keep their value. Without :=, sourcing this
+# file from such callers wiped COMPONENT_DIR and broke downstream validation.
+: "${COMPONENT_DIR:=""}"  # Set by ws_validate_component
 
 # ---------------------------------------------------------------------------
 # Shared functions (used by ws-clone.sh, ws-list.sh, ws, etc.)

--- a/scripts/ws-review.sh
+++ b/scripts/ws-review.sh
@@ -165,7 +165,13 @@ review_comments() {
         LC_ALL=C awk '
             BEGIN { hdr = "^\\[[A-Za-z0-9._-]+(\\[bot\\])?\\] "; details_depth=0 }
             /^---$/ { in_block=0; emitted_body=0; details_depth=0; next }
-            $0 ~ hdr "[^[:space:]]+:[0-9]+" || $0 ~ hdr "\\(note\\)" {
+            # Match either path:LINE (numeric) or path:? (GitLab fallback
+            # when no line number is available — see providers/gitlab.sh
+            # gp_review_list_comments where missing line positions render
+            # as ":?"). Without the "?" alternative, GitLab review
+            # comments without line numbers were parsed as body text and
+            # their headlines were merged into the previous block.
+            $0 ~ hdr "[^[:space:]]+:(\\?|[0-9]+)" || $0 ~ hdr "\\(note\\)" {
                 if (in_block && !emitted_body) print ""
                 print
                 in_block=1; emitted_body=0; details_depth=0

--- a/scripts/ws-review.sh
+++ b/scripts/ws-review.sh
@@ -162,7 +162,7 @@ review_comments() {
         # and skip the entire block. Without this, `#!/bin/bash` inside
         # a shell code-fence inside an analysis-chain details would slip
         # through as the "first body line."
-        awk '
+        LC_ALL=C awk '
             BEGIN { hdr = "^\\[[A-Za-z0-9._-]+(\\[bot\\])?\\] "; details_depth=0 }
             /^---$/ { in_block=0; emitted_body=0; details_depth=0; next }
             $0 ~ hdr "[^[:space:]]+:[0-9]+" || $0 ~ hdr "\\(note\\)" {
@@ -176,9 +176,13 @@ review_comments() {
             details_depth > 0 { next }
             in_block && !emitted_body && NF > 0 {
                 if (/^_/ || /^</ || /^>/ || /^```/) next
-                # Skip emoji-led analysis-chain markers (some CR variants
-                # put these outside details blocks too).
-                if (/^[🏁📝🌐💡]/) next
+                # Skip analysis-chain marker lines (any line starting
+                # with a non-ASCII byte — covers emoji-led markers like
+                # 🏁/📝/🌐/💡 from CR variants without embedding
+                # non-ASCII literals into the awk source. LC_ALL=C makes
+                # awk operate in byte mode so the [\x80-\xff] range
+                # matches reliably regardless of system locale.
+                if (/^[\x80-\xff]/) next
                 line = $0
                 sub(/^\*\*/, "", line)
                 sub(/\*\*\.?$/, "", line)

--- a/scripts/ws-review.sh
+++ b/scripts/ws-review.sh
@@ -176,13 +176,19 @@ review_comments() {
             details_depth > 0 { next }
             in_block && !emitted_body && NF > 0 {
                 if (/^_/ || /^</ || /^>/ || /^```/) next
-                # Skip analysis-chain marker lines (any line starting
-                # with a non-ASCII byte — covers emoji-led markers like
-                # 🏁/📝/🌐/💡 from CR variants without embedding
-                # non-ASCII literals into the awk source. LC_ALL=C makes
-                # awk operate in byte mode so the [\x80-\xff] range
-                # matches reliably regardless of system locale.
-                if (/^[\x80-\xff]/) next
+                # Skip CR analysis-chain marker lines. The four known
+                # marker emoji all live in the Symbols & Pictographs
+                # supplementary block, so each is a 4-byte UTF-8
+                # sequence starting with \xF0\x9F. Match each exact
+                # byte sequence — narrower than [\x80-\xff], which
+                # would also drop legitimate non-English review content
+                # (CJK, accented Latin, etc.). LC_ALL=C above makes awk
+                # operate in byte mode so these sequences match
+                # reliably regardless of system locale.
+                if (/^\xF0\x9F\x8F\x81/) next  # chequered flag
+                if (/^\xF0\x9F\x93\x9D/) next  # memo
+                if (/^\xF0\x9F\x8C\x90/) next  # globe with meridians
+                if (/^\xF0\x9F\x92\xA1/) next  # light bulb
                 line = $0
                 sub(/^\*\*/, "", line)
                 sub(/\*\*\.?$/, "", line)

--- a/scripts/ws-review.sh
+++ b/scripts/ws-review.sh
@@ -185,16 +185,19 @@ review_comments() {
                 # Skip CR analysis-chain marker lines. The four known
                 # marker emoji all live in the Symbols & Pictographs
                 # supplementary block, so each is a 4-byte UTF-8
-                # sequence starting with \xF0\x9F. Match each exact
-                # byte sequence — narrower than [\x80-\xff], which
-                # would also drop legitimate non-English review content
-                # (CJK, accented Latin, etc.). LC_ALL=C above makes awk
+                # sequence starting with 0xF0 0x9F. Match each exact
+                # byte sequence using POSIX-portable octal escapes
+                # (\NNN) — narrower than [\x80-\xff], which would also
+                # drop legitimate non-English review content (CJK,
+                # accented Latin, etc.). Octal rather than \xHH because
+                # \xHH is GNU-specific; \NNN is portable across mawk,
+                # nawk, and traditional awk. LC_ALL=C above makes awk
                 # operate in byte mode so these sequences match
                 # reliably regardless of system locale.
-                if (/^\xF0\x9F\x8F\x81/) next  # chequered flag
-                if (/^\xF0\x9F\x93\x9D/) next  # memo
-                if (/^\xF0\x9F\x8C\x90/) next  # globe with meridians
-                if (/^\xF0\x9F\x92\xA1/) next  # light bulb
+                if (/^\360\237\217\201/) next  # 0xF0 9F 8F 81 — chequered flag
+                if (/^\360\237\223\235/) next  # 0xF0 9F 93 9D — memo
+                if (/^\360\237\214\220/) next  # 0xF0 9F 8C 90 — globe with meridians
+                if (/^\360\237\222\241/) next  # 0xF0 9F 92 A1 — light bulb
                 line = $0
                 sub(/^\*\*/, "", line)
                 sub(/\*\*\.?$/, "", line)
@@ -471,7 +474,7 @@ _ECO=$(ws_resolve_ecosystem 2>/dev/null) || _ECO=""
 if [[ $# -lt 1 ]]; then
     echo "Usage: ws review <comp> threads <cr#> [--status | --resolve <id> | --resolve-all]" >&2
     echo "       ws review <comp> reply <cr#> <thread-id> <message> [--resolve]" >&2
-    echo "       ws review <comp> <cr#> [--reviewer <name>] [--since <time>]" >&2
+    echo "       ws review <comp> <cr#> [--reviewer <name>] [--since <time>] [--compact]" >&2
     echo "" >&2
     echo "Run 'ws review --help' for details." >&2
     exit 1

--- a/scripts/ws-review.sh
+++ b/scripts/ws-review.sh
@@ -17,7 +17,7 @@ ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 # --- Function definitions (must precede routing block at bottom) ---
 
 review_help() {
-    echo "Usage: ws review <comp> <cr#> [--reviewer <name>] [--since <time>]"
+    echo "Usage: ws review <comp> <cr#> [--reviewer <name>] [--since <time>] [--compact]"
     echo "       ws review <comp> threads <cr#> [--status | --resolve <id> | --resolve-all]"
     echo "       ws review <comp> notes <cr#> [--reviewer <name>] [--since <time>]"
     echo "       ws review <comp> reply <cr#> <thread-id> <message> [--resolve]"
@@ -30,6 +30,10 @@ review_help() {
     echo "    --reviewer <name>        Filter by reviewer login"
     echo "    --since <time>           Filter by time (last-push, prev-push, Nh, Nm, ISO 8601)"
     echo "                             (--since push events: GitHub only)"
+    echo "    --compact                Headline-only view: each comment shrinks to its"
+    echo "                             [reviewer] file:line + first body line. Useful when"
+    echo "                             a busy PR's full output runs into thousands of lines"
+    echo "                             and you just want to triage at a glance."
     echo ""
     echo "  threads <cr#>              Unresolved diff threads (targeted follow-up)"
     echo "    --status                 Show resolved/unresolved counts"
@@ -46,6 +50,7 @@ review_help() {
     echo ""
     echo "Examples:"
     echo "  ws review yggdrasil 8                      # All review output (start here)"
+    echo "  ws review yggdrasil 8 --compact             # Headline-only triage view"
     echo "  ws review mimir 5 --reviewer coderabbitai"
     echo "  ws review yggdrasil 8 --since last-push"
     echo "  ws review yggdrasil notes 8                # Top-level notes only"
@@ -59,7 +64,7 @@ review_help() {
 
 review_comments() {
     if [[ $# -lt 1 ]]; then
-        echo "Usage: ws review <comp> <cr#> [--reviewer <name>] [--since <time>]" >&2
+        echo "Usage: ws review <comp> <cr#> [--reviewer <name>] [--since <time>] [--compact]" >&2
         exit 1
     fi
 
@@ -68,6 +73,7 @@ review_comments() {
     shift
     local reviewer=""
     local since=""
+    local compact=false
     while [[ $# -gt 0 ]]; do
         case "$1" in
             --reviewer)
@@ -76,6 +82,8 @@ review_comments() {
             --since)
                 [[ $# -ge 2 ]] || { echo "ERROR: --since requires a value" >&2; exit 1; }
                 since="$2"; shift 2 ;;
+            --compact)
+                compact=true; shift ;;
             *) echo "ERROR: Unknown option '$1'" >&2; exit 1 ;;
         esac
     done
@@ -134,6 +142,52 @@ review_comments() {
         fi
     fi
 
+    # Compact rendering: extract `[reviewer] file:line` headers + the
+    # first meaningful body line per comment block, drop the rest.
+    # Skip severity markers (start with `_`), HTML <details> wrappers,
+    # blockquoted prefixes (`>`), code fences, and the `---` separator.
+    # Strip leading/trailing markdown bold from titles. Output stays
+    # readable as a flat list — fits comfortably in agent context for
+    # PRs with dozens of comments where the full output runs 1000+
+    # lines.
+    _render_compact() {
+        # Tight header regex: must look like `[<login>[bot]] <path>:<N>`
+        # or `[<login>[bot]] (note)`. Distinguishes real reviewer headers
+        # from CR analysis-chain `[warning]` / `[grammar]` lint lines and
+        # from bash conditionals like `[[ "${1:-}" == ... ]]` that start
+        # with a `[`.
+        #
+        # Track depth into `<details>` blocks (CR's analysis chain wraps
+        # everything in nested details — script blobs, web queries, etc.)
+        # and skip the entire block. Without this, `#!/bin/bash` inside
+        # a shell code-fence inside an analysis-chain details would slip
+        # through as the "first body line."
+        awk '
+            BEGIN { hdr = "^\\[[A-Za-z0-9._-]+(\\[bot\\])?\\] "; details_depth=0 }
+            /^---$/ { in_block=0; emitted_body=0; details_depth=0; next }
+            $0 ~ hdr "[^[:space:]]+:[0-9]+" || $0 ~ hdr "\\(note\\)" {
+                if (in_block && !emitted_body) print ""
+                print
+                in_block=1; emitted_body=0; details_depth=0
+                next
+            }
+            /<details>/ { details_depth++; next }
+            /<\/details>/ { if (details_depth > 0) details_depth--; next }
+            details_depth > 0 { next }
+            in_block && !emitted_body && NF > 0 {
+                if (/^_/ || /^</ || /^>/ || /^```/) next
+                # Skip emoji-led analysis-chain markers (some CR variants
+                # put these outside details blocks too).
+                if (/^[🏁📝🌐💡]/) next
+                line = $0
+                sub(/^\*\*/, "", line)
+                sub(/\*\*\.?$/, "", line)
+                print "    " line
+                emitted_body=1
+            }
+        '
+    }
+
     # Build jq filters
     local reviewer_filter="."
     if [[ -n "$reviewer" ]]; then
@@ -175,7 +229,11 @@ review_comments() {
     if [[ $_rc -ne 0 ]]; then
         echo "(failed to fetch inline comments — check auth and connectivity)" >&2
     elif [[ -n "$comments" ]]; then
-        echo "$comments"
+        if [[ "$compact" == true ]]; then
+            printf '%s\n' "$comments" | _render_compact
+        else
+            echo "$comments"
+        fi
     else
         echo "(no inline comments${reviewer:+ from $reviewer})"
     fi
@@ -188,7 +246,11 @@ review_comments() {
     if [[ $_rc -ne 0 ]]; then
         echo "(failed to fetch notes — check auth and connectivity)" >&2
     elif [[ -n "$notes" ]]; then
-        echo "$notes"
+        if [[ "$compact" == true ]]; then
+            printf '%s\n' "$notes" | _render_compact
+        else
+            echo "$notes"
+        fi
     else
         echo "(no notes${reviewer:+ from $reviewer})"
     fi

--- a/templates/components/gh-pages/README.md
+++ b/templates/components/gh-pages/README.md
@@ -78,14 +78,13 @@ If you'd rather create the repo by hand:
 3. Skip the README / .gitignore / license options — your scaffold
    already has them.
 4. Click **Create repository**.
-5. Back in your terminal, set the remote, set upstream tracking,
-   and push (`ws push` doesn't currently set upstream on its own,
-   so the first push needs explicit `-u` to wire the branch up;
+5. Back in your terminal, set the remote and push (`ws push` wires
+   up upstream tracking automatically on the first push, so
    subsequent `ws push <name>` calls work without arguments):
 
    ```bash
    git -C components/<name> remote add <yourname> https://github.com/<yourname>/<name>.git
-   git -C components/<name> push -u <yourname> main
+   ws push <name> main
    ```
 
 ## 2. Enable GitHub Pages

--- a/templates/hoards/basic/.ws-cadence.yaml
+++ b/templates/hoards/basic/.ws-cadence.yaml
@@ -1,0 +1,4 @@
+# Commit staleness threshold for this hoard.
+# ws hoard cadence nudges you to commit when the active thalamus file
+# (or hoard content generally) has been dirty for longer than this.
+staleness_days: 2

--- a/templates/hoards/basic/README.md
+++ b/templates/hoards/basic/README.md
@@ -1,0 +1,42 @@
+# Hoard
+
+A personal hoard — a private git repo that lives inside the yggdrasil
+workspace and syncs across machines or collaborators via its own git
+history.
+
+## Layout
+
+Add whatever structure makes sense for this hoard's purpose. Common
+patterns:
+
+```text
+<hoard-name>/
+  README.md           # this file
+  .ws-cadence.yaml    # commit staleness threshold
+  notes/              # private notes, never published
+  publish/            # content destined for external publishing
+```
+
+## Cadence
+
+Edit `.ws-cadence.yaml` to control how often the workspace nudges you
+to commit. Default is 2 days.
+
+## Pushing to your remote
+
+`ws hoard init` creates the hoard as a local git repo without a remote.
+To push:
+
+```bash
+# GitHub
+gh repo create <yourname>/<hoard-name> \
+  --private --source=hoards/<hoard-name> \
+  --remote=<yourname> --push
+
+# GitLab / other — set up manually:
+cd hoards/<hoard-name>
+git remote add <yourname> <your-url>
+git push -u <yourname> main
+```
+
+The workspace convention is to name remotes after the owner, not `origin`.

--- a/templates/hoards/thalami/README.md
+++ b/templates/hoards/thalami/README.md
@@ -8,7 +8,9 @@ history.
 ## Layout
 
 ```text
-thalami-<username>/
+thalami/                    # default name (ws hoard init thalami).
+                            # Override with --name; legacy `thalami-<username>`
+                            # form still supported for existing hoards.
   README.md
   <machine>-thalamus.md     # one per machine; e.g. win10-desktop-thalamus.md
   <machine>-thalamus.md

--- a/templates/hoards/thalami/README.md
+++ b/templates/hoards/thalami/README.md
@@ -41,10 +41,13 @@ The `ws hoard init` flow creates this hoard as a local git repo without
 a remote. To push:
 
 ```bash
-gh repo create <yourname>/thalami-<yourname> \
-  --private --source=hoards/thalami-<yourname> \
+gh repo create <yourname>/thalami \
+  --private --source=hoards/thalami \
   --remote=<yourname> --push
 ```
+
+(The `ws hoard init thalami` command prints the exact command for
+you, with `<yourname>` already filled in.)
 
 The `--remote=<yourname>` flag honors the workspace convention of
 avoiding generic `origin` remote names. `--push` pushes the initial


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @Cervator via GDD.

## Summary

Five commits from the `hodgepodge` integration branch. Headline item is the scribe-role + vault-templates design and plan; the rest are small `ws` CLI improvements made along the way.

- **docs(plans): scribe role and vault templates design + plan** — first-class Obsidian-vault support for GDD via a new `scribe` role with two layered skills (`scribe`, `scribe-claudesidian`), a deterministic `ws hoard scan` subcommand, and two new hoard templates (`obsidian-vault` vendored, `claudesidian-vault` thin wrapper that clones upstream Claudesidian on init). Modes and roles compose orthogonally; scribe is a peer of developer/designer/reviewer. Plan ships in five phases (scanner → templates → skills → wiring → verification), each independently committable.
- **feat(ws-hoard): `--name` flag and `basic` template** — overrides the default `<template>-<username>` directory naming so users can scaffold hoards with arbitrary names. Adds a `basic` template alongside `thalami` for non-thalamus personal hoards.
- **feat(ws-review): `--compact` flag** — headline-only triage view for `ws review` when scanning many CRs at once.
- **fix(ws-realm): preserve caller's `COMPONENT_DIR`** — sourcing `ws-realm.sh` from another script no longer overwrites the caller's working component context.
- **feat(ws): `ws push` auto-sets upstream + four-scope token baseline** — first push of a branch now sets upstream automatically; documents the four-scope GitHub PAT baseline downstream commands assume.

The scribe design + plan are committed as docs only; **no implementation is in this CR**. The plan in `docs/plans/2026-05-01-scribe-role-and-vault-templates-plan.md` is structured for a separate execution pass once the design clears review.

## Test plan

- [ ] Spec reads cleanly and matches the brainstorm shape
- [ ] Plan has no TBD/TODO/placeholder references (one intentional empty `fallback` in the claudesidian-vault `template.yaml`)
- [ ] Plan's task code blocks are buildable as written — review the bash for the `ws_classify_hoard` / `ws_hoard_scan` / `ws_hoard_init_from_yaml` helpers
- [ ] Phase ordering is correct — scanner before skills, templates parallel-able, wiring last
- [ ] `ws hoard scan` smoke output expectations match the existing `hoards/` content (borgr=obsidian+claudesidian, nonclaudesidian=obsidian, thalami-Cervator=thalami)
- [ ] `ws hoard init --name` and `basic` template land cleanly via existing `ws hoard init` flow
- [ ] `ws review --compact` produces the expected one-line-per-CR output
- [ ] `ws-realm.sh` source pattern preserves caller context in a multi-component invocation
- [ ] `ws push` sets upstream on a fresh branch

## Related

- Spec: `docs/plans/2026-05-01-scribe-role-and-vault-templates-design.md`
- Plan: `docs/plans/2026-05-01-scribe-role-and-vault-templates-plan.md`
- Builds on prior hoards work: [Realms and Hoards Design](docs/plans/2026-04-24-realms-and-hoards-design.md), [Component Templates Design](docs/plans/2026-04-25-component-templates-design.md)

## Notes for reviewers

- Out-of-scope items in the design are intentional: `ws hoard inspect`, `ws template upgrade` (likely Backstage-backed in a future iteration), MCP wiring for Gemini Vision, multi-Thalamus per workspace, plugin curation. Each is acknowledged with a hand-off path in the design doc.
- The Claudesidian wrapper is intentionally a clone-on-init pattern (option C from the brainstorm) rather than a vendored copy — keeps GDD lean and respects upstream's own `/upgrade` lifecycle. SiliconSaga fork as fallback URL is a placeholder field in `template.yaml` until the fork actually exists.
- Vault binding is in-memory / session-scoped by default; persistent multi-vault preference is via an optional `active_vault:` Thalamus frontmatter field.
