### PR TITLE
test(hook): support macOS in bats helpers and document coreutils prereq

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -13,7 +13,7 @@ The bats helpers wrap each hook / `ws` invocation in `timeout 10 …` so a regre
   brew install coreutils
   ```
 
-  After install, `gtimeout` is on PATH at `/opt/homebrew/bin/gtimeout`. The test helpers detect either `timeout` or `gtimeout`; you do not need to add the `gnubin` directory to PATH.
+  After install, `gtimeout` is on PATH wherever your Homebrew prefix puts shims (`/opt/homebrew/bin` on Apple Silicon, `/usr/local/bin` on Intel; `brew --prefix` confirms). The test helpers detect either `timeout` or `gtimeout`; you do not need to add the `gnubin` directory to PATH.
 
 If neither binary is present, every test fails immediately with a clear "install coreutils" message — no silent hangs.
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,42 @@
+# Running the workspace tests
+
+`ws test yggdrasil` runs every `*.bats` file under this directory using the
+vendored bats-core at `tests/vendor/bats-core/`. No system bats install
+needed.
+
+## Prerequisite: GNU `timeout`
+
+The bats helpers wrap each hook / `ws` invocation in `timeout 10 …` so a
+regression that hangs the upward-walk loop (or any other infinite loop)
+fails loudly instead of stalling the suite. That command is GNU
+coreutils.
+
+- **Linux / Git Bash on Windows:** ships with coreutils already — no action.
+- **macOS:** install via Homebrew. The helpers pick up the `g`-prefixed
+  binary automatically:
+
+  ```bash
+  brew install coreutils
+  ```
+
+  After install, `gtimeout` is on PATH at `/opt/homebrew/bin/gtimeout`.
+  The test helpers detect either `timeout` or `gtimeout`; you do not
+  need to add the `gnubin` directory to PATH.
+
+If neither binary is present, every test fails immediately with a
+clear "install coreutils" message — no silent hangs.
+
+## Running
+
+```bash
+ws test yggdrasil                # whole suite
+bash tests/vendor/bats-core/bin/bats tests/hook/   # one directory
+```
+
+## Interactive acceptance
+
+`tests/hook/interactive-acceptance.md` is the human-in-the-loop
+companion to the hook bats suite. The bats tests verify the hook's
+JSON output; the acceptance script verifies the human-facing
+permission prompt actually appears. Ask the agent to "run the hook
+acceptance script."

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,30 +1,21 @@
 # Running the workspace tests
 
-`ws test yggdrasil` runs every `*.bats` file under this directory using the
-vendored bats-core at `tests/vendor/bats-core/`. No system bats install
-needed.
+`ws test yggdrasil` runs every `*.bats` file under this directory using the vendored bats-core at `tests/vendor/bats-core/`. No system bats install needed.
 
 ## Prerequisite: GNU `timeout`
 
-The bats helpers wrap each hook / `ws` invocation in `timeout 10 …` so a
-regression that hangs the upward-walk loop (or any other infinite loop)
-fails loudly instead of stalling the suite. That command is GNU
-coreutils.
+The bats helpers wrap each hook / `ws` invocation in `timeout 10 …` so a regression that hangs the upward-walk loop (or any other infinite loop) fails loudly instead of stalling the suite. That command is GNU coreutils.
 
 - **Linux / Git Bash on Windows:** ships with coreutils already — no action.
-- **macOS:** install via Homebrew. The helpers pick up the `g`-prefixed
-  binary automatically:
+- **macOS:** install via Homebrew. The helpers pick up the `g`-prefixed binary automatically:
 
   ```bash
   brew install coreutils
   ```
 
-  After install, `gtimeout` is on PATH at `/opt/homebrew/bin/gtimeout`.
-  The test helpers detect either `timeout` or `gtimeout`; you do not
-  need to add the `gnubin` directory to PATH.
+  After install, `gtimeout` is on PATH at `/opt/homebrew/bin/gtimeout`. The test helpers detect either `timeout` or `gtimeout`; you do not need to add the `gnubin` directory to PATH.
 
-If neither binary is present, every test fails immediately with a
-clear "install coreutils" message — no silent hangs.
+If neither binary is present, every test fails immediately with a clear "install coreutils" message — no silent hangs.
 
 ## Running
 
@@ -35,8 +26,4 @@ bash tests/vendor/bats-core/bin/bats tests/hook/   # one directory
 
 ## Interactive acceptance
 
-`tests/hook/interactive-acceptance.md` is the human-in-the-loop
-companion to the hook bats suite. The bats tests verify the hook's
-JSON output; the acceptance script verifies the human-facing
-permission prompt actually appears. Ask the agent to "run the hook
-acceptance script."
+`tests/hook/interactive-acceptance.md` is the human-in-the-loop companion to the hook bats suite. The bats tests verify the hook's JSON output; the acceptance script verifies the human-facing permission prompt actually appears. Ask the agent to "run the hook acceptance script."

--- a/tests/hook/interactive-acceptance.md
+++ b/tests/hook/interactive-acceptance.md
@@ -16,13 +16,21 @@ bats (`gdd-permission-hook.bats`) verifies the hook's *output*. It cannot verify
 |---|---------|-----------------|
 | 1 | `rm -rf .tmp/acceptance-probe` | `ask` prompt — reason mentions the ask-list **and** carries the symlink caution |
 | 2 | `git -C .tmp/acceptance-repo reset --hard HEAD` | `ask` prompt — reason mentions the ask-list, **no** symlink caution |
-| 3 | `ls -la` | check your `hook-rules.local`: if `ls *` is present under `[allow-extras]`, expect a silent auto-allow (Tier 4) — otherwise a normal harness prompt. Either way, **not** an ask prompt |
+| 3 | `ls -la` | **not** an ask prompt. Three valid paths: Tier 4 silent auto-allow (if `ls *` is in `[allow-extras]`), normal harness prompt, or silent allow from Claude Code's session-scoped read trust if the harness has already accepted reads against the directory. The shape of the user-facing response varies; the invariant to verify is in the audit log — see "Confirmation" below. |
 | 4 | `echo hi && echo bye` | composition **deny** — blocked with the shell-composition message, NOT an ask |
 | 5 | `rm -rf .tmp/acceptance-probe-2` | `ask` prompt **still appears** despite `acceptEdits` mode — the core regression check |
 
 ## Confirmation
 
-For each step the human confirms: did the prompt appear, and did its shape match the table? Step 5 is the pass/fail gate — if it does not prompt, the ask-tier is not overriding `acceptEdits` and the fix is incomplete.
+For each step the human confirms: did the prompt appear (where one is expected), and did its shape match the table? Step 5 is the pass/fail gate — if it does not prompt, the ask-tier is not overriding `acceptEdits` and the fix is incomplete.
+
+After step 5, also skim the audit log to verify each step's *recorded* decision matches the table. This is the deterministic check that survives Claude Code's session-scoped trust (which can silently swallow step 3's prompt without involving the hook):
+
+```bash
+tail -10 ~/.claude/hook-audit.log
+```
+
+Expected entries: step 1 `ASK` with `symlinks` caution, step 2 `ASK` without it, step 3 **no entry** (passthrough is not logged) OR an `ALLOW` from `[allow-extras]`, step 4 `DENY` with the composition message, step 5 `ASK` with the `symlinks` caution. Any `ASK` against step 3's `ls -la` would be a regression — the ask-list is matching too broadly.
 
 ## Teardown
 

--- a/tests/hook/test_helper.bash
+++ b/tests/hook/test_helper.bash
@@ -14,6 +14,21 @@
 REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
 HOOK_BIN="$REPO_ROOT/.claude/hooks/gdd-permission-hook.sh"
 
+# Resolve a `timeout`-style command. GNU coreutils ships `timeout` on
+# Linux and Git Bash, but macOS only has it under the `g`-prefixed
+# Homebrew coreutils install (`gtimeout`). Tests need one or the other
+# — see tests/README.md for the install hint.
+if command -v timeout >/dev/null 2>&1; then
+    TIMEOUT_BIN="timeout"
+elif command -v gtimeout >/dev/null 2>&1; then
+    TIMEOUT_BIN="gtimeout"
+else
+    echo "ERROR: neither 'timeout' nor 'gtimeout' found on PATH." >&2
+    echo "  Install GNU coreutils — on macOS: 'brew install coreutils'." >&2
+    echo "  See tests/README.md." >&2
+    exit 1
+fi
+
 # Build an isolated workspace shape:
 #   $WORK                           — tmp project root
 #   $WORK/.claude/settings.json    — synthetic permissions.allow
@@ -84,7 +99,7 @@ run_hook_write() {
     local payload
     payload=$(jq -nc --arg t "$tool" --arg fp "$file_path" --arg cwd "$cwd" \
         '{tool_name:$t, tool_input:{file_path:$fp}, cwd:$cwd}')
-    run timeout 10 bash "$HOOK_BIN" <<< "$payload"
+    run "$TIMEOUT_BIN" 10 bash "$HOOK_BIN" <<< "$payload"
 }
 
 # Build the JSON tool-call payload and pipe it into the hook. The
@@ -106,5 +121,5 @@ run_hook() {
     # Bash herestring `<<<` feeds $payload as stdin to the hook —
     # cleaner than wrapping in `bash -c` to pipe (which also runs
     # afoul of the workspace's no-inline-shell-scripts convention).
-    run timeout 10 bash "$HOOK_BIN" <<< "$payload"
+    run "$TIMEOUT_BIN" 10 bash "$HOOK_BIN" <<< "$payload"
 }

--- a/tests/ws-smoke/test_helper.bash
+++ b/tests/ws-smoke/test_helper.bash
@@ -13,6 +13,19 @@
 REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
 WS_BIN="$REPO_ROOT/scripts/ws"
 
+# Resolve `timeout` (Linux/Git Bash) or `gtimeout` (macOS Homebrew
+# coreutils). See tests/README.md for the install hint.
+if command -v timeout >/dev/null 2>&1; then
+    TIMEOUT_BIN="timeout"
+elif command -v gtimeout >/dev/null 2>&1; then
+    TIMEOUT_BIN="gtimeout"
+else
+    echo "ERROR: neither 'timeout' nor 'gtimeout' found on PATH." >&2
+    echo "  Install GNU coreutils — on macOS: 'brew install coreutils'." >&2
+    echo "  See tests/README.md." >&2
+    exit 1
+fi
+
 init_workspace() {
     WORK="$BATS_TEST_TMPDIR/work"
     mkdir -p "$WORK/components" "$WORK/realms" "$WORK/hoards"
@@ -43,5 +56,5 @@ run_ws() {
     # infinite-loop / blocking regressions early. Read-only commands
     # should complete in milliseconds; anything approaching the
     # timeout is the regression we want to surface.
-    run timeout 10 bash "$WS_BIN" "$@"
+    run "$TIMEOUT_BIN" 10 bash "$WS_BIN" "$@"
 }


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @cervator via [GDD](https://github.com/SiliconSaga/yggdrasil).

## Summary

- Bats helpers (`tests/hook/test_helper.bash`, `tests/ws-smoke/test_helper.bash`) wrap each invocation in `timeout 10 …` to catch infinite-loop regressions. macOS doesn't ship GNU `timeout`, so on a fresh Mac the suite died with exit 127 ("Command not found") before any assertions ran. Helpers now detect `timeout` or `gtimeout` (Homebrew coreutils name) and fail with a clear install hint if neither is present.
- New `tests/README.md` documents coreutils as the macOS prereq and is referenced from the error message — no silent failures, no "tests just hang" guesswork.
- `tests/hook/interactive-acceptance.md` step 3 reframed: the original expectation table assumed two paths (Tier 4 silent allow, or normal harness prompt). Claude Code 2.x adds a third — session-scoped read trust silently allows `ls -la` against a directory the harness has already accepted reads in, with no visible prompt and no hook involvement. That looks like a regression in the live walk-through when it isn't. Step 3 now calls out the third path and the Confirmation section shifts verification to the audit log, which is deterministic regardless of which path the harness took.

## Test plan

- [x] `ws test yggdrasil` passes on macOS (140/140) after `brew install coreutils` — including the two symlink tests that skip on Windows.
- [x] Without coreutils, helpers fail fast with the documented "install GNU coreutils" message instead of exit 127.
- [x] All 5 steps of `tests/hook/interactive-acceptance.md` exercised live; audit-log entries match the updated Confirmation table (step 5's ASK fires despite `acceptEdits` mode — the regression gate).
- [ ] CI (Linux) still passes — `timeout` continues to be picked first when both are present.

## Related

- Surfaced while validating the recent hook updates on macOS after pulling latest `main`.