### PR TITLE
feat: organization-stack model + bridge slice

### DIFF
--- a/.agent/skills/gdd-housekeeping/SKILL.md
+++ b/.agent/skills/gdd-housekeeping/SKILL.md
@@ -96,7 +96,7 @@ once the PR has merged and the canonical doc is stable.
 ### Step 2.5: Walk the arcs list
 
 If the active Thalamus has a non-empty `arcs:` list, walk it before
-moving on to Step 3:
+moving on:
 
 - **Stale active arcs.** Any `active` arc whose `last_touched` is more
   than ~30 days old is a candidate to flip to `parked`. Propose the
@@ -120,7 +120,7 @@ audit so the dashboard shows the recently-closed work, then prunes.
 
 ### Step 2.6: Drain the Intake
 
-If the active thalami hoard has an `Intake.md` with a non-empty `## Items` section, walk it with the human before Step 3. Each item is pre-arc GDD work the scribe bridge handed off — staging, not a tracker. For each item, propose one of:
+If the active thalami hoard has an `Intake.md` whose `## Items` section contains at least one bullet item (`- ...`) after ignoring HTML comments and blank lines, walk it with the human before Step 3. Each item is pre-arc GDD work the scribe bridge handed off — staging, not a tracker. For each item, propose one of:
 
 - **Promote to an arc** — the item is real, scoped GDD work. Add an `arcs:` entry to the appropriate host's `*-thalamus.md` (usually this host; ask if another machine is the better home), then remove the item from `Intake.md`.
 - **Fold into an existing arc** — the item is part of work already tracked. Note it on that arc's `next` or body context, then remove it from `Intake.md`.

--- a/.agent/skills/gdd-housekeeping/SKILL.md
+++ b/.agent/skills/gdd-housekeeping/SKILL.md
@@ -118,6 +118,17 @@ For arcs promoted to issues, the body content should already be
 gone (it lives in the issue now); the `arcs:` entry survives one more
 audit so the dashboard shows the recently-closed work, then prunes.
 
+### Step 2.6: Drain the Intake
+
+If the active thalami hoard has an `Intake.md` with a non-empty `## Items` section, walk it with the human before Step 3. Each item is pre-arc GDD work the scribe bridge handed off — staging, not a tracker. For each item, propose one of:
+
+- **Promote to an arc** — the item is real, scoped GDD work. Add an `arcs:` entry to the appropriate host's `*-thalamus.md` (usually this host; ask if another machine is the better home), then remove the item from `Intake.md`.
+- **Fold into an existing arc** — the item is part of work already tracked. Note it on that arc's `next` or body context, then remove it from `Intake.md`.
+- **Route without an arc** — the item is a one-off (a quick fix, a doc tweak) that does not justify an arc. Do it now or note it where it belongs, then remove it from `Intake.md`.
+- **Leave** — not yet actionable; keep it in `Intake.md` for the next pass.
+
+`Intake.md` is meant to stay short. If it keeps growing audit-over-audit, the GDD ceremony is not draining often enough — surface that to the human as a process observation.
+
 ### Step 3: Check for Pattern Accumulation
 
 After reviewing individual items, look across them:

--- a/.agent/skills/gdd-orientation/SKILL.md
+++ b/.agent/skills/gdd-orientation/SKILL.md
@@ -520,11 +520,11 @@ If `arcs:` is empty or absent (e.g. hoard predates the arc layer), skip this sub
 
 #### Unclaimed intake items (when a thalami hoard is active)
 
-The thalami hoard may carry an `Intake.md` at its root — machine-agnostic staging for pre-arc GDD work the scribe bridge has handed off. At session framing, if `Intake.md` exists and its `## Items` section is non-empty, surface a one-liner:
+The thalami hoard may carry an `Intake.md` at its root — machine-agnostic staging for pre-arc GDD work the scribe bridge has handed off. At session framing, if `Intake.md` exists and its `## Items` section contains at least one bullet item (`- ...`) after ignoring HTML comments and blank lines, surface a one-liner:
 
 > "3 unclaimed items in the thalami Intake. Drain them into arcs as part of this session, or leave for housekeeping?"
 
-This is advisory, not a gate. Draining the Intake is the GDD housekeeping skill's job (see @gdd-housekeeping Step 2.6); orientation only makes the items visible so they are not forgotten. If `Intake.md` is absent or its `## Items` section is empty, stay silent — no "intake is empty" noise.
+This is advisory, not a gate. Draining the Intake is the GDD housekeeping skill's job (see @gdd-housekeeping Step 2.6); orientation only makes the items visible so they are not forgotten. If `Intake.md` is absent or has no bullet items in `## Items`, stay silent — no "intake is empty" noise.
 
 ## During-Session Writes
 

--- a/.agent/skills/gdd-orientation/SKILL.md
+++ b/.agent/skills/gdd-orientation/SKILL.md
@@ -518,6 +518,14 @@ If the user agrees to pick it up, propose adding the same slug to *this* host's 
 
 If `arcs:` is empty or absent (e.g. hoard predates the arc layer), skip this subsection silently. No nudge to populate it — that's a housekeeping concern.
 
+#### Unclaimed intake items (when a thalami hoard is active)
+
+The thalami hoard may carry an `Intake.md` at its root — machine-agnostic staging for pre-arc GDD work the scribe bridge has handed off. At session framing, if `Intake.md` exists and its `## Items` section is non-empty, surface a one-liner:
+
+> "3 unclaimed items in the thalami Intake. Drain them into arcs as part of this session, or leave for housekeeping?"
+
+This is advisory, not a gate. Draining the Intake is the GDD housekeeping skill's job (see @gdd-housekeeping Step 2.6); orientation only makes the items visible so they are not forgotten. If `Intake.md` is absent or its `## Items` section is empty, stay silent — no "intake is empty" noise.
+
 ## During-Session Writes
 
 The orientation skill also governs when to write to Thalamus during work:

--- a/.agent/skills/scribe/SKILL.md
+++ b/.agent/skills/scribe/SKILL.md
@@ -309,6 +309,32 @@ On the monthly review, in addition to the template's prompts: review projects th
 
 `WaitingRoom.md` (a second dashboard at the vault root, alongside `Dashboard.md`) lists every `waiting`-status project. During any ceremony, call out `waiting` items older than 30 days — *"still waiting on X?"* — and propose either a concrete follow-up or a status flip back to `active`/`next`. Because `waiting` never decays automatically, this poke is the only thing keeping blocked work from rotting silently.
 
+## The GDD Bridge
+
+GDD-bound work captured in the vault — anything tagged `#gdd` in a daily note — does not belong in the vault long-term. It belongs in GDD-land: a per-machine Thalamus, and ultimately an arc. The **bridge** is the scribe ceremony's hand-off of those items into the thalami hoard's `Intake.md`, a machine-agnostic staging file the GDD ceremony later drains.
+
+The scribe skill only *moves items across* the bridge — it never decides whether something becomes an arc. That judgment belongs to the GDD ceremony (orientation surfaces the Intake; housekeeping drains it). See @gdd-housekeeping Step 2.6.
+
+### When the bridge fires
+
+During the daily review, inbox processing, or a weekly sweep, watch for daily-note bullets tagged `#gdd`. For each one, propose moving it to the active thalami hoard's `Intake.md`:
+
+> "`Test the updated GDD hook on the Nvidia laptop` is tagged `#gdd` — move it to the thalami-hoard Intake so the GDD ceremony can route it?"
+
+This is propose-then-confirm like every other ceremony move — never shift an item silently.
+
+### Locating and creating Intake.md
+
+`Intake.md` lives at the root of the active thalami hoard, beside `ArcDashboard.md` — the same directory as the per-machine `*-thalamus.md` files. Resolve the hoard with `ws hoard thalamus-path` and take the sibling `Intake.md`. If no thalami hoard is active, tell the user the bridge has nowhere to go and leave the item in the daily note. If the hoard is active but `Intake.md` does not exist yet, create it from the `templates/hoards/thalami/Intake.md` shape before adding the first item.
+
+### Applying a move
+
+When the user confirms, append a bullet to the `## Items` section of `Intake.md`:
+
+`- <item text> (from: <host or vault>, captured: YYYY-MM-DD)`
+
+Then check off or remove the originating daily-note bullet per the vault's normal task convention. The thalami hoard is a separate git repo — the move commits with the hoard's normal commit cadence (see @gdd-orientation Step 0a), not a forced commit.
+
 ## De-AI-ifying Text
 
 When the user says *"de-AI-ify this"*, *"strip the AI tells from

--- a/docs/gdd/features.md
+++ b/docs/gdd/features.md
@@ -272,6 +272,18 @@ See [self-improving-loop.md](self-improving-loop.md).
 
 ---
 
+## The organization stack — capture to durable knowledge
+
+Work in this ecosystem moves through four tiers: the **Vault** (a personal Obsidian hoard for life organization), the **Thalami** hoard (the Thalamus and in-flight arcs), component **Docs**, and **GitHub** (issues, PRs, the companion Project board). The *organization stack* is the model that names these tiers and the promotion paths between them, so nothing captured gets lost in a seam.
+
+Two propose-then-confirm ceremonies move items across the tiers. The **scribe ceremony** triages the vault and hands GDD-bound items to a machine-agnostic `Intake.md` — the *bridge*. The **GDD ceremony** drains that intake into arcs, and graduates a closing arc's lasting value out to component docs and GitHub. A cadence ladder (daily / weekly / monthly) keeps each tier reviewed.
+
+The model is adopt-as-you-grow: the Vault and scribe ceremony are a complete system on their own; the Thalami bridge, then the Docs and GitHub seams, layer on when the work calls for them.
+
+Full reference: [organization-stack.md](organization-stack.md). Design and rationale: [the design doc](../plans/2026-05-19-organization-stack-design.md).
+
+---
+
 ## Next steps
 
 - Brand new? [Getting Started](../getting-started/index.md) walks

--- a/docs/gdd/index.md
+++ b/docs/gdd/index.md
@@ -87,6 +87,7 @@ The last entry relates to the original more amusing "Dad-Driven-Development" nam
 - [Agent Training](agent-training.md) — the PreToolUse hook, the "scary red" deny output new users see early in a session, why one-action-per-call doesn't double API cost
 - [Access](access.md) — identities, tokens, and remote Git operations (the companion to Permissions)
 - [The Self-Improving Loop](self-improving-loop.md) — how the framework evolves through use
+- [Organization Stack](organization-stack.md) — four-tier capture model (Vault → Thalami → Docs → GitHub), the scribe and GDD ceremonies, and the Intake bridge
 
 **Design archive:**
 

--- a/docs/gdd/organization-stack.md
+++ b/docs/gdd/organization-stack.md
@@ -8,12 +8,14 @@ The stack is read as audience/purpose tiers, not a simple durability ladder. Dur
 
 | Tier | Artifact(s) | Audience / purpose | Horizon |
 |------|-------------|--------------------|---------|
-| **Vault** (`borgr`) | daily notes, project notes, area notes | You — and your agent during the scribe ceremony. Life organization, every topic: personal, GDD, work | daily: hours; project: weeks–months; area: permanent |
+| **Vault** | daily notes, project notes, area notes | You — and your agent during the scribe ceremony. Life organization, every topic: personal, GDD, work | daily: hours; project: weeks–months; area: permanent |
 | **Thalami** (the thalami hoard) | per-machine `*-thalamus.md` (observations + arcs), `Intake.md`, `ArcDashboard.md` | You + your agents. GDD working memory, in-flight work | weeks–months, pruned in housekeeping |
 | **Docs** (`<component>/docs/`) | repo README + docs index + topic files | Anyone reading the repo. Durable reference knowledge | permanent, versioned |
 | **GitHub** | issues, PRs, the companion Project board | Collaborators / public. Trackable, durable, dynamic work | long-lived, edited live |
 
 Both the Vault and the Thalami hoard are already git-synced across machines — neither tier is machine-specific. The distinction between them is audience: the Vault is human-facing life organization; the Thalami hoard is agent-facing GDD working memory.
+
+Any Obsidian hoard scaffolded from the `obsidian-vault` template (`ws hoard init obsidian-vault`) plays the Vault role. Examples below name **`borgr`** — the maintainer's personal vault — as the concrete instance; the model works the same with any vault produced by the template, under any name.
 
 ## The two ceremonies
 

--- a/docs/gdd/organization-stack.md
+++ b/docs/gdd/organization-stack.md
@@ -1,0 +1,95 @@
+# The Organization Stack
+
+Work in this ecosystem lives across several places: an Obsidian vault for daily life organization, the Thalamus and arcs for in-flight GDD work, component `docs/` directories for durable reference knowledge, and GitHub for trackable collaborative work. The **organization stack** is the model that names those four tiers and defines the promotion paths between them — so items move deliberately rather than drifting or getting lost.
+
+## The four tiers
+
+The stack is read as audience/purpose tiers, not a simple durability ladder. Durability rises roughly across the tiers but not monotonically — an Area note in the Vault is permanent, while an arc in the Thalami tier is ephemeral.
+
+| Tier | Artifact(s) | Audience / purpose | Horizon |
+|------|-------------|--------------------|---------|
+| **Vault** (`borgr`) | daily notes, project notes, area notes | You — and your agent during the scribe ceremony. Life organization, every topic: personal, GDD, work | daily: hours; project: weeks–months; area: permanent |
+| **Thalami** (the thalami hoard) | per-machine `*-thalamus.md` (observations + arcs), `Intake.md`, `ArcDashboard.md` | You + your agents. GDD working memory, in-flight work | weeks–months, pruned in housekeeping |
+| **Docs** (`<component>/docs/`) | repo README + docs index + topic files | Anyone reading the repo. Durable reference knowledge | permanent, versioned |
+| **GitHub** | issues, PRs, the companion Project board | Collaborators / public. Trackable, durable, dynamic work | long-lived, edited live |
+
+Both the Vault and the Thalami hoard are already git-synced across machines — neither tier is machine-specific. The distinction between them is audience: the Vault is human-facing life organization; the Thalami hoard is agent-facing GDD working memory.
+
+## The two ceremonies
+
+Exactly two ceremonies move items across seams. Both are propose-then-confirm — neither moves anything silently.
+
+**The scribe ceremony** (operating in `borgr`) owns Vault-internal drift and the Vault → Thalami bridge: daily-note bullets that have clarified their horizon drift to project or area notes, and daily-note `#gdd` bullets cross the bridge to `Intake.md` in the thalami hoard.
+
+**The GDD ceremony** (orientation + housekeeping) owns the Thalami tier and everything to its right: `Intake.md` items are promoted to arcs when the work justifies one, arcs graduate to Docs (durable knowledge) or GitHub (trackable work), and inbound GitHub items are surfaced for the human's consideration — an arc is never created automatically from an inbound issue.
+
+The **bridge** is the process of populating and draining `Intake.md`, not the file itself. `Intake.md` is a machine-agnostic file in the thalami hoard, sitting beside `ArcDashboard.md`. It holds pre-arc GDD work items — things lifted out of a daily note that belong in GDD-land but have not yet been shaped into an arc or assigned to a host. The scribe ceremony populates it; the GDD ceremony drains it — distributing items to the right host's `*-thalamus.md` and promoting to an arc when the work justifies one.
+
+```mermaid
+flowchart LR
+    CAP["Capture<br/>daily note / Thalamus observation"]
+    INTAKE["Intake.md<br/>thalami hoard"]
+    ARC["Arc<br/>ArcDashboard"]
+    DOCS["Component docs/"]
+    GH["GitHub issue / PR / Project"]
+    PRUNE["Pruned"]
+
+    CAP -->|scribe ceremony| INTAKE
+    INTAKE -->|GDD ceremony — promote when justified| ARC
+    ARC -->|graduate — knowledge| DOCS
+    ARC -->|graduate — trackable work| GH
+    ARC -->|process residue| PRUNE
+    GH -.->|surface inbound — human call| ARC
+```
+
+## Capture wide, route narrow
+
+There are exactly two capture surfaces, and everything funnels through one of them. Routing happens later, in a ceremony — never at capture time.
+
+- The **`borgr` daily note** is the universal capture surface. Any topic, captured the moment it occurs, with zero categorization required.
+- The **Thalamus Observations section** is the capture surface when you are already mid-GDD-session — an idea that surfaces during work is written there rather than forcing a context-switch into the vault.
+
+Routing — the "where does it go" decision — is driven by three questions:
+
+1. **Horizon** — minutes/hours → stays a daily-note task. Days–weeks → arc-candidate. Bounded multi-step outcome → project. Open-ended responsibility → area.
+2. **Audience** — just you / life → stays in the Vault. GDD agent work → `Intake.md` → Thalami. Reference others will read → Docs. Collaborative / trackable → GitHub.
+3. **Durability** — ephemeral → leave it low; it will drift or be pruned. Durable → it must eventually reach Docs or GitHub, or it is at risk.
+
+The "belongs in two places" problem dissolves: an item has one home for its current horizon and audience, and it moves as those change — it is never copied. A daily-note bullet that drifts unactioned across several days was simply mis-horizoned; the ceremony promotes it to a project, arc, or `Intake.md` rather than letting it rot in the daily note.
+
+## Graduation
+
+When an arc completes, its residue splits three ways:
+
+- **Knowledge** — how something works, why a decision was made, conceptual reference — graduates to **component `docs/`**. Durable knowledge belongs in a real docs index plus topic files, not stranded in a closed arc.
+- **Trackable work** — follow-ups, deferred items, anything others should see — graduates to **GitHub** as an issue or PR. The arc closes as `promoted` with a pointer to the GitHub item.
+- **Process residue** — the day-to-day "did X, reviewed Y" churn — is **not** graduated. It is pruned in housekeeping. That is the ephemeral tier doing its job.
+
+The `ArcDashboard` and the GitHub Project board are **companions, not redundant**: `ArcDashboard` shows in-flight private work across your machines — ephemeral, fast, pruned. The GitHub Project board shows graduated durable work — persistent, public, edited live. An arc with `status: promoted` is the hand-off marker between the two.
+
+## The cadence ladder
+
+The two ceremonies move items across seams as work happens. But the durable tier also needs periodic review — otherwise promoted issues are never looked at again. The model therefore defines a **cadence ladder**: ceremonies keyed to horizon, not only to session boundaries.
+
+| Cadence | Ceremony | Scope |
+|---------|----------|-------|
+| Per session | GDD orientation | Picks up arcs, reads the Thalamus, sets session context |
+| Daily / ad-hoc | scribe micro + daily review | Vault — daily note, project-status drift |
+| Weekly | scribe weekly synthesis **+ durable-tier sweep** | Vault weekly review **+ GitHub Project review** |
+| Monthly | scribe monthly **+ GDD housekeeping at scale** | Thalami arc audit **+ Docs freshness + GitHub board grooming** |
+
+The new element is the **durable-tier sweep** — a recurring walk of the GitHub Project board asking of each promoted issue: still relevant? stalled? needs an arc to actually move it? done and closeable? This is what keeps promoted work from rotting unseen.
+
+The weekly and monthly passes have distinct focuses: the weekly sweep is a lightweight review (what is on the board, what is stalled); the monthly pass is grooming (deeper — re-prioritizing, closing dead items, checking Docs freshness). The durable-tier sweep is a step appended to the existing scribe weekly/monthly ceremony rather than a standalone ceremony — the scribe weekly synthesis is already the "zoom out" moment, so the review attaches there instead of adding another ceremony to remember.
+
+## Start small
+
+The full stack — four tiers, two ceremonies, a cadence ladder — is the complete picture, but it is not all-or-nothing. You can adopt a subset and grow into the rest:
+
+- **Vault only.** Use `borgr` and the scribe ceremony for life organization. No Thalami bridge, no arcs, no GitHub Project. A complete, useful system on its own.
+- **+ Thalami.** Add arcs and `ArcDashboard` for in-flight GDD work; the bridge connects the daily note to `Intake.md`. Where most solo GDD users will sit.
+- **+ Docs / GitHub.** Add the graduation seams and the companion GitHub Project once work is durable or collaborative enough to warrant them.
+
+Each tier is independently useful; each seam is dormant until the tier on its far side is in use. The model degrades gracefully — a missing tier means its seam is unused, not broken, and the routing rule still works: items simply have fewer possible homes.
+
+Full design and rationale: [organization-stack design doc](../plans/2026-05-19-organization-stack-design.md).

--- a/docs/plans/2026-05-19-organization-stack-design.md
+++ b/docs/plans/2026-05-19-organization-stack-design.md
@@ -19,12 +19,14 @@ The stack is read as **audience/purpose tiers**, not a durability ladder. Durabi
 
 | Tier | Artifact(s) | Audience / purpose | Horizon |
 |------|-------------|--------------------|---------|
-| **Vault** (`borgr`) | daily notes, project notes, area notes | You — and your agent during the scribe ceremony. Life organization, every topic: personal, GDD, work | daily: hours; project: weeks–months; area: permanent |
+| **Vault** | daily notes, project notes, area notes | You — and your agent during the scribe ceremony. Life organization, every topic: personal, GDD, work | daily: hours; project: weeks–months; area: permanent |
 | **Thalami** (the thalami hoard) | per-machine `*-thalamus.md` (observations + arcs), `Intake.md`, `ArcDashboard.md` | You + your agents. GDD working memory, in-flight work | weeks–months, pruned in housekeeping |
 | **Docs** (`<component>/docs/`) | repo README + docs index + topic files | Anyone reading the repo. Durable reference knowledge | permanent, versioned |
 | **GitHub** | issues, PRs, the companion Project board | Collaborators / public. Trackable, durable, dynamic work | long-lived, edited live |
 
 Both the Vault and the Thalami hoard are already git-synced across machines — neither tier is machine-specific. The distinction between them is audience: the Vault is human-facing life organization; the Thalami hoard is agent-facing GDD working memory.
+
+Any Obsidian hoard scaffolded from the `obsidian-vault` template (`ws hoard init obsidian-vault`) plays the Vault role. In this document, examples refer to **`borgr`** — the maintainer's personal vault, kept in a private repo — as the concrete instance; the model works the same with any vault produced by the template, under any name.
 
 ## The seams and the ceremonies that own them
 

--- a/docs/plans/2026-05-19-organization-stack-design.md
+++ b/docs/plans/2026-05-19-organization-stack-design.md
@@ -1,0 +1,156 @@
+# Organization Stack — Design
+
+*Design doc — 2026-05-19. Defines the conceptual model; the facets (SP-A/B/C) and the nonclaudesidian migration carry the detailed work. See "Facet boundaries" below.*
+
+## Problem
+
+Work in this ecosystem is captured and tracked across several disconnected artifacts: an Obsidian vault (`borgr`) for daily life-organization, per-machine Thalamus files plus `ArcDashboard.md` for in-flight GDD work, component `docs/` directories for reference knowledge, and GitHub issues/PRs. Each works well alone, but the *seams* between them are undefined:
+
+- An item captured in a daily note that is really GDD work has no machine-agnostic place to go — arcs must be filed against a specific host's `*-thalamus.md`.
+- Arcs get pruned in housekeeping, so knowledge produced inside a closed arc is lost unless someone manually moves it to durable docs.
+- Issues promoted out of the Thalamus "disappear into the ether" — nothing periodically reviews them.
+- The same item can plausibly belong in two places (a personal task that is also GDD work), with no rule for resolving it.
+
+This document defines a single model — the **organization stack** — that names the artifacts, their boundaries, and the promotion paths between them. It does not implement anything; it is the frame the facet designs slot into.
+
+## The four tiers
+
+The stack is read as **audience/purpose tiers**, not a durability ladder. Durability rises roughly across the tiers but not monotonically — an Area note in the Vault is permanent, while an arc in the Thalami tier is ephemeral.
+
+| Tier | Artifact(s) | Audience / purpose | Horizon |
+|------|-------------|--------------------|---------|
+| **Vault** (`borgr`) | daily notes, project notes, area notes | You — and your agent during the scribe ceremony. Life organization, every topic: personal, GDD, work | daily: hours; project: weeks–months; area: permanent |
+| **Thalami** (the thalami hoard) | per-machine `*-thalamus.md` (observations + arcs), `Intake.md`, `ArcDashboard.md` | You + your agents. GDD working memory, in-flight work | weeks–months, pruned in housekeeping |
+| **Docs** (`<component>/docs/`) | repo README + docs index + topic files | Anyone reading the repo. Durable reference knowledge | permanent, versioned |
+| **GitHub** | issues, PRs, the companion Project board | Collaborators / public. Trackable, durable, dynamic work | long-lived, edited live |
+
+Both the Vault and the Thalami hoard are already git-synced across machines — neither tier is machine-specific. The distinction between them is audience: the Vault is human-facing life organization; the Thalami hoard is agent-facing GDD working memory.
+
+## The seams and the ceremonies that own them
+
+Exactly **two ceremonies** move items across seams. Both are propose-then-confirm — neither moves anything silently.
+
+**The scribe ceremony** (operating in `borgr`) owns Vault-internal drift and the Vault → Thalami bridge:
+
+- daily-note bullet → project / area note (intra-Vault drift, as horizon clarifies)
+- daily-note `#gdd` bullet → Thalami `Intake.md` (the bridge)
+
+**The GDD ceremony** (orientation + housekeeping) owns the Thalami tier and everything to its right:
+
+- `Intake.md` item → **arc** (promoted to an arc only when justified — not every intake item becomes an arc)
+- arc → **Docs** (durable knowledge graduates here)
+- arc → **GitHub** issue / PR / Project (trackable work graduates; the arc closes as `promoted`)
+- GitHub inbound → **surfaced for consideration** (issues/PRs needing attention are shown to the human; an arc is never created automatically from one)
+
+### The bridge
+
+The "bridge" is the *process* of populating and draining `Intake.md`, not the file itself. `Intake.md` is a machine-agnostic file in the thalami hoard, sitting beside `ArcDashboard.md`. It holds pre-arc GDD work items — things lifted out of a daily note that belong in GDD-land but have not yet been shaped into an arc or assigned to a host.
+
+The scribe ceremony populates it; the GDD ceremony drains it — distributing items to the right host's `*-thalamus.md` and promoting to an arc when the work justifies one. Because the agent runs both ceremonies, it can move items into the thalami hoard readily even though that hoard is a separate repo.
+
+```mermaid
+flowchart LR
+    CAP["Capture<br/>daily note / Thalamus observation"]
+    INTAKE["Intake.md<br/>thalami hoard"]
+    ARC["Arc<br/>ArcDashboard"]
+    DOCS["Component docs/"]
+    GH["GitHub issue / PR / Project"]
+    PRUNE["Pruned"]
+
+    CAP -->|scribe ceremony| INTAKE
+    INTAKE -->|GDD ceremony — promote when justified| ARC
+    ARC -->|graduate — knowledge| DOCS
+    ARC -->|graduate — trackable work| GH
+    ARC -->|process residue| PRUNE
+    GH -.->|surface inbound — human call| ARC
+```
+
+## Routing rule — capture wide, route narrow
+
+There are exactly two capture surfaces, and everything funnels through one of them. Routing happens later, in a ceremony — **never at capture time**.
+
+- The **`borgr` daily note** is the universal capture surface. Any topic, captured the moment it occurs, with zero categorization required.
+- The **Thalamus Observations section** is the capture surface when the user is already mid-GDD-session — an idea that surfaces during work is written there rather than forcing a context-switch into the vault.
+
+Routing — the "where does it go" decision — is driven by three questions:
+
+1. **Horizon** — minutes/hours → stays a daily-note task. Days–weeks → arc-candidate. Bounded multi-step outcome → project. Open-ended responsibility → area.
+2. **Audience** — just you / life → stays in the Vault. GDD agent work → `Intake.md` → Thalami. Reference others will read → Docs. Collaborative / trackable → GitHub.
+3. **Durability** — ephemeral → leave it low; it will drift or be pruned. Durable → it must eventually reach Docs or GitHub, or it is at risk.
+
+The "belongs in two places" problem dissolves: an item has **one** home for its current horizon and audience, and it **moves** as those change — it is never copied. A daily-note bullet that drifts unactioned across several days was simply mis-horizoned; the ceremony promotes it to a project, arc, or `Intake.md` rather than letting it rot in the daily note.
+
+## Graduation — the durable end of the stack
+
+When an arc completes, its residue splits three ways:
+
+- **Knowledge** — how something works, why a decision was made, conceptual reference — graduates to **component `docs/`**. (Worked example: HTTPS / wildcard-TLS knowledge belongs in `nidavellir/docs/`, organized as a real index plus topic files — not stranded in a closed arc or hodge-podged into one file. This is SP-C's exercise.)
+- **Trackable work** — follow-ups, deferred items, anything others should see — graduates to **GitHub** as an issue or PR. The arc closes as `promoted` with a pointer to the GitHub item.
+- **Process residue** — the day-to-day "did X, reviewed Y" churn — is **not** graduated. It is pruned in housekeeping. That is the ephemeral tier doing its job.
+
+The `ArcDashboard` and the GitHub Project board are **companions, not redundant**:
+
+- `ArcDashboard` shows in-flight private work across the user's machines — ephemeral, fast, pruned.
+- The GitHub Project board shows graduated durable work — persistent, public, edited live.
+
+An arc with `status: promoted` is the hand-off marker between the two. The GitHub Project board is what SP-B designs.
+
+## The cadence ladder
+
+The two ceremonies above move items across seams *as work happens*. But the durable tier also needs periodic *review* — otherwise promoted issues are never looked at again. The model therefore defines a **cadence ladder**: ceremonies keyed to horizon, not only to session boundaries.
+
+| Cadence | Ceremony | Scope |
+|---------|----------|-------|
+| Per session | GDD orientation | Picks up arcs, reads the Thalamus, sets session context |
+| Daily / ad-hoc | scribe micro + daily review | Vault — daily note, project-status drift |
+| Weekly | scribe weekly synthesis **+ durable-tier sweep** | Vault weekly review **+ GitHub Project review** |
+| Monthly | scribe monthly **+ GDD housekeeping at scale** | Thalami arc audit **+ Docs freshness + GitHub board grooming** |
+
+The new element is the **durable-tier sweep** — a recurring walk of the GitHub Project board asking of each promoted issue: *still relevant? stalled? needs an arc to actually move it? done and closeable?* This is what keeps promoted work from rotting unseen.
+
+The weekly and monthly passes have **distinct focuses**: the weekly sweep is a lightweight *review* (what is on the board, what is stalled); the monthly pass is *grooming* (deeper — re-prioritizing, closing dead items, checking Docs freshness).
+
+The durable-tier sweep is a **step appended to the existing scribe weekly/monthly ceremony** rather than a standalone ceremony — the scribe weekly synthesis is already the user's "zoom out" moment, so the review attaches there instead of adding another ceremony to remember.
+
+## Incremental adoption
+
+The full stack — four tiers, two ceremonies, a cadence ladder — is the complete picture, but it must not be all-or-nothing. A newcomer (and the GDD tutorial deliberately starts gentle) should be able to adopt a subset and grow into the rest:
+
+- **Vault only.** Use `borgr` and the scribe ceremony for life organization. No Thalami bridge, no arcs, no GitHub Project. A complete, useful system on its own.
+- **+ Thalami.** Add arcs and `ArcDashboard` for in-flight GDD work; the bridge connects the daily note to `Intake.md`. Where most solo GDD users will sit.
+- **+ Docs / GitHub.** Add the graduation seams and the companion GitHub Project once work is durable or collaborative enough to warrant them.
+
+Each tier is independently useful; each seam is dormant until the tier on its far side is in use. The model degrades gracefully — a missing tier means its seam is unused, not broken, and the routing rule still works: items simply have fewer possible homes.
+
+## Documentation
+
+When the model is implemented it must be discoverable, not merely present:
+
+- A section in `docs/gdd/features.md` (the GDD Features Tour) introducing the organization stack as a named feature, in the same style as the existing Thalamus and self-improving-loop sections.
+- A dedicated `docs/gdd/` reference page (e.g. `organization-stack.md`) carrying the full user-facing explanation, linked from the features.md section — mirroring how `features.md` links out to `thalamus.md`, `hoards.md`, and `self-improving-loop.md`.
+
+These are implementation deliverables tracked in the plan, not separate facets.
+
+## Model-level vocabulary calls
+
+The model fixes the following distinctions. The *detail* behind each is deferred to a facet or to the migration.
+
+- **Area vs. tag.** An **area** is a hierarchical container — a note with one home in a tree (e.g. Household → Family → Graciela). A **tag** is a cross-cutting facet that ignores the tree (e.g. `#medical` spanning multiple children and areas; `#gdd` spanning Vault and GDD work). One item has **exactly one area** (its home) and **any number of tags**. The actual area tree and tag vocabulary are deferred to the nonclaudesidian migration.
+- **`Intake.md`.** The bridge file is machine-agnostic, lives in the thalami hoard beside `ArcDashboard.md`, and holds pre-arc GDD work items. "Bridge" names the populating/draining *process*, not the file.
+- **Project vs. arc.** A project (Vault) is a container that can span **multiple arcs** (Thalami) over its life. One project, many arcs. The internal structure question — "active projects stay flat, archive gets subfolders by area" — is a Vault-internal matter deferred to SP-C / the migration; it is not a model call.
+- **Tier naming.** This document uses "tier" generically for the four organization-stack tiers and names them (Vault / Thalami / Docs / GitHub) rather than numbering them, to avoid collision with the platform **Tier** (1/2/3) and bootstrap **Layer** (L2/L3) terminology defined in the writing-yggdrasil-docs skill.
+
+## Facet boundaries
+
+This model is deliberately thin. The detailed work lives in separate specs, each brainstormed and planned on its own:
+
+- **SP-A — ArcDashboard QoL upgrade.** Impact/Urgency columns ("Eisenhower-lite"), the `review` status schema gap, the arc → Obsidian-project `priority` collapse. (A refined sketch already exists in the Dionysus thalamus, dated 2026-05-19.)
+- **SP-B — Companion GitHub Project.** The board structure, columns, what the durable-tier sweep walks, how `promoted` arcs land as cards, inbound-item surfacing.
+- **SP-C — Component docs convention.** The `docs/<component>/` standard — repo README + docs index + topic files, cross-linking from the ecosystem, GitHub Pages presentation. The nidavellir docs cleanup is its worked example.
+- **nonclaudesidian migration.** The Vault-internal area tree and tag taxonomy, plus the active-flat / archive-by-area project structure.
+
+## Open questions
+
+- **Intake-file lifecycle detail.** How long may an item sit in `Intake.md` before the GDD ceremony nudges it? Does it have lightweight per-item frontmatter (captured date, source host) or is it a plain list? Likely settled when SP-B or the GDD-ceremony skill update is specified.
+- **Work vs. personal capture.** The model routes everything through the `borgr` daily note, including work items. This is fine today (one work machine, the Nvidia laptop), but if work organization grows its own surface, the capture-wide rule may need a second universal surface. Deferred until there is evidence of need.
+- **Ceremony skill updates.** Implementing this model means touching the scribe skill (bridge population, durable-tier sweep) and the gdd-orientation / gdd-housekeeping skills (intake drain, graduation, cadence ladder). The sequencing of those edits is an implementation-plan concern, not a model one.

--- a/docs/plans/2026-05-19-organization-stack-plan.md
+++ b/docs/plans/2026-05-19-organization-stack-plan.md
@@ -1,0 +1,370 @@
+# Organization Stack — Bridge Slice Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the independently-shippable "bridge slice" of the organization-stack model — the machine-agnostic `Intake.md` staging file plus the scribe/GDD skill updates that populate and drain it, and the user-facing documentation.
+
+**Architecture:** No code or scripts. The work is one new template file, three skill-prose edits, and two documentation files, all in the `yggdrasil` repo. The skills resolve `Intake.md` as a sibling of the per-machine thalamus file (root of the active thalami hoard) — no new `ws` subcommand. The scribe ceremony populates `Intake.md` from `#gdd`-tagged daily-note bullets; GDD orientation surfaces it; GDD housekeeping drains it into arcs.
+
+**Tech Stack:** Markdown. Workspace conventions: `ws commit` with `.commits/` bodyfiles; `ws test yggdrasil` (bats) for the test suite.
+
+**Scope boundary:** This plan covers only the bridge slice. The durable-tier sweep rides with SP-B (companion GitHub Project); the graduation-to-Docs seam rides with SP-C (component docs convention). See `docs/plans/2026-05-19-organization-stack-design.md` for the full model.
+
+**Branch:** All commits go on the existing `docs/organization-stack-design` branch (already carries the design-doc commit `ed3e6a7`).
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `templates/hoards/thalami/Intake.md` | Create | Template for the machine-agnostic intake file; new thalami hoards get it |
+| `templates/hoards/thalami/README.md` | Modify | Document `Intake.md` alongside the existing ArcDashboard section |
+| `.agent/skills/scribe/SKILL.md` | Modify | Add "The GDD Bridge" section — populate `Intake.md` from `#gdd` daily-note bullets |
+| `.agent/skills/gdd-orientation/SKILL.md` | Modify | Surface unclaimed `Intake.md` items at session framing |
+| `.agent/skills/gdd-housekeeping/SKILL.md` | Modify | Add "Step 2.6: Drain the Intake" — promote intake items to arcs |
+| `docs/gdd/organization-stack.md` | Create | User-facing reference page for the model |
+| `docs/gdd/features.md` | Modify | Add an "Organization stack" section linking the new page |
+
+The live `Intake.md` in the user's `hoards/thalami-Cervator/` is **not** a plan task — the scribe skill creates it on demand from the template shape the first time the bridge fires (Task 2 specifies this).
+
+---
+
+## Task 1: The `Intake.md` template + thalami README
+
+**Files:**
+- Create: `templates/hoards/thalami/Intake.md`
+- Modify: `templates/hoards/thalami/README.md` (append a new section at the end of the file, after the existing "Cross-host arc dashboard" section)
+- Test: `ws test yggdrasil` (bats suite)
+
+- [ ] **Step 1: Create the `Intake.md` template**
+
+Create `templates/hoards/thalami/Intake.md` with exactly this content:
+
+```markdown
+# Intake
+
+Machine-agnostic staging for pre-arc GDD work. The scribe ceremony populates this file from `#gdd`-tagged daily-note bullets (the "bridge"); the GDD ceremony drains it — orientation surfaces unclaimed items, housekeeping promotes them to arcs when justified.
+
+This file is *staging*, not a tracker. Items here have not yet been shaped into arcs or assigned to a machine. Keep it short — a growing Intake means the GDD ceremony is not draining often enough.
+
+See the [organization-stack model](https://github.com/SiliconSaga/yggdrasil/blob/main/docs/gdd/organization-stack.md) for how the bridge fits the wider picture.
+
+## Items
+
+<!-- One bullet per pre-arc item. Optional inline metadata: (from: <host or vault>, captured: YYYY-MM-DD). Drained by GDD housekeeping Step 2.6. -->
+```
+
+- [ ] **Step 2: Document `Intake.md` in the thalami README**
+
+In `templates/hoards/thalami/README.md`, append the following section at the end of the file (after the existing "Cross-host arc dashboard" section and its setup steps):
+
+```markdown
+
+---
+
+## Intake — the GDD bridge
+
+This hoard also carries an `Intake.md` at its root: machine-agnostic staging for pre-arc GDD work. The scribe ceremony moves `#gdd`-tagged items out of a vault daily note and into this file; the GDD ceremony (orientation surfaces it, housekeeping drains it) routes each item to a machine and promotes it to an arc when the work justifies one.
+
+`Intake.md` is staging, not a tracker — it is meant to stay short. New hoards are scaffolded with it; existing hoards get one created on demand the first time the scribe bridge fires.
+```
+
+- [ ] **Step 3: Verify the test suite still passes**
+
+Run: `bash scripts/ws test yggdrasil`
+Expected: PASS — adding a template file and a README section does not affect the bats suite (which tests `ws` script behavior, not template inventory). If any test fails, investigate before continuing.
+
+- [ ] **Step 4: Commit**
+
+Create `.commits/intake-template.md`:
+
+```markdown
+---
+message: "feat(hoards): add Intake.md template to thalami hoard"
+add:
+  - templates/hoards/thalami/Intake.md
+  - templates/hoards/thalami/README.md
+---
+
+Adds the machine-agnostic Intake.md staging file to the thalami hoard template — the shared surface for the organization-stack bridge. The scribe ceremony populates it from #gdd-tagged daily-note bullets; the GDD ceremony drains it into arcs.
+
+Part of the SP-D organization-stack bridge slice; see docs/plans/2026-05-19-organization-stack-plan.md.
+```
+
+Run: `bash scripts/ws commit yggdrasil .commits/intake-template.md`
+Expected: commit created on `docs/organization-stack-design`.
+
+---
+
+## Task 2: Scribe skill — the bridge
+
+**Files:**
+- Modify: `.agent/skills/scribe/SKILL.md` (insert a new section between `## Ceremony Layers` and `## De-AI-ifying Text`)
+
+- [ ] **Step 1: Add "The GDD Bridge" section**
+
+In `.agent/skills/scribe/SKILL.md`, insert the following new section immediately after the end of the `## Ceremony Layers` section (after the "Waiting-room surface" subsection) and immediately before `## De-AI-ifying Text`:
+
+```markdown
+## The GDD Bridge
+
+GDD-bound work captured in the vault — anything tagged `#gdd` in a daily note — does not belong in the vault long-term. It belongs in GDD-land: a per-machine Thalamus, and ultimately an arc. The **bridge** is the scribe ceremony's hand-off of those items into the thalami hoard's `Intake.md`, a machine-agnostic staging file the GDD ceremony later drains.
+
+The scribe skill only *moves items across* the bridge — it never decides whether something becomes an arc. That judgment belongs to the GDD ceremony (orientation surfaces the Intake; housekeeping drains it). See @gdd-housekeeping Step 2.6.
+
+### When the bridge fires
+
+During the daily review, inbox processing, or a weekly sweep, watch for daily-note bullets tagged `#gdd`. For each one, propose moving it to the active thalami hoard's `Intake.md`:
+
+> "`Test the updated GDD hook on the Nvidia laptop` is tagged `#gdd` — move it to the thalami-hoard Intake so the GDD ceremony can route it?"
+
+This is propose-then-confirm like every other ceremony move — never shift an item silently.
+
+### Locating and creating Intake.md
+
+`Intake.md` lives at the root of the active thalami hoard, beside `ArcDashboard.md` — the same directory as the per-machine `*-thalamus.md` files. Resolve the hoard with `ws hoard thalamus-path` and take the sibling `Intake.md`. If no thalami hoard is active, tell the user the bridge has nowhere to go and leave the item in the daily note. If the hoard is active but `Intake.md` does not exist yet, create it from the `templates/hoards/thalami/Intake.md` shape before adding the first item.
+
+### Applying a move
+
+When the user confirms, append a bullet to the `## Items` section of `Intake.md`:
+
+`- <item text> (from: <host or vault>, captured: YYYY-MM-DD)`
+
+Then check off or remove the originating daily-note bullet per the vault's normal task convention. The thalami hoard is a separate git repo — the move commits with the hoard's normal commit cadence (see @gdd-orientation Step 0a), not a forced commit.
+```
+
+- [ ] **Step 2: Verify cross-references resolve**
+
+Read the inserted section back and confirm: the `@gdd-housekeeping Step 2.6` reference matches the step added in Task 4, and `@gdd-orientation Step 0a` exists in `gdd-orientation/SKILL.md` (it does — the commit-cadence step). Confirm the section sits between `## Ceremony Layers` and `## De-AI-ifying Text`.
+Expected: both references valid; section correctly placed.
+
+- [ ] **Step 3: Commit**
+
+Create `.commits/scribe-bridge.md`:
+
+```markdown
+---
+message: "feat(scribe): add the GDD bridge — populate thalami Intake.md"
+add:
+  - .agent/skills/scribe/SKILL.md
+---
+
+Adds "The GDD Bridge" section to the scribe skill: during ceremonies, #gdd-tagged daily-note bullets are proposed for the thalami hoard's Intake.md (created on demand). The scribe skill only moves items across the bridge; arc-worthiness is the GDD ceremony's call.
+
+Part of the SP-D organization-stack bridge slice.
+```
+
+Run: `bash scripts/ws commit yggdrasil .commits/scribe-bridge.md`
+Expected: commit created.
+
+---
+
+## Task 3: GDD orientation — surface unclaimed Intake items
+
+**Files:**
+- Modify: `.agent/skills/gdd-orientation/SKILL.md` (insert a subsection into Step 7, after the "Active arcs" subsection)
+
+- [ ] **Step 1: Add the "Unclaimed intake items" subsection**
+
+In `.agent/skills/gdd-orientation/SKILL.md`, Step 7 ("Session Framing") contains a subsection `#### Active arcs (when a thalami hoard is active)`. Immediately after that subsection ends (after the line about skipping the subsection when `arcs:` is empty) and before `## During-Session Writes`, insert:
+
+```markdown
+#### Unclaimed intake items (when a thalami hoard is active)
+
+The thalami hoard may carry an `Intake.md` at its root — machine-agnostic staging for pre-arc GDD work the scribe bridge has handed off. At session framing, if `Intake.md` exists and its `## Items` section is non-empty, surface a one-liner:
+
+> "3 unclaimed items in the thalami Intake. Drain them into arcs as part of this session, or leave for housekeeping?"
+
+This is advisory, not a gate. Draining the Intake is the GDD housekeeping skill's job (see @gdd-housekeeping Step 2.6); orientation only makes the items visible so they are not forgotten. If `Intake.md` is absent or its `## Items` section is empty, stay silent — no "intake is empty" noise.
+```
+
+- [ ] **Step 2: Verify placement**
+
+Read the surrounding lines back. Confirm the new subsection is inside Step 7, directly after "Active arcs", and that `## During-Session Writes` still follows. Confirm the `@gdd-housekeeping Step 2.6` reference matches Task 4.
+Expected: subsection correctly placed; reference valid.
+
+- [ ] **Step 3: Commit**
+
+Create `.commits/orientation-intake.md`:
+
+```markdown
+---
+message: "feat(gdd-orientation): surface unclaimed thalami Intake items"
+add:
+  - .agent/skills/gdd-orientation/SKILL.md
+---
+
+Adds an "Unclaimed intake items" subsection to Step 7 session framing: when the active thalami hoard's Intake.md has non-empty Items, orientation surfaces a one-line advisory. Draining stays a housekeeping job; orientation only makes pre-arc work visible.
+
+Part of the SP-D organization-stack bridge slice.
+```
+
+Run: `bash scripts/ws commit yggdrasil .commits/orientation-intake.md`
+Expected: commit created.
+
+---
+
+## Task 4: GDD housekeeping — drain the Intake
+
+**Files:**
+- Modify: `.agent/skills/gdd-housekeeping/SKILL.md` (insert a new step between `### Step 2.5: Walk the arcs list` and `### Step 3: Check for Pattern Accumulation`)
+
+- [ ] **Step 1: Add "Step 2.6: Drain the Intake"**
+
+In `.agent/skills/gdd-housekeeping/SKILL.md`, immediately after the `### Step 2.5: Walk the arcs list` section ends (after the paragraph about arcs promoted to issues) and before `### Step 3: Check for Pattern Accumulation`, insert:
+
+```markdown
+### Step 2.6: Drain the Intake
+
+If the active thalami hoard has an `Intake.md` with a non-empty `## Items` section, walk it with the human before Step 3. Each item is pre-arc GDD work the scribe bridge handed off — staging, not a tracker. For each item, propose one of:
+
+- **Promote to an arc** — the item is real, scoped GDD work. Add an `arcs:` entry to the appropriate host's `*-thalamus.md` (usually this host; ask if another machine is the better home), then remove the item from `Intake.md`.
+- **Fold into an existing arc** — the item is part of work already tracked. Note it on that arc's `next` or body context, then remove it from `Intake.md`.
+- **Route without an arc** — the item is a one-off (a quick fix, a doc tweak) that does not justify an arc. Do it now or note it where it belongs, then remove it from `Intake.md`.
+- **Leave** — not yet actionable; keep it in `Intake.md` for the next pass.
+
+`Intake.md` is meant to stay short. If it keeps growing audit-over-audit, the GDD ceremony is not draining often enough — surface that to the human as a process observation.
+```
+
+- [ ] **Step 2: Verify placement and numbering**
+
+Read the surrounding lines back. Confirm the new step is numbered `2.6`, sits between Step 2.5 and Step 3, and that no other step numbering needs to shift (Step 3 onward is unchanged).
+Expected: step correctly placed; numbering consistent.
+
+- [ ] **Step 3: Commit**
+
+Create `.commits/housekeeping-intake.md`:
+
+```markdown
+---
+message: "feat(gdd-housekeeping): add Step 2.6 — drain the thalami Intake"
+add:
+  - .agent/skills/gdd-housekeeping/SKILL.md
+---
+
+Adds Step 2.6 to the housekeeping process: walk the thalami hoard's Intake.md with the human, promoting pre-arc items to arcs, folding them into existing arcs, routing one-offs, or leaving them. Closes the GDD-ceremony end of the organization-stack bridge.
+
+Part of the SP-D organization-stack bridge slice.
+```
+
+Run: `bash scripts/ws commit yggdrasil .commits/housekeeping-intake.md`
+Expected: commit created.
+
+---
+
+## Task 5: The `organization-stack.md` reference page
+
+**Files:**
+- Create: `docs/gdd/organization-stack.md`
+
+This page is the user-facing retelling of the committed design doc. Source: `docs/plans/2026-05-19-organization-stack-design.md`. House style: match `docs/gdd/thalamus.md` and `docs/gdd/self-improving-loop.md` — explanatory prose, no implementation/meta sections. Drop the design doc's "Problem", "Open questions", "Facet boundaries", and "Documentation" sections; keep the model.
+
+- [ ] **Step 1: Create the page**
+
+Create `docs/gdd/organization-stack.md` with these sections, in order:
+
+1. **`# The Organization Stack`** + a 2-3 sentence intro: work in this ecosystem lives across an Obsidian vault, the Thalamus/arcs, component docs, and GitHub; the organization stack is the model that names those tiers and the promotion paths between them.
+2. **`## The four tiers`** — reproduce the four-tier table from the design doc's "The four tiers" section (Vault / Thalami / Docs / GitHub, with Audience/purpose and Horizon columns), plus the design doc's follow-up paragraph about both Vault and Thalami being cross-machine.
+3. **`## The two ceremonies`** — the scribe ceremony and GDD ceremony, the seams each owns, and the bridge (the process of populating/draining `Intake.md`). Reproduce the Mermaid flow diagram from the design doc's "The seams" section verbatim (it already satisfies the Mermaid rules — no `\n`, no fill colors).
+4. **`## Capture wide, route narrow`** — the two capture surfaces and the three routing questions (Horizon / Audience / Durability) from the design doc's "Routing rule" section, plus the "belongs in two places dissolves" paragraph.
+5. **`## Graduation`** — the three-way split of a closing arc's residue (knowledge → Docs, trackable work → GitHub, process residue → pruned) and the "companions, not redundant" paragraph, from the design doc's "Graduation" section.
+6. **`## The cadence ladder`** — reproduce the cadence-ladder table and the durable-tier-sweep / weekly-vs-monthly paragraphs from the design doc.
+7. **`## Start small`** — the incremental-adoption path (Vault only → + Thalami → + Docs/GitHub) from the design doc's "Incremental adoption" section.
+8. A closing line linking the full design doc: `Full design and rationale: [organization-stack design doc](../plans/2026-05-19-organization-stack-design.md).`
+
+Do not invent new content — every section is a restatement of the named design-doc section in user-facing prose. Keep prose unwrapped (one paragraph per line) per the writing-yggdrasil-docs convention.
+
+- [ ] **Step 2: Verify links and diagram**
+
+Confirm: the relative link `../plans/2026-05-19-organization-stack-design.md` resolves from `docs/gdd/`; the Mermaid block has no `\n` in labels and no `style ... fill:` lines. Read the page top to bottom for internal consistency.
+Expected: links resolve, diagram clean, no contradictions.
+
+- [ ] **Step 3: Commit**
+
+Create `.commits/organization-stack-doc.md`:
+
+```markdown
+---
+message: "docs(gdd): add organization-stack reference page"
+add:
+  - docs/gdd/organization-stack.md
+---
+
+Adds the user-facing organization-stack reference page under docs/gdd/ — the four tiers, the two ceremonies and the bridge, capture-wide/route-narrow, graduation, the cadence ladder, and the start-small adoption path. Restates the committed design doc for newcomers.
+
+Part of the SP-D organization-stack bridge slice.
+```
+
+Run: `bash scripts/ws commit yggdrasil .commits/organization-stack-doc.md`
+Expected: commit created.
+
+---
+
+## Task 6: Features tour section
+
+**Files:**
+- Modify: `docs/gdd/features.md` (insert a section before `## Next steps`)
+
+- [ ] **Step 1: Add the "Organization stack" section**
+
+In `docs/gdd/features.md`, immediately before the `## Next steps` section, insert:
+
+```markdown
+## The organization stack — capture to durable knowledge
+
+Work in this ecosystem moves through four tiers: the **Vault** (a personal Obsidian hoard for life organization), the **Thalami** hoard (the Thalamus and in-flight arcs), component **Docs**, and **GitHub** (issues, PRs, the companion Project board). The *organization stack* is the model that names these tiers and the promotion paths between them, so nothing captured gets lost in a seam.
+
+Two propose-then-confirm ceremonies move items across the tiers. The **scribe ceremony** triages the vault and hands GDD-bound items to a machine-agnostic `Intake.md` — the *bridge*. The **GDD ceremony** drains that intake into arcs, and graduates a closing arc's lasting value out to component docs and GitHub. A cadence ladder (daily / weekly / monthly) keeps each tier reviewed.
+
+The model is adopt-as-you-grow: the Vault and scribe ceremony are a complete system on their own; the Thalami bridge, then the Docs and GitHub seams, layer on when the work calls for them.
+
+Full reference: [organization-stack.md](organization-stack.md). Design and rationale: [the design doc](../plans/2026-05-19-organization-stack-design.md).
+```
+
+- [ ] **Step 2: Check the GDD docs index**
+
+Read `docs/gdd/index.md`. If it contains an enumerated list or table of the `docs/gdd/` pages, add an `organization-stack.md` entry consistent with the existing entries' format. If it has no such list, make no change.
+Expected: index updated only if it indexes the gdd pages.
+
+- [ ] **Step 3: Verify links**
+
+Confirm both links in the new features.md section resolve: `organization-stack.md` (same directory) and `../plans/2026-05-19-organization-stack-design.md`.
+Expected: links resolve.
+
+- [ ] **Step 4: Commit**
+
+Create `.commits/features-org-stack.md`:
+
+```markdown
+---
+message: "docs(gdd): add organization-stack section to the features tour"
+add:
+  - docs/gdd/features.md
+---
+
+Adds an "organization stack" section to the GDD Features Tour, introducing the four-tier model, the two ceremonies and the bridge, and the adopt-as-you-grow path. Links the organization-stack reference page and the design doc.
+
+Part of the SP-D organization-stack bridge slice.
+```
+
+If `docs/gdd/index.md` was modified in Step 2, add it to the `add:` list and mention it in the body.
+
+Run: `bash scripts/ws commit yggdrasil .commits/features-org-stack.md`
+Expected: commit created.
+
+---
+
+## After the plan
+
+All six tasks land on `docs/organization-stack-design` alongside the design-doc commit. When the user is ready, push and open a CR:
+
+- `bash scripts/ws diagnose yggdrasil` — confirm token coverage (first push of the session).
+- `bash scripts/ws push yggdrasil`
+- Draft the CR body from `templates/change.md` into `.crs/organization-stack.md`, then `bash scripts/ws cr yggdrasil "feat: organization-stack model + bridge slice" .crs/organization-stack.md`.
+
+The CR description should note it contains both the SP-D design doc (the whole model) and the bridge-slice implementation (the buildable subset), with the durable-tier sweep and Docs-graduation seam explicitly deferred to SP-B and SP-C.
+
+## Verification summary
+
+There is no automated test for prose changes. Verification per task is: cross-reference validity (skill `@`-references and relative doc links resolve), correct placement of inserted sections, and `ws test yggdrasil` green after the template change (Task 1). The functional proof is exercising the bridge in a real session — capture a `#gdd` item, run the scribe ceremony, confirm it lands in `Intake.md`, then run housekeeping and confirm it drains to an arc.

--- a/templates/hoards/thalami/Intake.md
+++ b/templates/hoards/thalami/Intake.md
@@ -1,0 +1,11 @@
+# Intake
+
+Machine-agnostic staging for pre-arc GDD work. The scribe ceremony populates this file from `#gdd`-tagged daily-note bullets (the "bridge"); the GDD ceremony drains it — orientation surfaces unclaimed items, housekeeping promotes them to arcs when justified.
+
+This file is *staging*, not a tracker. Items here have not yet been shaped into arcs or assigned to a machine. Keep it short — a growing Intake means the GDD ceremony is not draining often enough.
+
+See the [organization-stack model](https://github.com/SiliconSaga/yggdrasil/blob/main/docs/gdd/organization-stack.md) for how the bridge fits the wider picture.
+
+## Items
+
+<!-- One bullet per pre-arc item. Optional inline metadata: (from: <host or vault>, captured: YYYY-MM-DD). Drained by GDD housekeeping Step 2.6. -->

--- a/templates/hoards/thalami/README.md
+++ b/templates/hoards/thalami/README.md
@@ -54,3 +54,11 @@ This hoard ships an `ArcDashboard.md` that renders an at-a-glance table of in-fl
 4. **Open `ArcDashboard.md`.** The query blocks render as live tables.
 
 Obsidian creates a `.obsidian/` directory the first time you open the vault; that's gitignored by default since it's a per-machine UI preference store, not shared state.
+
+---
+
+## Intake — the GDD bridge
+
+This hoard also carries an `Intake.md` at its root: machine-agnostic staging for pre-arc GDD work. The scribe ceremony moves `#gdd`-tagged items out of a vault daily note and into this file; the GDD ceremony (orientation surfaces it, housekeeping drains it) routes each item to a machine and promotes it to an arc when the work justifies one.
+
+`Intake.md` is staging, not a tracker — it is meant to stay short. New hoards are scaffolded with it; existing hoards get one created on demand the first time the scribe bridge fires.

--- a/templates/hoards/thalami/README.md
+++ b/templates/hoards/thalami/README.md
@@ -9,6 +9,8 @@ thalami/                    # default name (ws hoard init thalami).
                             # Override with --name; legacy `thalami-<username>`
                             # form still supported for existing hoards.
   README.md
+  ArcDashboard.md           # cross-host in-flight arcs (Dataview-rendered)
+  Intake.md                 # machine-agnostic pre-arc GDD staging (the bridge)
   <machine>-thalamus.md     # one per machine; e.g. win10-desktop-thalamus.md
   <machine>-thalamus.md
   ...


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @Cervator via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

This CR introduces the **organization stack** — a model for how work flows across four tiers (the `borgr` Obsidian vault (Cervator's personal vault based on the `obsidian-vault` template shipped with GDD - ask your agent for your own!), the Thalami hoard / arcs, component `docs/`, and GitHub) — together with the first independently-shippable slice of it.

- **Design doc** (`docs/plans/2026-05-19-organization-stack-design.md`) — the SP-D model: the four tiers, the two propose-then-confirm ceremonies and the seams they own, the capture-wide/route-narrow rule, arc graduation, the cadence ladder, and incremental adoption. Detailed facet work (SP-A ArcDashboard columns, SP-B companion GitHub Project, SP-C component docs convention) is explicitly deferred.
- **Implementation plan** (`docs/plans/2026-05-19-organization-stack-plan.md`) — the six-task bridge-slice plan.
- **The bridge slice itself:**
  - New `templates/hoards/thalami/Intake.md` — a machine-agnostic staging file for pre-arc GDD work — plus its thalami-README section.
  - `scribe` skill — a new "The GDD Bridge" section: `#gdd`-tagged daily-note bullets are proposed for `Intake.md`.
  - `gdd-orientation` skill — surfaces unclaimed `Intake.md` items at session framing.
  - `gdd-housekeeping` skill — new Step 2.6 drains `Intake.md` into arcs.
  - New `docs/gdd/organization-stack.md` reference page + a GDD Features Tour section + index entry.

The durable-tier sweep and the arc-to-docs graduation seam are out of scope here — they ride with the SP-B and SP-C facets.

## Test plan

- [ ] `ws test yggdrasil` — bats suite green (140/140; no scripts changed).
- [ ] Cross-references resolve: `@gdd-housekeeping Step 2.6` exists; `@gdd-orientation Step 0a` exists; doc links resolve.
- [ ] Functional proof (post-merge): capture a `#gdd` item, run the scribe ceremony, confirm it lands in `Intake.md`; run housekeeping, confirm it drains to an arc.

## Related

- Produced via a brainstorm → spec → plan → subagent-driven-execution session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "Intake" staging bridge to capture and propose actions for pre-arc items, and a session advisory that offers to drain unclaimed intake items into arcs.
  * Scribe now proposes moving tagged daily-note items into the intake bridge (create-if-missing).

* **Documentation**
  * New "Organization Stack" guide and linked how-to docs covering the capture→intake→arc lifecycle, cadence, and adoption guidance.
  * Updated ceremony and template guidance to keep intake lists short and process-driven.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SiliconSaga/yggdrasil/pull/66?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->