### PR TITLE
docs: add MCP, Adapters, Skills Reference pages; env var table; collapse nav

### DIFF
--- a/docs/gdd/adapters.md
+++ b/docs/gdd/adapters.md
@@ -42,9 +42,10 @@ ai_context:
 - **`ai_context`** — optional list of paths agents should orient
   against when working on the component, with one-line descriptions.
 
-A starter file with comments ships at
-`realm-template/adapters/example.yaml`; copy it to
-`<your-realm>/adapters/<comp>.yaml` and edit.
+A starter file with comments ships in the upstream
+[`realm-template`](realms.md) repo (cloned via `ws realm init`) at
+`adapters/example.yaml`. Copy it to your community realm at
+`realms/<your-realm>/adapters/<comp>.yaml` and edit.
 
 ---
 

--- a/docs/gdd/adapters.md
+++ b/docs/gdd/adapters.md
@@ -1,14 +1,21 @@
 # Adapters
 
-An **adapter file** declares per-component build, test, and lint
-commands so the workspace can invoke them uniformly. Adapter files
-live in the active realm at `realms/<active>/adapters/<component>.yaml`
-— it's realm-side configuration, kept out of the component repo so a
-community can wire up commands without forking upstream.
+An **adapter file** declares per-component commands the workspace
+can list and (where wired) invoke. Today, `ws test` reads
+`commands.test` to choose the test runner — adapter > auto-detection.
+Other commands (`build`, `run`, `lint`, anything you care to declare)
+are surfaced by `ws actions <component>` for human and agent
+reference; they're documentation today, not bound to dedicated `ws`
+subcommands. Adapter files live in the active realm at
+`realms/<active>/adapters/<component>.yaml` — realm-side
+configuration, kept out of the component repo so a community can wire
+up commands without forking upstream.
 
 Components without an adapter file fall back to auto-detection
-(Gradle, Make, Go, Python, npm) — adapters are optional, but they're
-the only way to override defaults or expose project-specific commands.
+(Gradle, Make, Go, Python, npm) for `ws test`. Adapters are optional;
+add one when you want to override the test runner, document
+project-specific commands, or pin a different default for your
+community.
 
 ---
 
@@ -67,13 +74,15 @@ unconfigured commands.
 
 ## When to add an adapter
 
-The fallback patterns cover the common case — a Gradle component gets
-`build` and `test` for free. Add an adapter file when:
+The auto-detect fallback covers the common case for `ws test` — a
+Gradle component gets `./gradlew test` for free. Add an adapter file
+when:
 
-- The component uses a non-default build system the workspace doesn't
+- The component uses a non-default test runner the workspace doesn't
   auto-detect.
-- You want to expose project-specific commands (e.g. `e2e`,
-  `migrate`, `bench`) under uniform names.
+- You want to document project-specific commands (e.g. `e2e`,
+  `migrate`, `bench`) so `ws actions` surfaces them for agents and
+  contributors.
 - Different communities want different defaults for the same
   component (one realm wires `test` to a quick subset, another wires
   it to the full suite).

--- a/docs/gdd/adapters.md
+++ b/docs/gdd/adapters.md
@@ -70,8 +70,9 @@ If the component has neither an adapter file nor a recognized build
 system, `ws actions` prints a hint pointing at the path you'd create
 to add one.
 
-Realm commands take precedence; auto-detection only fires for
-unconfigured commands.
+For execution (`ws test`), realm-configured `commands.test` takes
+precedence over auto-detection. `ws actions` displays both configured
+and auto-detected commands for inspection.
 
 ---
 

--- a/docs/gdd/adapters.md
+++ b/docs/gdd/adapters.md
@@ -43,9 +43,11 @@ ai_context:
   against when working on the component, with one-line descriptions.
 
 A starter file with comments ships in the upstream
-[`realm-template`](realms.md) repo (cloned via `ws realm init`) at
-`adapters/example.yaml`. Copy it to your community realm at
-`realms/<your-realm>/adapters/<comp>.yaml` and edit.
+[`realm-template`](https://github.com/SiliconSaga/realm-template) repo
+(cloned via `ws realm init`) at `adapters/example.yaml`. Copy it to
+your community realm at `realms/<your-realm>/adapters/<comp>.yaml`
+and edit. See [Realms](realms.md) for the realm-template's role in
+the workspace.
 
 ---
 

--- a/docs/gdd/adapters.md
+++ b/docs/gdd/adapters.md
@@ -1,0 +1,89 @@
+# Adapters
+
+An **adapter file** declares per-component build, test, and lint
+commands so the workspace can invoke them uniformly. Adapter files
+live in the active realm at `realms/<active>/adapters/<component>.yaml`
+— it's realm-side configuration, kept out of the component repo so a
+community can wire up commands without forking upstream.
+
+Components without an adapter file fall back to auto-detection
+(Gradle, Make, Go, Python, npm) — adapters are optional, but they're
+the only way to override defaults or expose project-specific commands.
+
+---
+
+## File shape
+
+```yaml
+# realms/<active>/adapters/<component>.yaml
+commands:
+  build: "./gradlew build"
+  test: "./gradlew test"
+  run: "./gradlew run"
+  clean: "./gradlew clean"
+
+ai_context:
+  - path: "CONTRIBUTING.md"
+    description: "Contribution guidelines and PR conventions"
+  - path: "docs/architecture.md"
+    description: "Architecture overview for AI orientation"
+```
+
+- **`commands`** — a map from action name to shell command. Keys are
+  free-form (`build`, `test`, `lint`, `serve`, anything the community
+  cares to expose). Values run from the component directory.
+- **`ai_context`** — optional list of paths agents should orient
+  against when working on the component, with one-line descriptions.
+
+A starter file with comments ships at
+`realm-template/adapters/example.yaml`; copy it to
+`<your-realm>/adapters/<comp>.yaml` and edit.
+
+---
+
+## `ws actions <component>`
+
+Inspect what's wired up for a given component:
+
+```bash
+ws actions <component>
+```
+
+The command prints two sections:
+
+- **Configured (from realm)** — commands declared in the adapter file,
+  if one exists for the component.
+- **Auto-detected** — what the workspace would fall back to if no
+  adapter file existed (e.g. `./gradlew build`, `go test ./...`).
+
+If the component has neither an adapter file nor a recognized build
+system, `ws actions` prints a hint pointing at the path you'd create
+to add one.
+
+Realm commands take precedence; auto-detection only fires for
+unconfigured commands.
+
+---
+
+## When to add an adapter
+
+The fallback patterns cover the common case — a Gradle component gets
+`build` and `test` for free. Add an adapter file when:
+
+- The component uses a non-default build system the workspace doesn't
+  auto-detect.
+- You want to expose project-specific commands (e.g. `e2e`,
+  `migrate`, `bench`) under uniform names.
+- Different communities want different defaults for the same
+  component (one realm wires `test` to a quick subset, another wires
+  it to the full suite).
+
+---
+
+## See also
+
+- [Realms](realms.md) — where adapter files live and why they're
+  realm-side configuration.
+- [Ecosystem Architecture](../ecosystem-architecture.md) — how realms
+  fit into the three-layer config merge.
+- [`ws help actions`](../ws-cli-guide.md) — CLI behavior and arguments.

--- a/docs/gdd/skills-reference.md
+++ b/docs/gdd/skills-reference.md
@@ -1,0 +1,113 @@
+# Skills Reference
+
+The yggdrasil workspace ships a set of **skills** — markdown files
+under `.agent/skills/<name>/SKILL.md` that capture how the agent
+should approach specific situations. Skills are discovered during
+[GDD orientation](self-improving-loop.md) and read as plain markdown;
+they are *not* invoked through plugin tools.
+
+This page is the catalog: what ships, grouped by purpose. For
+day-to-day use, the orchestrator skill (`gdd`) decides which other
+skills apply at any moment based on the active mode, role, and
+context.
+
+---
+
+## Modes — *how* to work
+
+Modes set the ceremony level for a session. Most sessions sit in
+exactly one mode; the active mode lives in the per-machine thalamus
+frontmatter.
+
+| Skill | Use when |
+|---|---|
+| **gdd-zen** | Deep focus on a single topic with full ceremony. Defers distractions until natural completion points. |
+| **gdd-flow** | Productive drift across several topics with responsive collaboration. Often the natural default. |
+| **gdd-quick** | Minimal-ceremony short sessions (≈15 minutes). Suggests appropriately small tasks. |
+| **gdd-autonomous** | Permission-bounded independent work — background agents, async delegation. |
+| **gdd-mentoring** | Agent explains decisions and teaches practices in context. For unfamiliar areas or learning new tools. |
+
+See [Roles and Modes](roles-and-modes.md) for the full mental model.
+
+---
+
+## Roles — *what kind* of work
+
+Roles scope the agent to a specific kind of work. A session has at
+most one role active.
+
+| Skill | Use when |
+|---|---|
+| **scribe** | Obsidian vault conventions — PARA, frontmatter, daily notes, wikilinks, inbox capture. |
+| **scribe-claudesidian** | Extension to scribe for Claudesidian-flavored vaults; loaded automatically when bound. |
+
+---
+
+## Lifecycle and orchestration
+
+Skills that handle session-level coordination — start, end, cross-cutting work.
+
+| Skill | Use when |
+|---|---|
+| **gdd** | The top-level orchestrator. Detects active mode/role and delegates to the right skills. |
+| **gdd-orientation** | Session start, or when new components are discovered. Reads thalamus, verifies trust, sets mode/role. |
+| **gdd-housekeeping** | Triage thalamus content — review observations and concerns, promote to issues/skills, prune resolved items. |
+| **gdd-review-triage** | After pushing, when CR review comments arrive (CodeRabbit, Copilot, others). Dedupes and triages. |
+| **multi-repo-orchestration** | A session touches more than one repo; deciding work-now vs defer. |
+| **topic-branch-workflow** | About to commit and push; deciding direct-to-main vs topic branch. |
+
+---
+
+## Practice skills
+
+Skills that capture *how* to do specific kinds of technical work.
+
+| Skill | Use when |
+|---|---|
+| **bdd** | Writing Gherkin scenarios, planning features, placing `.feature` files. |
+| **bdd-pytest** | Pytest-bdd runner specifics — step definitions, execution, Cucumber JSON output. |
+| **kuttl-testing** | Writing or debugging kuttl e2e tests for Kubernetes (Crossplane claims, operator-managed resources, secret-dependent checks). |
+| **writing-yggdrasil-docs** | Writing or editing any yggdrasil-ecosystem documentation, including Mermaid diagrams. |
+
+---
+
+## Workspace operations
+
+Skills tied to specific workspace operations.
+
+| Skill | Use when |
+|---|---|
+| **creating-github-issues** | Filing a deferred task or capturing work a fresh agent should be able to complete in a single repo. |
+| **permissions-management** | Adding/editing permission patterns, considering "don't ask again" offers, reviewing `.claude/settings.json` changes. |
+| **mcp-usage** | Setup offers, auth, tool-calling conventions for [MCP servers](../mcp-setup.md). |
+| **workflow-auditor** | At session wrap-up, after noticing 3+ instances of a manual workaround. |
+
+---
+
+## Where skills live
+
+```text
+.agent/skills/<name>/SKILL.md
+```
+
+Each skill has a frontmatter block (name, description) and the
+markdown body. Some skills include subdirectories with reference
+material (templates, examples, sub-skills).
+
+To read a skill: open the file. To author a new skill or change an
+existing one: edit the file. Skills are plain documentation —
+there's no "load skill" tool to invoke. The orchestrator and
+orientation skills walk this directory at session start and decide
+what's relevant to surface.
+
+---
+
+## See also
+
+- [Roles and Modes](roles-and-modes.md) — the model the mode and
+  role skills implement.
+- [Self-Improving Loop](self-improving-loop.md) — how observations
+  in the thalamus become new or revised skills over time.
+- [`AGENTS.md`](https://github.com/SiliconSaga/yggdrasil/blob/main/AGENTS.md)
+  — the workspace-root pointer that names the skills agents read at
+  orientation.

--- a/docs/gdd/skills-reference.md
+++ b/docs/gdd/skills-reference.md
@@ -3,8 +3,9 @@
 The yggdrasil workspace ships a set of **skills** — markdown files
 under `.agent/skills/<name>/SKILL.md` that capture how the agent
 should approach specific situations. Skills are discovered during
-[GDD orientation](self-improving-loop.md) and read as plain markdown;
-they are *not* invoked through plugin tools.
+GDD orientation and read as plain markdown; they are *not* invoked
+through plugin tools. See the [Self-Improving Loop](self-improving-loop.md)
+for how the catalog evolves over time.
 
 This page is the catalog: what ships, grouped by purpose. For
 day-to-day use, the orchestrator skill (`gdd`) decides which other

--- a/docs/git-provider-setup.md
+++ b/docs/git-provider-setup.md
@@ -16,9 +16,9 @@ manual `source .env` step required during normal `ws` use.
 | Variable | Purpose | Required when |
 |---|---|---|
 | `GH_TOKEN` | GitHub PAT (`gh` reads it directly) | Using GitHub remotes |
-| `GH_USER` | Your GitHub username (used for attribution) | Using GitHub remotes |
+| `GH_USER` | GitHub username — used by `ws-validate-agent-setup` for attribution; falls back to `gh api /user` if unset | Optional — convenience only |
 | `GITLAB_TOKEN` | Default GitLab PAT (`glab` fallback) | Using GitLab remotes |
-| `GITLAB_USER` | Your GitLab username | Using GitLab remotes |
+| `GITLAB_USER` | GitLab username — referenced in setup docs and example `.env` | Optional — not consumed by `ws` directly |
 | `GITLAB_HOST` | Self-hosted GitLab hostname | Self-hosted GitLab only |
 | `GITLAB_<scope>_<owner>_<role>` | Per-fork / per-group GitLab tokens | Multi-token GitLab setups (see GitLab section) |
 

--- a/docs/git-provider-setup.md
+++ b/docs/git-provider-setup.md
@@ -7,6 +7,36 @@ for `github.com` or `gitlab.com`. Self-hosted instances need a config entry
 
 ---
 
+## Env var quick reference
+
+All workspace credentials live in `.env` at the yggdrasil root
+(gitignored). The shell scripts source it automatically — there's no
+manual `source .env` step required during normal `ws` use.
+
+| Variable | Purpose | Required when |
+|---|---|---|
+| `GH_TOKEN` | GitHub PAT (`gh` reads it directly) | Using GitHub remotes |
+| `GH_USER` | Your GitHub username (used for attribution) | Using GitHub remotes |
+| `GITLAB_TOKEN` | Default GitLab PAT (`glab` fallback) | Using GitLab remotes |
+| `GITLAB_USER` | Your GitLab username | Using GitLab remotes |
+| `GITLAB_HOST` | Self-hosted GitLab hostname | Self-hosted GitLab only |
+| `GITLAB_<scope>_<owner>_<role>` | Per-fork / per-group GitLab tokens | Multi-token GitLab setups (see GitLab section) |
+
+For GitLab multi-token setups, individual env vars are mapped to URL
+prefixes via `defaults.gitTokens` in `ecosystem.yaml` (longest-prefix
+match). The script `gp_set_token_for_url` exports the right
+`GITLAB_TOKEN` for each operation. The full naming pattern and
+examples live in the [GitLab](#gitlab) section below.
+
+Verify what's currently set without changing anything:
+
+```bash
+ws gitlab-auth --status   # which token slots are set/unset
+ws diagnose <comp>        # which token covers each remote for a component
+```
+
+---
+
 ## GitHub
 
 ### Install the GitHub CLI

--- a/docs/mcp-setup.md
+++ b/docs/mcp-setup.md
@@ -1,0 +1,82 @@
+# MCP Setup
+
+[Model Context Protocol](https://modelcontextprotocol.io) servers extend
+agent sessions with additional tools and data sources. The yggdrasil
+workspace declares MCP servers in the active realm's `ecosystem.yaml`,
+and `ws mcp-setup` generates the `.mcp.json` Claude Code reads at
+startup.
+
+---
+
+## Declaring servers in the realm
+
+Add an `mcp` block to the realm's `ecosystem.yaml`:
+
+```yaml
+mcp:
+  doc: docs/mcp-servers.md   # optional pointer to per-server URLs/notes
+  servers:
+    sentry:
+      url: https://mcp.sentry.dev/mcp
+      transport: http
+    linear:
+      url: https://mcp.linear.app/mcp
+      transport: http
+```
+
+Each server entry must declare:
+
+- **`url`** — the MCP server endpoint
+- **`transport`** — the transport type (`http` is typical for MaaS-style
+  remote servers)
+
+Both are required; `ws mcp-setup` errors if either is missing rather
+than writing a `.mcp.json` Claude Code would reject.
+
+The optional `mcp.doc` field points at a realm-side reference doc
+(server descriptions, who owns each, auth caveats). The setup command
+prints the resolved path so users can find it.
+
+---
+
+## The `ws mcp-setup` and `ws mcp-status` commands
+
+```bash
+ws mcp-setup              # generate .mcp.json from realm mcp.servers
+ws mcp-setup --dry-run    # preview without touching .mcp.json
+ws mcp-status             # show currently configured servers
+```
+
+`ws mcp-setup` reads the merged ecosystem config (upstream + realm +
+local), builds `.mcp.json` at the workspace root, and prints the
+resulting server map. The write is atomic — the file is staged to a
+sibling temp file and `mv`d into place, so an interrupted run never
+leaves a truncated `.mcp.json`.
+
+`ws mcp-status` reads the existing `.mcp.json` and lists each server's
+name and URL. Useful to confirm a regeneration produced what you
+expected, or to check what an existing checkout is currently wired up
+for.
+
+---
+
+## Authenticating
+
+After `.mcp.json` exists, **restart Claude Code** so it picks up the
+new server list, then run `/mcp` inside the session to authenticate
+each server. Claude Code handles the browser OAuth flow — don't
+paste auth URLs manually.
+
+Cursor users: MaaS servers must be added to `~/.cursor/mcp.json`
+manually; the workspace's `.mcp.json` is Claude Code-shaped.
+
+---
+
+## See also
+
+- [`ws help mcp-setup`](ws-cli-guide.md) — CLI flags and behavior
+- [Ecosystem Architecture](ecosystem-architecture.md) — the
+  three-layer config merge `ws mcp-setup` reads from
+- [Realms](gdd/realms.md) — where the `mcp.servers` declaration lives
+- [`mcp-usage` skill](../.agent/skills/mcp-usage/SKILL.md) — agent
+  conventions around calling MCP tools and surfacing setup nudges

--- a/docs/mcp-setup.md
+++ b/docs/mcp-setup.md
@@ -78,5 +78,5 @@ manually; the workspace's `.mcp.json` is Claude Code-shaped.
 - [Ecosystem Architecture](ecosystem-architecture.md) — the
   three-layer config merge `ws mcp-setup` reads from
 - [Realms](gdd/realms.md) — where the `mcp.servers` declaration lives
-- [`mcp-usage` skill](../.agent/skills/mcp-usage/SKILL.md) — agent
-  conventions around calling MCP tools and surfacing setup nudges
+- [`mcp-usage` skill](gdd/skills-reference.md#workspace-operations) —
+  agent conventions around calling MCP tools and surfacing setup nudges

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,7 +21,6 @@ theme:
         name: Switch to light mode
   features:
     - navigation.sections
-    - navigation.expand
     - navigation.path
     - toc.follow
     - content.code.copy
@@ -56,14 +55,17 @@ nav:
     - WS CLI Guide: ws-cli-guide.md
     - Code Style: code-style.md
     - Git Provider Setup: git-provider-setup.md
+    - MCP Setup: mcp-setup.md
     - Cross-Fork CR Internals: cr-internals.md
     - Multi-Repo Workflow: multi-repo-workflow.md
   - Guardian Driven Development:
     - Overview: gdd/index.md
     - Features Tour: gdd/features.md
     - Roles and Modes: gdd/roles-and-modes.md
+    - Skills Reference: gdd/skills-reference.md
     - The Thalamus: gdd/thalamus.md
     - Realms: gdd/realms.md
+    - Adapters: gdd/adapters.md
     - Hoards: gdd/hoards.md
     - Trust and Safety: gdd/trust-and-safety.md
     - Access: gdd/access.md


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @Cervator via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

- Adds three new doc-site pages filling the largest "missing entirely"
  gaps from the doc-coverage audit:
  - `docs/mcp-setup.md` — realm `mcp.servers:` declaration, the
    `ws mcp-setup` / `ws mcp-status` workflow, and the `/mcp` auth
    flow. Wired in under Yggdrasil after Git Provider Setup.
  - `docs/gdd/adapters.md` — `realms/<active>/adapters/<comp>.yaml`
    file shape, `ws actions <comp>` inspector, when to add an adapter
    vs rely on auto-detection. Wired in under GDD after Realms.
  - `docs/gdd/skills-reference.md` — catalog of all 21 skills under
    `.agent/skills/`, grouped by purpose (modes, roles, lifecycle,
    practices, workspace ops). Notes that skills are plain markdown,
    not plugin tools. Wired in under GDD after Roles and Modes.
- Adds an "Env var quick reference" table near the top of
  `docs/git-provider-setup.md` — quick lookup for `GH_TOKEN`,
  `GITLAB_TOKEN`, host vars, and the multi-token GitLab naming
  pattern, with cross-links to `ws gitlab-auth --status` and
  `ws diagnose`.
- Removes `navigation.expand` from `mkdocs.yml` so the Samples
  section (currently the only expandable group) starts collapsed
  by default. All sections now collapse-and-open-on-click for
  consistency.

## Test plan

- [ ] `mkdocs serve` from the workspace root and confirm:
  - Every nav section starts collapsed (Samples included).
  - MCP Setup appears under Yggdrasil after Git Provider Setup.
  - Adapters appears under GDD after Realms.
  - Skills Reference appears under GDD after Roles and Modes.
- [ ] Open each new page and verify cross-links resolve.
- [ ] Open the Git Provider Setup page and confirm the env var table
      renders cleanly above the GitHub section.

## Related

- Follows the doc-coverage audit on PR #55 (Realms page + nav fixes).
- Skipped from the audit per user direction: Vörðu ingestion, custom
  hoard types, and component template flavors (emerging features /
  `ws help`-covered specifics).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added MCP setup guide covering server declaration, workspace MCP config generation/validation, and authentication notes
  * Documented realm adapters: placement, command precedence vs. auto-detect, fallback behavior, and included a starter adapter template
  * Added a skills reference catalog with discovery and authoring guidance
  * Added an env-var quick reference for Git provider credentials and verification commands
  * Updated site navigation to surface these new sections
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
