### PR TITLE
docs: add Realms page; surface six pages missing from doc-site nav

### DIFF
--- a/docs/gdd/hoards.md
+++ b/docs/gdd/hoards.md
@@ -128,32 +128,18 @@ line (`clean`, `dirty-fresh`, `dirty-stale`, `never-committed`,
 nudge text substitutes in. The orientation skill calls it
 automatically; you can also run it manually any time.
 
-**Migrating an existing thalami hoard.** If your thalami hoard
-predates the `.ws-cadence.yaml` convention (created before
-yggdrasil PR #49) and used to carry `commit_staleness_days` in
-each `<machine>-thalamus.md` frontmatter, copy the template file
-into the hoard root once:
+**Migrating an existing thalami hoard** (created before yggdrasil
+PR #49 introduced `.ws-cadence.yaml`): copy
+`templates/hoards/thalami/.ws-cadence.yaml` into your hoard root,
+commit, and push. The old per-machine `commit_staleness_days`
+frontmatter field is now ignored; without the new file, the cadence
+script falls back to its 2-day default.
 
-```bash
-cp templates/hoards/thalami/.ws-cadence.yaml hoards/thalami-<user>/
-```
-
-…then commit and push it to the hoard remote so other machines
-pick up the same threshold. The old per-machine frontmatter field
-is now ignored — without the new file, the cadence script falls
-back to its default of 2 days, which is fine for most setups. Easy
-to forget since it's a one-time migration on a hoard that already
-exists; the cadence nudge will just silently use the default until
-the file is in place.
-
-**Future direction: scope filters.** A `watch:` glob list at the
-hoard root would let other hoard types scope dirty-detection to
-specific files (e.g., a vault-style hoard might want all `*.md`
-files to count, but ignore `_attachments/`). Not implemented in v1
-because thalami's "watch the per-machine file specifically" is
-hardcoded and that's the only shipping hoard type. Add `watch:` to
-`.ws-cadence.yaml` when a second hoard type with different scoping
-needs lands.
+**Future direction: scope filters.** A `watch:` glob list could
+let other hoard types scope dirty-detection (e.g., a vault hoard
+counting `*.md` but ignoring `_attachments/`). Not implemented in
+v1 — thalami's per-machine-file watching is hardcoded — but the
+extension point is reserved for when a second hoard type needs it.
 
 ---
 

--- a/docs/gdd/realms.md
+++ b/docs/gdd/realms.md
@@ -1,0 +1,145 @@
+# Realms
+
+A **realm** is a community's shared configuration as a small git repo,
+cloned into `realms/realm-<community>/` alongside components and hoards.
+Where a hoard is *yours* and a component is *the work*, a realm is the
+*community layer* between them — which components exist, what tier each
+sits in, identity defaults, MCP server overrides, adapter commands, and
+any community-scoped agent material (`AGENTS.md`, `.agent/skills/`).
+
+Realms are how a group sets up the same workspace shape across all of
+its members' machines without forcing everyone to edit config by hand.
+One person curates the realm; everyone else clones it.
+
+---
+
+## Where realms live
+
+```text
+yggdrasil/
+  realms/
+    realm-template/        # upstream tutorial scaffold
+    realm-siliconsaga/     # example community realm
+```
+
+Each realm is an independent git repo, gitignored from the workspace
+itself. The naming convention `realm-<community>` is what makes
+auto-detection work — `ws` looks for matching directories under
+`realms/` and treats them as realm candidates.
+
+The upstream `realm-template` ships as a tutorial scaffold; communities
+fork it and edit, ending up with something like `realm-siliconsaga`
+or `realm-yourorg`. See [Getting Started](../getting-started/index.md)
+for the clone-and-go walkthrough and the realm-creation pattern.
+
+---
+
+## What's in a realm
+
+A realm typically carries:
+
+- **`ecosystem.yaml`** — component list, tiers, defaults. The community
+  declaration of "what we work on."
+- **Identity defaults** — agent identity (e.g. `agent-refr`),
+  attribution conventions, fork-org settings.
+- **MCP server overrides** — which MCP servers the community runs and
+  how they're wired.
+- **Adapter commands** — community-specific shell helpers exposed to
+  agents.
+- **`AGENTS.md`** — community-level agent instructions layered on top
+  of the workspace root's.
+- **`.agent/skills/`** — community-scoped skills that ship to every
+  member's sessions.
+
+Anything an individual would otherwise have to copy across machines
+or re-explain to a new contributor is a candidate to live in the realm.
+
+---
+
+## The three-layer config merge
+
+`ws` resolves a single effective config from three sources, child
+overrides parent:
+
+```text
+ecosystem.yaml              (upstream — generic defaults)
+  ↓
+realms/<active>/ecosystem.yaml   (community)
+  ↓
+ecosystem.local.yaml             (per-developer, gitignored)
+```
+
+All `ws` subcommands read the merged result. The realm owns the
+component list and community defaults; upstream provides methodology
+and tooling; local overrides are for per-developer or per-machine
+quirks. See
+[Ecosystem Architecture](../ecosystem-architecture.md#three-layer-config-merge)
+for the full merge semantics.
+
+---
+
+## The `ws realm` commands
+
+```bash
+ws realm init              # clone the upstream template realm (tutorial)
+ws realm <git-url>         # clone a community realm
+ws realm list              # show available realms and which is active
+ws realm use <name>        # set active realm in ecosystem.local.yaml
+```
+
+The active realm is whichever directory `ecosystem.local.yaml`'s
+`realm:` selector points at — or, if unset, the single non-template
+realm under `realms/` (auto-detected). `ws realm use` writes that
+selector for you.
+
+---
+
+## Trust level
+
+Realm content is **trusted at the workspace root level** —
+`AGENTS.md`, `.agent/skills/`, ecosystem config, and adapter commands
+all flow into your sessions as community-curated instructions. That
+means cloning a realm is a higher-trust act than cloning an arbitrary
+component; only clone realms from communities you're committing to.
+See [Trust and Safety](trust-and-safety.md) for the full hierarchy.
+
+---
+
+## Switching and running side-by-side
+
+You can have multiple realms cloned simultaneously and flip between
+them with `ws realm use <name>`. This is mostly useful for:
+
+- **Tutorial → real.** Start with `realm-template` to learn the
+  workspace, then switch to your community realm when ready.
+- **Cross-community contribution.** A developer who works in two
+  communities (say, `realm-siliconsaga` and `realm-yourorg`) keeps
+  both cloned and switches when context shifts.
+
+Components from inactive realms aren't touched — `ws` just reads a
+different `ecosystem.yaml` for resolution.
+
+---
+
+## Future direction: realm chains
+
+The merge generalizes to N layers. The same upstream → realm → local
+shape extends to corp → dept → team chains for organizations with
+layered config, with the same child-wins semantics. Light reservation
+in code; not needed for v1. See the
+[realms and hoards design](../plans/2026-04-24-realms-and-hoards-design.md#future-directions)
+for the planned shape.
+
+---
+
+## See also
+
+- [GDD Features Tour](features.md) — where realms fit in the larger
+  feature set.
+- [Hoards](hoards.md) — the personal counterpart to realms.
+- [Ecosystem Architecture](../ecosystem-architecture.md) — the merge
+  semantics and dual-mode source resolution.
+- [Getting Started](../getting-started/index.md) — clone-and-go
+  walkthrough including realm setup.
+- [Trust and Safety](trust-and-safety.md) — realm content's trust
+  level and the broader hierarchy.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,15 +52,22 @@ nav:
   - Yggdrasil:
     - Ecosystem Architecture: ecosystem-architecture.md
     - Dev Setup: dev-setup.md
+    - IDE Setup: ide-setup.md
     - WS CLI Guide: ws-cli-guide.md
+    - Code Style: code-style.md
     - Git Provider Setup: git-provider-setup.md
     - Cross-Fork CR Internals: cr-internals.md
     - Multi-Repo Workflow: multi-repo-workflow.md
   - Guardian Driven Development:
     - Overview: gdd/index.md
+    - Features Tour: gdd/features.md
     - Roles and Modes: gdd/roles-and-modes.md
     - The Thalamus: gdd/thalamus.md
+    - Realms: gdd/realms.md
+    - Hoards: gdd/hoards.md
     - Trust and Safety: gdd/trust-and-safety.md
+    - Access: gdd/access.md
+    - Permissions: gdd/permissions.md
     - Self-Improving Loop: gdd/self-improving-loop.md
     - Samples:
       - gdd/samples/index.md


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @Cervator via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

- Wires six existing pages into the `mkdocs.yml` left-side nav that were
  shipped to `docs/` but never linked: `code-style.md`, `ide-setup.md` under
  Yggdrasil; `features.md`, `hoards.md`, `access.md`, `permissions.md`
  under Guardian Driven Development.
- Adds a new `docs/gdd/realms.md` page parallel to (but leaner than) the
  existing Hoards page — covers what a realm is, what's in it, the
  three-layer config merge, the `ws realm` commands, trust level,
  switching, and the multi-realm chain future direction. Defers
  realm-creation walkthrough to Getting Started.
- Trims two overlong blocks in `docs/gdd/hoards.md` without losing
  meaning: the `.ws-cadence.yaml` migration note (PR #49 transitional)
  and the "future scope filters" note. Saves ~16 lines.

## Test plan

- [ ] `mkdocs serve` from the workspace root and confirm the left-side nav
      shows: IDE Setup + Code Style under Yggdrasil; Features Tour, Realms,
      Hoards, Access, Permissions under Guardian Driven Development.
- [ ] Open the new Realms page and verify cross-links resolve (Hoards,
      Features Tour, Ecosystem Architecture, Getting Started, Trust and
      Safety, the realms-and-hoards design plan).
- [ ] Open Hoards and confirm the trimmed migration + scope-filter
      paragraphs still convey the migration step and the reserved
      extension point.

## Related

- Builds on [#0ffe204](https://github.com/SiliconSaga/yggdrasil/commit/0ffe204) (feature tour, hoards, access docs) and
  [#1a95e75](https://github.com/SiliconSaga/yggdrasil/commit/1a95e75) (the migration note this trims).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified hoard migration documentation with updated instructions and clarified defaults
  * Added comprehensive realms documentation covering configuration management, CLI commands, and multi-realm workflows
  * Enhanced documentation navigation with IDE Setup section and expanded Guardian Driven Development subsection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->