### PR TITLE
chore: QOL cleanup — hook-bypass prompt wording + doc framing pass

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -61,7 +61,7 @@ The Tier 2 redirect-deny channels three raw commands toward the workspace's `ws`
 A deny here is a *training* signal, not a safety floor (that's Tier 3 ask). The hook trusts the workspace's own `ws` wrappers to do the right thing — attribution, remote selection, the right token. When a legitimate edge case exists (`ws` doesn't yet support what you need), the agent can request a bypass:
 
 1. Agent hits the deny; corrective message names `ws hook-bypass <slug>` as the escape hatch.
-2. Agent runs `ws hook-bypass <slug> --reason "<why>"`. The subcommand is on the ask-list, so the human gets a permission prompt.
+2. Agent runs `ws hook-bypass <slug> --reason "<why>"`. The subcommand is on the ask-list, so the human gets a permission prompt — tailored to name the slug being bypassed and surface the `--reason`, so the human sees what they're approving rather than a generic "destructive command" line.
 3. Human approves; the script writes `.tmp/hook-bypass/<slug>.bypass` keyed to the Claude Code session id (`$CLAUDE_CODE_SESSION_ID`).
 4. Agent retries the raw command; the hook finds the marker, matches session_id, and emits an allow with audit `BYPASS-ALLOW [<slug>] reason="<text>" [PreToolUse]: <cmd>`.
 5. The marker is honored for the rest of the session. Next session's `CLAUDE_CODE_SESSION_ID` differs, so the marker is stale; `ws clean` sweeps `.tmp/` whenever you want a clean slate.

--- a/.claude/hooks/gdd-permission-hook.sh
+++ b/.claude/hooks/gdd-permission-hook.sh
@@ -757,7 +757,23 @@ for _ask in ${ask_commands[@]+"${ask_commands[@]}"}; do
                 # Strip one layer of surrounding double quotes, if present.
                 _bp_reason="${_bp_reason#\"}"
                 _bp_reason="${_bp_reason%\"}"
-                _ask_reason="Approve to grant a session-scoped bypass for the '$_bp_slug' redirect — the agent will then be able to run the otherwise-denied '$_bp_slug' command for the rest of this session (it still issues that command as a separate step). Per-slug, expires when the session ends. Reason given: ${_bp_reason:-(none)}. Decline if you'd rather it use the ws wrapper."
+                # The slug is NOT the raw command — look up the matching
+                # redirect pattern so the message names what actually gets
+                # unblocked (e.g. slug `git-commit` → `git commit*`).
+                _bp_pattern=""
+                for _bp_entry in ${redirect_commands[@]+"${redirect_commands[@]}"}; do
+                    if [[ "${_bp_entry%%|*}" == "$_bp_slug" ]]; then
+                        _bp_entry_rest="${_bp_entry#*|}"
+                        _bp_pattern="${_bp_entry_rest%%|*}"
+                        break
+                    fi
+                done
+                if [[ -n "$_bp_pattern" ]]; then
+                    _bp_target="raw commands matching \`$_bp_pattern\` (e.g. \`${_bp_pattern%\*}…\`), which the '$_bp_slug' redirect normally denies"
+                else
+                    _bp_target="the raw command behind the '$_bp_slug' redirect slug"
+                fi
+                _ask_reason="Approve to grant a session-scoped bypass of the '$_bp_slug' redirect — the agent will then be able to run $_bp_target for the rest of this session (it still issues that command as a separate step). Per-slug, expires when the session ends. Reason given: ${_bp_reason:-(none)}. Decline if you'd rather it use the ws wrapper."
                 ;;
         esac
         ask "$_ask_reason"

--- a/.claude/hooks/gdd-permission-hook.sh
+++ b/.claude/hooks/gdd-permission-hook.sh
@@ -742,6 +742,23 @@ for _ask in ${ask_commands[@]+"${ask_commands[@]}"}; do
             rm|rm\ *)
                 _ask_reason="$_ask_reason Caution: symlinks here could delete outside the workspace."
                 ;;
+            "ws hook-bypass "*)
+                # Tailored message: `ws hook-bypass` is NOT destructive — it
+                # requests a session-scoped bypass of a Tier 2 redirect deny.
+                # The generic ask line misdescribes it and never names what's
+                # being bypassed, so surface the slug + the --reason instead.
+                _bp_rest="${match_cmd#ws hook-bypass }"
+                _bp_slug="${_bp_rest%% *}"
+                _bp_reason=""
+                case "$match_cmd" in
+                    *--reason=*)   _bp_reason="${match_cmd#*--reason=}" ;;
+                    *"--reason "*) _bp_reason="${match_cmd#*--reason }" ;;
+                esac
+                # Strip one layer of surrounding double quotes, if present.
+                _bp_reason="${_bp_reason#\"}"
+                _bp_reason="${_bp_reason%\"}"
+                _ask_reason="Approve to grant a session-scoped bypass for the '$_bp_slug' redirect — the agent will then be able to run the otherwise-denied '$_bp_slug' command for the rest of this session (it still issues that command as a separate step). Per-slug, expires when the session ends. Reason given: ${_bp_reason:-(none)}. Decline if you'd rather it use the ws wrapper."
+                ;;
         esac
         ask "$_ask_reason"
     fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,7 +101,7 @@ Superpowers — only the `superpowers:*` plugin skills are unavailable.
 | **Multi-Repo Orchestration** | Session start/end discipline when a session touches more than one repo, TODO triage | [SKILL.md](./.agent/skills/multi-repo-orchestration/SKILL.md) |
 | **Topic Branch Workflow** | Branch naming, commit/push workflow, utility scripts, and when direct push to main is acceptable | [SKILL.md](./.agent/skills/topic-branch-workflow/SKILL.md) |
 | **Workflow Auditor** | Detect repeated manual workarounds (3+ instances) and propose utility scripts or ws subcommands | [SKILL.md](./.agent/skills/workflow-auditor/SKILL.md) |
-| **Writing Yggdrasil Docs** | Conventions for documentation, Mermaid diagram rules, terminology, and cluster layer naming | [SKILL.md](./.agent/skills/writing-yggdrasil-docs/SKILL.md) |
+| **Writing Yggdrasil Docs** | Documentation conventions: the Component Documentation Convention (four-Shape graduation ladder), no-hard-wrap rule, Mermaid diagram rules, terminology, and cluster layer naming | [SKILL.md](./.agent/skills/writing-yggdrasil-docs/SKILL.md) |
 | **MCP Usage** | Agent behaviour when MCP servers are present — auth patterns, tool calling, realm deferral | [SKILL.md](./.agent/skills/mcp-usage/SKILL.md) |
 
 ---

--- a/README.md
+++ b/README.md
@@ -8,16 +8,16 @@
 
 ## Start here
 
-- **[`AGENTS.md`](AGENTS.md)** — the canonical workspace guide for humans and AI agents: session startup, the `ws` CLI, skills, git workflow, auth, conventions. Read this first.
-- **[`docs/gdd/`](docs/gdd/index.md)** — the methodology: roles and modes, the Thalamus, trust & safety, permissions, and the agent-training companion to the PreToolUse hook.
-- **The `ws` CLI** — the shared interface for both humans and agents. Run `bash scripts/ws help` (or `ws help` once `scripts/` is on your PATH).
+- **New here (human)?** The human-facing docs live in [`docs/gdd/`](docs/gdd/index.md): start with the [features tour](docs/gdd/features.md) — what's in the box — and the [GDD index](docs/gdd/index.md) for the methodology behind it.
+- **Driving a session?** [`AGENTS.md`](AGENTS.md) is the operational guide — session startup, the `ws` CLI, skills, git workflow, auth. It's written *for agents* (terse and optimized for them, not prose for humans), but it's the reference when you need workspace mechanics.
+- **The `ws` CLI** is the shared interface for both humans and agents. Run `bash scripts/ws help` (or `ws help` once `scripts/` is on your PATH).
 
 ## What lives here
 
 - **`ecosystem.yaml`** — the manifest declaring components and their tiers, three-layer-merged with an active realm and a per-developer `ecosystem.local.yaml`.
 - **`scripts/ws`** — the unified CLI: clone, status, commit, push, cr, review, test, plus realm / hoard / component management.
-- **`.agent/skills/`** — workspace skills (GDD orchestration, orientation, housekeeping, the documentation conventions, and more). They are plain-markdown files read directly; some practice flows also lean on the optional [Obra Superpowers](https://github.com/obra/superpowers) plugin.
-- **`docs/`** — ecosystem architecture, the GDD methodology, and design / plan docs. Documentation follows the **Component Documentation Convention** — a four-Shape graduation ladder (loose root Markdown → structured `/docs` → themed site → custom) defined in the [`writing-yggdrasil-docs`](.agent/skills/writing-yggdrasil-docs/SKILL.md) skill.
+- **`.agent/skills/`** — agent-facing workspace skills (GDD orchestration, orientation, housekeeping, the documentation conventions, and more). These are operational guidance the agent reads directly, not human reading material — humans get the higher-level concepts from `docs/`. Some practice flows also lean on the optional [Obra Superpowers](https://github.com/obra/superpowers) plugin.
+- **`docs/`** — ecosystem architecture, the GDD methodology, and design / plan docs. Component docs follow the **Component Documentation Convention** — a four-Shape graduation ladder, described human-side in [the organization stack](docs/gdd/organization-stack.md); the operational rules for agents writing docs live in the `writing-yggdrasil-docs` skill.
 - **Components / realms / hoards** — cloned under `components/`, `realms/`, `hoards/` (all gitignored, independent Git repos). A VS Code workspace file is generated on demand via `ws vscode`; it is not committed.
 
 ## AI usage

--- a/README.md
+++ b/README.md
@@ -1,33 +1,38 @@
 # Yggdrasil
 
-*The World Tree — The Meta-Workspace*
+*The World Tree — GDD's Meta-Workspace*
 
 > "An immense mythical tree that connects the nine worlds in Norse cosmology."
 
-**Yggdrasil** is the **Root Workspace** / wrapper for the entire ecosystem. It holds the VS Code workspace file, the high-level "Project Constellation" map, workflow strategies that bind the other projects together, and so on
+**Yggdrasil** is the meta-workspace where [Guardian Driven Development (GDD)](docs/gdd/index.md) lives. It isn't just a wrapper around the ecosystem's repos — it's the home of the methodology itself: the `ws` workspace CLI, the GDD skills, the shared-thinking Thalamus, the components/realms/hoards model, and the documentation, commit, and branch conventions that bind everything together. Components, realms, and hoards are what Yggdrasil *orchestrates*; GDD is what Yggdrasil *is*.
 
-## AI Usage
+## Start here
 
-This ecosystem is largely made possible by extensive AI usage, such as with Claude Code or Google's Antigravity. General AI instructions can be found in `agents.md` in this project, which can be pointed at by other agent-specific files like `CLAUDE.md` to avoid duplication. Only put agent-specific instructions in named agent files.
+- **[`AGENTS.md`](AGENTS.md)** — the canonical workspace guide for humans and AI agents: session startup, the `ws` CLI, skills, git workflow, auth, conventions. Read this first.
+- **[`docs/gdd/`](docs/gdd/index.md)** — the methodology: roles and modes, the Thalamus, trust & safety, permissions, and the agent-training companion to the PreToolUse hook.
+- **The `ws` CLI** — the shared interface for both humans and agents. Run `bash scripts/ws help` (or `ws help` once `scripts/` is on your PATH).
 
-Agent skills can be installed in various ways and custom ones added at `.agent/skills`
+## What lives here
 
-### Claude Code
+- **`ecosystem.yaml`** — the manifest declaring components and their tiers, three-layer-merged with an active realm and a per-developer `ecosystem.local.yaml`.
+- **`scripts/ws`** — the unified CLI: clone, status, commit, push, cr, review, test, plus realm / hoard / component management.
+- **`.agent/skills/`** — workspace skills (GDD orchestration, orientation, housekeeping, the documentation conventions, and more). They are plain-markdown files read directly; some practice flows also lean on the optional [Obra Superpowers](https://github.com/obra/superpowers) plugin.
+- **`docs/`** — ecosystem architecture, the GDD methodology, and design / plan docs. Documentation follows the **Component Documentation Convention** — a four-Shape graduation ladder (loose root Markdown → structured `/docs` → themed site → custom) defined in the [`writing-yggdrasil-docs`](.agent/skills/writing-yggdrasil-docs/SKILL.md) skill.
+- **Components / realms / hoards** — cloned under `components/`, `realms/`, `hoards/` (all gitignored, independent Git repos). A VS Code workspace file is generated on demand via `ws vscode`; it is not committed.
 
-* https://code.claude.com/docs/en/skills - read about skills in general and which are bundled
-* https://github.com/anthropics/skills - an additional set of official skills by Anthropic
-  * Install with `/plugin marketplace add anthropics/skills`
-  * Then `/plugin install example-skills@anthropic-agent-skills`
-* https://github.com/obra/superpowers - Obra Superpowers is a well-reputed set of additional skills
-  * Install with `/plugin marketplace add obra/superpowers-marketplace`
-  * Then `/plugin install superpowers@superpowers-marketplace`
-* Restart Claude or run `/reload-plugins` after
+## AI usage
 
-#### Shipped Claude Code hook
+This ecosystem is built with heavy AI assistance (Claude Code, among others). General agent instructions live in [`AGENTS.md`](AGENTS.md); agent-specific files like `CLAUDE.md` point at it to avoid duplication. Custom skills go under `.agent/skills/`.
 
-This repo ships a PreToolUse hook at `.claude/hooks/gdd-permission-hook.sh` (registered in `.claude/settings.json`). When a Claude Code session is started in this workspace, the hook fires on every Bash tool call the agent attempts and:
+### Claude Code skills
 
-* **Rejects shell composition** (`&&`, `||`, `;`, pipes, redirects, command substitution) with a corrective message telling the agent to use separate tool calls or native `ws` flags. Keeps commands single-purpose and easier for newer users to follow.
-* **Auto-allows** anything matching the project's `permissions.allow` patterns or per-machine allow patterns in `.claude/hooks/hook-rules.local`.
+* https://code.claude.com/docs/en/skills — skills overview and what ships bundled
+* https://github.com/anthropics/skills — Anthropic's official skill set
+  * `/plugin marketplace add anthropics/skills`, then `/plugin install example-skills@anthropic-agent-skills`
+* https://github.com/obra/superpowers — Obra Superpowers, a well-regarded additional set
+  * `/plugin marketplace add obra/superpowers-marketplace`, then `/plugin install superpowers@superpowers-marketplace`
+* Restart Claude or run `/reload-plugins` after installing.
 
-If the hook ever stalls a session, or you'd just rather have Claude's default permission flow, you can opt out by exporting `WS_HOOK_DISABLE=1`. Full operational details, including how to add safe-command patterns of your own, live in [`.claude/hooks/README.md`](./.claude/hooks/README.md).
+### The PreToolUse hook
+
+This repo ships a Claude Code PreToolUse hook (`.claude/hooks/gdd-permission-hook.sh`) that channels agent Bash calls toward the `ws` CLI and away from opaque shell composition. Corrective "deny" messages early in a session are the hook teaching conventions, not errors. Full details live in [`.claude/hooks/README.md`](.claude/hooks/README.md) (the technical spec) and [`docs/gdd/agent-training.md`](docs/gdd/agent-training.md) (why it exists, in plain terms). Opt out for a session with `WS_HOOK_DISABLE=1`.

--- a/docs/gdd/features.md
+++ b/docs/gdd/features.md
@@ -1,30 +1,16 @@
 # GDD Features Tour
 
-A tour of what the yggdrasil workspace ships with. The [GDD index](index.md)
-covers the methodology; this doc covers the *features* — what's actually
-in the box and what each piece is for.
+A tour of what the yggdrasil workspace ships with. The [GDD index](index.md) covers the methodology; this doc covers the *features* — what's actually in the box and what each piece is for.
 
-If you want an end-to-end walkthrough rather than a feature inventory,
-go to [Getting Started](../getting-started/index.md). If you want the
-methodology that motivates the features, read the [GDD index](index.md)
-first.
+If you want an end-to-end walkthrough rather than a feature inventory, go to [Getting Started](../getting-started/index.md). If you want the methodology that motivates the features, read the [GDD index](index.md) first.
 
 ---
 
 ## The workspace and the `ws` CLI
 
-Yggdrasil is a *meta workspace* — a top-level directory that contains a
-shared CLI (`scripts/ws`), a workspace-level ecosystem config, and
-everything else (realms, hoards, components, templates, docs) hanging
-off it. Sessions run from the workspace root; all path references are
-relative to it.
+Yggdrasil is a *meta workspace* — a top-level directory that contains a shared CLI (`scripts/ws`), a workspace-level ecosystem config, and everything else (realms, hoards, components, templates, docs) hanging off it. Sessions run from the workspace root; all path references are relative to it.
 
-The `ws` CLI is the shared interface for both humans and AI agents.
-Add `scripts/` to your PATH to run `ws <cmd>` directly; otherwise
-`bash scripts/ws <cmd>` works without setup. Run `ws help` to see all
-subcommands; `ws <subcommand> --help` for per-command details. Skills
-and instructions defer to the help system as the source of truth so
-they don't drift out of date.
+The `ws` CLI is the shared interface for both humans and AI agents. Add `scripts/` to your PATH to run `ws <cmd>` directly; otherwise `bash scripts/ws <cmd>` works without setup. Run `ws help` to see all subcommands; `ws <subcommand> --help` for per-command details. Skills and instructions defer to the help system as the source of truth so they don't drift out of date.
 
 **Common subcommands:**
 
@@ -40,71 +26,35 @@ they don't drift out of date.
 
 ## Realms — community configuration layer
 
-A *realm* is a community's shared configuration: which components
-exist, what tier each is in, identity defaults, MCP server overrides,
-adapter commands. Realms are external git repos cloned into
-`realms/realm-<community>/`. The upstream `realm-template` is the
-tutorial scaffold; communities fork-and-edit (e.g.
-`realm-siliconsaga`).
+A *realm* is a community's shared configuration: which components exist, what tier each is in, identity defaults, MCP server overrides, adapter commands. Realms are external git repos cloned into `realms/realm-<community>/`. The upstream `realm-template` is the tutorial scaffold; communities fork-and-edit (e.g. `realm-siliconsaga`).
 
-The active realm is selected in `ecosystem.local.yaml`
-(per-developer, gitignored). You can switch realms (`ws realm use`)
-or run multiple side-by-side; the [three-layer config merge](../ecosystem-architecture.md#three-layer-config-merge)
-combines `ecosystem.yaml` (upstream) → `realms/<active>/ecosystem.yaml`
-(community) → `ecosystem.local.yaml` (your overrides).
+The active realm is selected in `ecosystem.local.yaml` (per-developer, gitignored). You can switch realms (`ws realm use`) or run multiple side-by-side; the [three-layer config merge](../ecosystem-architecture.md#three-layer-config-merge) combines `ecosystem.yaml` (upstream) → `realms/<active>/ecosystem.yaml` (community) → `ecosystem.local.yaml` (your overrides).
 
-Realm content is **trusted** at the same level as the workspace root
-itself — see [trust-and-safety.md](trust-and-safety.md) for the full
-hierarchy. A realm's `AGENTS.md`, `.agent/skills/`, and ecosystem
-config all flow into your sessions.
+Realm content is **trusted** at the same level as the workspace root itself — see [trust-and-safety.md](trust-and-safety.md) for the full hierarchy. A realm's `AGENTS.md`, `.agent/skills/`, and ecosystem config all flow into your sessions.
 
-Future direction: multi-realm chains (corp → dept → team) for
-organizations with layered config. Light reservation in code; not
-needed for v1.
+Future direction: multi-realm chains (corp → dept → team) for organizations with layered config. Light reservation in code; not needed for v1.
 
 ---
 
 ## Hoards — personal containers
 
-A *hoard* is a personal repo for content that doesn't belong in any
-component or realm. The canonical hoard type is **thalami** — a
-per-developer container for the [Thalamus](thalamus.md) (the shared
-thinking space between you and the agent), with per-machine files so
-multiple workstations can sync their state via git.
+A *hoard* is a personal repo for content that doesn't belong in any component or realm. The canonical hoard type is **thalami** — a per-developer container for the [Thalamus](thalamus.md) (the shared thinking space between you and the agent), with per-machine files so multiple workstations can sync their state via git.
 
-Hoards live in `hoards/<type>-<user>/` and are independent git repos.
-The first session on a new machine resolves a hostname-derived
-`<machine>-thalamus.md` inside the active thalami hoard; subsequent
-sessions pick up the conversation history from there.
+Hoards live in `hoards/<type>-<user>/` and are independent git repos. The first session on a new machine resolves a hostname-derived `<machine>-thalamus.md` inside the active thalami hoard; subsequent sessions pick up the conversation history from there.
 
-See [hoards.md](hoards.md) for the deeper dive: setup, the cadence
-config (`.ws-cadence.yaml`), multi-machine workflows, and where
-future hoard types might fit (e.g. vault-style knowledgebases).
+See [hoards.md](hoards.md) for the deeper dive: setup, the cadence config (`.ws-cadence.yaml`), multi-machine workflows, and where future hoard types might fit (e.g. vault-style knowledgebases).
 
 ---
 
 ## Component templates — opinionated scaffolds
 
-`templates/components/<flavor>/` ships scaffolds for common project
-types. Run `ws component init <flavor> <name>` to copy one into
-`components/<name>/`, git-init it, register it in your local
-ecosystem config, and print suggested next steps (e.g. `gh repo
-create`).
+`templates/components/<flavor>/` ships scaffolds for common project types. Run `ws component init <flavor> <name>` to copy one into `components/<name>/`, git-init it, register it in your local ecosystem config, and print suggested next steps (e.g. `gh repo create`).
 
-The flagship template is **gh-pages** — a tiny GitHub Pages site
-designed as the new-contributor tutorial. From scaffold to live
-deployed page through the full GDD-and-bot-review loop is roughly
-15 minutes.
+The flagship template is **gh-pages** — a tiny GitHub Pages site designed as the new-contributor tutorial. From scaffold to live deployed page through the full GDD-and-bot-review loop is roughly 15 minutes.
 
-Templates are designed to be opinionated where it removes friction
-and unopinionated where it constrains creativity. The README inside
-each template is a deterministic walkthrough that someone can follow
-solo, without an agent.
+Templates are designed to be opinionated where it removes friction and unopinionated where it constrains creativity. The README inside each template is a deterministic walkthrough that someone can follow solo, without an agent.
 
-Future direction: more flavors (local frontend, local backend,
-full-stack mini, MCP server template). The shape is established;
-each new flavor is just another `templates/components/<flavor>/`
-directory.
+Future direction: more flavors (local frontend, local backend, full-stack mini, MCP server template). The shape is established; each new flavor is just another `templates/components/<flavor>/` directory.
 
 ---
 
@@ -112,163 +62,86 @@ directory.
 
 Every component PR runs through automated review:
 
-- **CodeRabbit** — semantic review of code, comments, structure.
-  Posts inline comments and a top-level summary. Rate-limited per
-  hour but otherwise reliable.
-- **Copilot** — additional review (semantically distinct findings;
-  often catches things CodeRabbit misses, and vice versa).
-- **`ws review <component> <pr#>`** — fetches both reviews into a
-  single shell view. `ws review <component> threads <pr#> --resolve <id>`
-  for thread management; `ws review <component> reply <pr#> <thread-id>
-  "<msg>" --resolve` for a reply-and-resolve in one go.
+- **CodeRabbit** — semantic review of code, comments, structure. Posts inline comments and a top-level summary. Rate-limited per hour but otherwise reliable.
+- **Copilot** — additional review (semantically distinct findings; often catches things CodeRabbit misses, and vice versa).
+- **`ws review <component> <pr#>`** — fetches both reviews into a single shell view. `ws review <component> threads <pr#> --resolve <id>` for thread management; `ws review <component> reply <pr#> <thread-id> "<msg>" --resolve` for a reply-and-resolve in one go.
 
-The agent + the bots together form the review apparatus. You can
-work fully via the agent (which reads the bot output and proposes
-fixes) or step in manually — the `ws review` CLI is shaped for both.
+The agent + the bots together form the review apparatus. You can work fully via the agent (which reads the bot output and proposes fixes) or step in manually — the `ws review` CLI is shaped for both.
 
 Skills involved:
+
 - `gdd-review-triage` — fetches and consolidates review findings.
-- `requesting-code-review` — pre-merge review template (when you
-  want a final pass before pushing).
+- `requesting-code-review` — pre-merge review template (when you want a final pass before pushing).
 
 ---
 
 ## The Thalamus — shared thinking
 
-A *Thalamus* file (`Thalamus.md` in the workspace root, OR
-`<machine>-thalamus.md` in the active thalami hoard) is the
-shared thinking space between you and the agent: observations,
-preferences, concerns, and audit log. The agent writes immediately
-on safety concerns (the "black-box pattern"); other writes happen
-at natural pauses.
+A *Thalamus* file (`Thalamus.md` in the workspace root, OR `<machine>-thalamus.md` in the active thalami hoard) is the shared thinking space between you and the agent: observations, preferences, concerns, and audit log. The agent writes immediately on safety concerns (the "black-box pattern"); other writes happen at natural pauses.
 
-The orientation skill reads it at session start. The housekeeping
-skill audits it periodically (defaults to every 14 days; configurable
-via `staleness_days` frontmatter). The cadence skill nudges you to
-commit accumulated changes when they age past a threshold (defaults
-to 2 days; configured per-hoard in `.ws-cadence.yaml`).
+The orientation skill reads it at session start. The housekeeping skill audits it periodically (defaults to every 14 days; configurable via `staleness_days` frontmatter). The cadence skill nudges you to commit accumulated changes when they age past a threshold (defaults to 2 days; configured per-hoard in `.ws-cadence.yaml`).
 
-Full design: [thalamus.md](thalamus.md). Operational mechanics:
-[hoards.md](hoards.md).
+Full design: [thalamus.md](thalamus.md). Operational mechanics: [hoards.md](hoards.md).
 
 ---
 
 ## Modes — agent demeanor
 
-Sessions run in one of four modes that shape how chatty or careful
-the agent is:
+Sessions run in one of four modes that shape how chatty or careful the agent is:
 
 - **Quick** — terse, no ceremony, get-it-done.
 - **Zen** — full ceremony, deep work, frequent housekeeping.
 - **Flow** — the middle gear; sessions naturally drift across topics.
-- **Mentoring** — the agent explains decisions, teaches as it goes.
-  This is the right first-session mode for new contributors.
+- **Mentoring** — the agent explains decisions, teaches as it goes. This is the right first-session mode for new contributors.
 
-Modes are picked at session start (and can be re-picked mid-session).
-The default lives in your Thalamus frontmatter (`mode:`). Roles
-(developer, designer, reviewer, scribe) compose with modes — see
-[roles-and-modes.md](roles-and-modes.md).
+Modes are picked at session start (and can be re-picked mid-session). The default lives in your Thalamus frontmatter (`mode:`). Roles (developer, designer, reviewer, scribe) compose with modes — see [roles-and-modes.md](roles-and-modes.md).
 
 ---
 
 ## Permissions — what the agent can run without prompting
 
-`.claude/settings.json`'s `permissions.allow` and `permissions.deny`
-control which commands run without a confirmation prompt (output
-still streams normally either way; the question is just whether the
-user gets asked before execution). The two-layer defense
-model (subcommand-level safety + matcher-level scoping) keeps the
-allowlist trustworthy even if Claude Code's matcher behavior shifts.
+`.claude/settings.json`'s `permissions.allow` and `permissions.deny` control which commands run without a confirmation prompt (output still streams normally either way; the question is just whether the user gets asked before execution). The two-layer defense model (subcommand-level safety + matcher-level scoping) keeps the allowlist trustworthy even if Claude Code's matcher behavior shifts.
 
-Adding a new pattern? Read [permissions.md](permissions.md) —
-the **When to widen vs narrow patterns** section — first. Operational guidance
-for adding patterns or handling "don't ask again" prompts is in the
-`permissions-management` skill.
+Adding a new pattern? Read [permissions.md](permissions.md) — the **When to widen vs narrow patterns** section — first. Operational guidance for adding patterns or handling "don't ask again" prompts is in the `permissions-management` skill.
 
 ---
 
 ## Agent training — the PreToolUse hook
 
-A PreToolUse hook at `.claude/hooks/gdd-permission-hook.sh` runs
-before every Bash tool call. It rejects shell composition (`&&`,
-`||`, `;`, pipes, redirects, command substitution, FD merges) with
-**corrective** messages — the deny is paired with a one-line
-explanation of what to do instead. The agent reads the message on
-its next turn and retries with the suggested approach, so the hook
-acts as a continuous training signal rather than a hard wall.
+A PreToolUse hook at `.claude/hooks/gdd-permission-hook.sh` runs before every Bash tool call. It rejects shell composition (`&&`, `||`, `;`, pipes, redirects, command substitution, FD merges) with **corrective** messages — the deny is paired with a one-line explanation of what to do instead. The agent reads the message on its next turn and retries with the suggested approach, so the hook acts as a continuous training signal rather than a hard wall.
 
-New users often see a burst of "scary red" deny output in the
-first few tool calls of a session as the agent's generic shell
-habits collide with the workspace's one-action-per-call
-convention. That's working as intended; nothing was harmed (the
-commands never ran) and the noise drops to near zero once the
-agent has cached the local conventions.
+New users often see a burst of "scary red" deny output in the first few tool calls of a session as the agent's generic shell habits collide with the workspace's one-action-per-call convention. That's working as intended; nothing was harmed (the commands never ran) and the noise drops to near zero once the agent has cached the local conventions.
 
-The hook is roughly free in API-token cost — splitting a
-`cmd | head 20` into two separate tool calls is still one
-assistant turn, not two API calls — and pays off in
-auditability and context hygiene. See
-[agent-training.md](agent-training.md) for the full explanation,
-including the token-cost model and what to do when a legitimate
-command gets denied.
+The hook is roughly free in API-token cost — splitting a `cmd | head 20` into two separate tool calls is still one assistant turn, not two API calls — and pays off in auditability and context hygiene. See [agent-training.md](agent-training.md) for the full explanation, including the token-cost model and what to do when a legitimate command gets denied.
 
-Per-machine extras (opt-in): if a command you trust keeps getting
-denied, copy `.claude/hooks/hook-rules.local.example` to
-`hook-rules.local` (in the same directory) and add bash glob
-patterns under the `[allow-extras]` section. The live file is
-gitignored — patterns stay per-machine and don't leak into project
-policy.
+Per-machine extras (opt-in): if a command you trust keeps getting denied, copy `.claude/hooks/hook-rules.local.example` to `hook-rules.local` (in the same directory) and add bash glob patterns under the `[allow-extras]` section. The live file is gitignored — patterns stay per-machine and don't leak into project policy.
 
 ---
 
 ## Access — identities, tokens, remote operations
 
-The parallel permission system: which **remote Git operations** the
-agent can perform on a repo. Mediated by token scope, collaborator
-status, and a deliberate **two-identity model** — the human
-contributor and a separate agent identity (e.g. `agent-refr`),
-each with its own scoped PAT.
+The parallel permission system: which **remote Git operations** the agent can perform on a repo. Mediated by token scope, collaborator status, and a deliberate **two-identity model** — the human contributor and a separate agent identity (e.g. `agent-refr`), each with its own scoped PAT.
 
-The two-identity model gives reviewable attribution (every commit
-and PR is clearly authored by one or the other), scope minimization
-(the agent token holds *just enough* permission for routine work),
-and clean revocation (compromise the agent token? revoke without
-disrupting your own access). The fork-or-collaborator pattern lets
-the agent push to repos it doesn't own:
+The two-identity model gives reviewable attribution (every commit and PR is clearly authored by one or the other), scope minimization (the agent token holds *just enough* permission for routine work), and clean revocation (compromise the agent token? revoke without disrupting your own access). The fork-or-collaborator pattern lets the agent push to repos it doesn't own:
 
-- **Forks** for upstream contribution: `forkOrg` configures where
-  the agent forks; PRs target the upstream from the fork.
-- **Collaborator** for personal repos (typical for hoards): add the
-  agent as a `push`-permission collaborator on your personal repo;
-  no fork needed.
+- **Forks** for upstream contribution: `forkOrg` configures where the agent forks; PRs target the upstream from the fork.
+- **Collaborator** for personal repos (typical for hoards): add the agent as a `push`-permission collaborator on your personal repo; no fork needed.
 
-Multi-provider workflows (GitHub + GitLab + self-hosted) work
-without per-command configuration — `ws push` / `ws cr` / `ws
-review` auto-detect provider from remote URL and pick the right CLI
-and token.
+Multi-provider workflows (GitHub + GitLab + self-hosted) work without per-command configuration — `ws push` / `ws cr` / `ws review` auto-detect provider from remote URL and pick the right CLI and token.
 
-Conceptual model: [access.md](access.md). Setup mechanics
-(installing CLIs, generating tokens, `.env` shape):
-[`docs/git-provider-setup.md`](../git-provider-setup.md).
-Diagnostic: `ws diagnose <component>` reports per-component remote
-detection and token coverage.
+Conceptual model: [access.md](access.md). Setup mechanics (installing CLIs, generating tokens, `.env` shape): [`docs/git-provider-setup.md`](../git-provider-setup.md). Diagnostic: `ws diagnose <component>` reports per-component remote detection and token coverage.
 
 ---
 
 ## The self-improving loop
 
-Every observation captured in the Thalamus is candidate material
-for promotion. Housekeeping audits (default every 14 days, or
-on demand) walk through accumulated items and decide:
+Every observation captured in the Thalamus is candidate material for promotion. Housekeeping audits (default every 14 days, or on demand) walk through accumulated items and decide:
 
-- **Promote** — to a GitHub issue, a skill update, an instruction-file
-  edit, a workflow-auditor candidate.
+- **Promote** — to a GitHub issue, a skill update, an instruction-file edit, a workflow-auditor candidate.
 - **Keep** — relevant but not yet actionable.
 - **Prune** — resolved, stale, or superseded.
 
-This is how the framework refines itself through use: the things
-that recur become formalized; the things that resolve drop off.
-See [self-improving-loop.md](self-improving-loop.md).
+This is how the framework refines itself through use: the things that recur become formalized; the things that resolve drop off. See [self-improving-loop.md](self-improving-loop.md).
 
 ---
 
@@ -286,9 +159,6 @@ Full reference: [organization-stack.md](organization-stack.md). Design and ratio
 
 ## Next steps
 
-- Brand new? [Getting Started](../getting-started/index.md) walks
-  you through cloning yggdrasil and a first session.
+- Brand new? [Getting Started](../getting-started/index.md) walks you through cloning yggdrasil and a first session.
 - Want the methodology before the tools? [GDD index](index.md).
-- Ready to scaffold a tutorial component?
-  `ws component init gh-pages my-page` and follow the printed
-  README.
+- Ready to scaffold a tutorial component? `ws component init gh-pages my-page` and follow the printed README.

--- a/docs/gdd/organization-stack.md
+++ b/docs/gdd/organization-stack.md
@@ -69,6 +69,17 @@ When an arc completes, its residue splits three ways:
 
 The `ArcDashboard` and the GitHub Project board are **companions, not redundant**: `ArcDashboard` shows in-flight private work across your machines — ephemeral, fast, pruned. The GitHub Project board shows graduated durable work — persistent, public, edited live. An arc with `status: promoted` is the hand-off marker between the two.
 
+## How the Docs tier is structured — the doc-shape ladder
+
+The Docs tier has its own "start small, grow as needed" ladder, mirroring the stack as a whole. A component's documentation moves through four **shapes** as its content grows, and — like every seam here — graduation between shapes is propose-then-confirm during ceremony, never automatic:
+
+1. **Loose root Markdown** — a `README.md` plus optional root companions (`CONTRIBUTING.md`, `CHANGELOG.md`, …), no `docs/` yet. Right for anything from brand-new to small-but-focused, where everything fits in a handful of root files.
+2. **Plainly structured `/docs`** — the README plus a `docs/` directory holding a `docs/README.md` index and one topic file per concept, in plain Markdown with no site config. This is the shape a graduating arc's durable knowledge lands in.
+3. **Themed docs site** — adds a site config (MkDocs / Jekyll / equivalent), a theme, and navigation, and deploys to GitHub Pages. Right once navigation and search start to matter, or the audience extends beyond developers reading on GitHub.
+4. **Custom site** — beyond the standard frameworks. Named only so the ladder is finite; most components never reach it.
+
+The Shape 1 → 2 trigger is exactly the graduation moment above: when a closing arc's durable knowledge would otherwise pile into a single root README, that is the signal to give the component a real `docs/` index plus topic files. The per-shape structure, file roles, and anti-patterns are the operational detail an agent applies when actually writing docs — those live in the `writing-yggdrasil-docs` skill.
+
 ## The cadence ladder
 
 The two ceremonies move items across seams as work happens. But the durable tier also needs periodic review — otherwise promoted issues are never looked at again. The model therefore defines a **cadence ladder**: ceremonies keyed to horizon, not only to session boundaries.

--- a/templates/thalamus.md
+++ b/templates/thalamus.md
@@ -11,7 +11,7 @@ active_vault: null  # name of the vault-flavored hoard scribe should
                     # want session friction reduced.
 staleness_days: 14  # suggest housekeeping after this many days without audit
 arcs: []            # in-flight strands of work — see docs/plans/2026-05-07-thalamus-arc-dashboard-design.md
-                    # and docs/plans/2026-05-19-arc-dashboard-qol-design.md (SP-A: Impact/Urgency, review status)
+                    # and docs/plans/2026-05-19-arc-dashboard-qol-design.md (Impact/Urgency + review status)
                     # Each entry: id (slug), name, status (active|review|parked|closed|promoted),
                     #             started, last_touched, next;
                     #   optional: issue, tags, impact (high|medium|low),

--- a/tests/hook/gdd-permission-hook.bats
+++ b/tests/hook/gdd-permission-hook.bats
@@ -530,6 +530,34 @@ ws hook-bypass [a-z]*"
     [[ "$output" == *"(none)"* ]]
 }
 
+@test "ask: ws hook-bypass supports the --reason=<value> form" {
+    write_project_hook_rules "[ask-commands]
+ws hook-bypass [a-z]*"
+    run_hook "ws hook-bypass git-commit --reason=amend-last-commit"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"\"permissionDecision\":\"ask\""* ]]
+    [[ "$output" == *"git-commit"* ]]
+    [[ "$output" == *"amend-last-commit"* ]]
+    [[ "$output" != *"destructive or hard to undo"* ]]
+}
+
+@test "ask: ws hook-bypass message names the raw command pattern, not just the slug" {
+    write_project_hook_rules "$(cat <<'EOF'
+[redirect-commands]
+git-commit | git commit* | Use ws commit
+[ask-commands]
+ws hook-bypass [a-z]*
+EOF
+)"
+    run_hook "ws hook-bypass git-commit"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"\"permissionDecision\":\"ask\""* ]]
+    # The slug is named AND the raw command pattern it maps to is surfaced,
+    # so the human isn't told the slug 'git-commit' is itself the command.
+    [[ "$output" == *"git-commit"* ]]
+    [[ "$output" == *"git commit*"* ]]
+}
+
 @test "ask: Tier 1 composition denies before the ask-tier is reached" {
     write_project_hook_rules "[ask-commands]
 rm -rf*"

--- a/tests/hook/gdd-permission-hook.bats
+++ b/tests/hook/gdd-permission-hook.bats
@@ -508,6 +508,28 @@ git reset --hard*"
     [[ "$output" != *"symlinks"* ]]
 }
 
+@test "ask: ws hook-bypass gets a tailored message naming the slug + reason" {
+    write_project_hook_rules "[ask-commands]
+ws hook-bypass [a-z]*"
+    run_hook 'ws hook-bypass git-commit --reason "amend last commit"'
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"\"permissionDecision\":\"ask\""* ]]
+    [[ "$output" == *"git-commit"* ]]
+    [[ "$output" == *"amend last commit"* ]]
+    # NOT the generic destructive-command message
+    [[ "$output" != *"destructive or hard to undo"* ]]
+}
+
+@test "ask: ws hook-bypass without --reason surfaces (none)" {
+    write_project_hook_rules "[ask-commands]
+ws hook-bypass [a-z]*"
+    run_hook "ws hook-bypass git-push"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"\"permissionDecision\":\"ask\""* ]]
+    [[ "$output" == *"git-push"* ]]
+    [[ "$output" == *"(none)"* ]]
+}
+
 @test "ask: Tier 1 composition denies before the ask-tier is reached" {
     write_project_hook_rules "[ask-commands]
 rm -rf*"


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @Cervator via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

A small QOL bundle — one hook tweak plus a round of doc cleanup that came out of the post-#71 housekeeping. (The meatier hook-v3 ideas and the `ws audit-permissions` over-matching fix are deliberately deferred — captured as Thalamus notes for a focused future pass.)

- **`feat(hook)`: tailored `ws hook-bypass` ask prompt.** The bypass-creation prompt used the generic ask-list message ("destructive or hard to undo"), which misdescribes a bypass grant and never named the underlying command. It now names the slug and surfaces the `--reason` so the human sees what they're approving. Surfaced during PR #71 acceptance testing. (171 bats green.)
- **`docs`: reframe the root README as GDD's meta-workspace.** Dropped the vague "wrapper for the entire ecosystem" lead and two stale point-in-time bits (the "holds the VS Code workspace file" claim — we generate one via `ws vscode`, don't commit it — and the inlined PreToolUse-hook tier description). Added a "Start here" that splits by audience (humans → `docs/gdd/`; agents → `AGENTS.md`) and a "What lives here" map.
- **`docs`: retire the cryptic `SP-A` label** from the thalamus template's `arcs:` comment (the org-stack facet shorthand is opaque to a newcomer).
- **`docs(gdd)`: surface the doc-shape convention human-side.** Added a "How the Docs tier is structured — the doc-shape ladder" section to `organization-stack.md` (the Docs tier already gestured at Shape 2), so the four-Shape Component Documentation Convention has a human-facing home; the `writing-yggdrasil-docs` skill stays the agent-facing operational version.
- **`docs(gdd)`: reflow `features.md`** to single-line prose (it predated the no-hard-wrap rule). Content unchanged — the large diff is purely unwrapping.

## Test plan

- [ ] `bash scripts/ws test yggdrasil` — full bats suite green (171 tests, 2 platform-skipped on Windows), including the two new `ws hook-bypass` ask-message tests.
- [ ] Live: `ws hook-bypass git-commit --reason "x"` shows an ask prompt that names `git-commit` and the reason (not the generic destructive line).
- [ ] Rendered docs: README "Start here" reads correctly for both audiences; the `organization-stack.md` doc-shape ladder section renders; `features.md` reflow has no broken lists/links.

## Notes for reviewers

- No behavior change to the hook's deny/allow tiers — only the ask-tier *message* for `ws hook-bypass` is new.
- Deferred (Thalamus notes, not in this PR): auto-approve `ws exec <comp> ls *`, and the `ws audit-permissions` watchlist over-matching (its `Bash(bash *)` entry flags every `bash scripts/ws <cmd>` allow). Both are security-sensitive matcher work for a separate focused pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified bypass approval procedure and updated main README to present Yggdrasil as a meta-workspace with clearer navigation.
  * Expanded documentation conventions and added a doc-shape ladder; reformatted feature docs for readability.

* **Improvements**
  * Permission prompts for hook-bypass now show a tailored approval message that includes the target slug, what will be unblocked, and the provided reason.

* **Tests**
  * Added tests covering hook-bypass behavior with and without reason parameters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SiliconSaga/yggdrasil/pull/72?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->