### PR TITLE
feat(ws): hold off ws clean below a mining threshold

### DIFF
--- a/scripts/ws
+++ b/scripts/ws
@@ -386,14 +386,17 @@ ws_clean() {
     # generated scripts), so recursive removal; the .tmp/ dir itself stays
     # for next-use since we only remove its top-level entries.
     printf '%s\n' "${report[@]}"
-    local c
-    for c in ${candidates[@]+"${candidates[@]}"}; do
-        rm -f "$c"
-    done
-    local t
-    for t in ${tmp_entries[@]+"${tmp_entries[@]}"}; do
-        rm -rf "$t"
-    done
+    # Delete the snapshot with one rm per group (batched for speed,
+    # quoted + `--` so paths with spaces or leading dashes stay intact).
+    # Each group is length-guarded: one side can be empty even when
+    # total > 0, and a bare "${arr[@]}" on an empty array trips `set -u`
+    # on older bash.
+    if [[ ${#candidates[@]} -gt 0 ]]; then
+        rm -f -- "${candidates[@]}"
+    fi
+    if [[ ${#tmp_entries[@]} -gt 0 ]]; then
+        rm -rf -- "${tmp_entries[@]}"
+    fi
 
     echo "Cleaned $total draft file(s) total."
 }

--- a/scripts/ws
+++ b/scripts/ws
@@ -293,7 +293,7 @@ ws_clean() {
     local arg
     for arg in "$@"; do
         case "$arg" in
-            --force|--yes) force=1 ;;
+            --force) force=1 ;;
             -h|--help)
                 echo "Usage: ws clean [--force]"
                 echo ""
@@ -330,32 +330,36 @@ ws_clean() {
     local bodyfile_specs=('.issues:*.md' '.crs:*.md' '.commits:*.md' '.outputs:*.txt')
     local tmp_dir="$ROOT_DIR/.tmp"
 
-    # First pass: count what WOULD be removed (per dir), without deleting,
-    # so the threshold decision happens before anything is touched.
-    local total=0
+    # Single scan: collect the exact paths to remove, so the threshold
+    # decision and the deletion act on the same snapshot. Re-scanning at
+    # delete time would risk deleting files that were never counted, or
+    # proceeding after the live total dropped below the threshold.
+    local candidates=()   # individual files in the bodyfile dirs
+    local tmp_entries=()  # top-level entries under .tmp/ (may be dirs)
     local report=()
     local spec
     for spec in "${bodyfile_specs[@]}"; do
         local dir="${spec%%:*}"
         local pattern="${spec#*:}"
         local dirpath="$ROOT_DIR/$dir"
-        if [[ -d "$dirpath" ]]; then
-            local count
-            count=$(find "$dirpath" -maxdepth 1 -name "$pattern" -type f | wc -l)
-            if [[ "$count" -gt 0 ]]; then
-                report+=("  $dir/  $count file(s)")
-                total=$((total + count))
-            fi
-        fi
+        [[ -d "$dirpath" ]] || continue
+        local before=${#candidates[@]}
+        local f
+        while IFS= read -r f; do
+            candidates+=("$f")
+        done < <(find "$dirpath" -maxdepth 1 -name "$pattern" -type f)
+        local n=$(( ${#candidates[@]} - before ))
+        [[ "$n" -gt 0 ]] && report+=("  $dir/  $n file(s)")
     done
-    local tmp_count=0
     if [[ -d "$tmp_dir" ]]; then
-        tmp_count=$(find "$tmp_dir" -mindepth 1 -maxdepth 1 | wc -l)
-        if [[ "$tmp_count" -gt 0 ]]; then
-            report+=("  .tmp/  $tmp_count entr(ies)")
-            total=$((total + tmp_count))
-        fi
+        local e
+        while IFS= read -r e; do
+            tmp_entries+=("$e")
+        done < <(find "$tmp_dir" -mindepth 1 -maxdepth 1)
+        [[ ${#tmp_entries[@]} -gt 0 ]] && report+=("  .tmp/  ${#tmp_entries[@]} entr(ies)")
     fi
+
+    local total=$(( ${#candidates[@]} + ${#tmp_entries[@]} ))
 
     if [[ "$total" -eq 0 ]]; then
         echo "(no draft files to clean)"
@@ -377,33 +381,21 @@ ws_clean() {
         return 0
     fi
 
-    # Proceed: delete. Re-run the same finds — the dirs haven't changed
-    # since the count pass, so the per-dir totals match the report above.
-    local removed=0
-    for spec in "${bodyfile_specs[@]}"; do
-        local dir="${spec%%:*}"
-        local pattern="${spec#*:}"
-        local dirpath="$ROOT_DIR/$dir"
-        if [[ -d "$dirpath" ]]; then
-            local count
-            count=$(find "$dirpath" -maxdepth 1 -name "$pattern" -type f | wc -l)
-            if [[ "$count" -gt 0 ]]; then
-                find "$dirpath" -maxdepth 1 -name "$pattern" -type f -delete
-                echo "  $dir/  $count file(s) removed"
-                removed=$((removed + count))
-            fi
-        fi
+    # Proceed: delete exactly the snapshot we counted. .tmp/ entries are
+    # arbitrary and often nested (synthetic git repos, test fixtures,
+    # generated scripts), so recursive removal; the .tmp/ dir itself stays
+    # for next-use since we only remove its top-level entries.
+    printf '%s\n' "${report[@]}"
+    local c
+    for c in ${candidates[@]+"${candidates[@]}"}; do
+        rm -f "$c"
     done
-    # .tmp/ contents are arbitrary and often nested (synthetic git repos,
-    # test fixtures, generated scripts), so recursive cleanup. We blow
-    # away top-level entries; the directory itself stays for next-use.
-    if [[ -d "$tmp_dir" && "$tmp_count" -gt 0 ]]; then
-        find "$tmp_dir" -mindepth 1 -maxdepth 1 -exec rm -rf {} +
-        echo "  .tmp/  $tmp_count entr(ies) removed"
-        removed=$((removed + tmp_count))
-    fi
+    local t
+    for t in ${tmp_entries[@]+"${tmp_entries[@]}"}; do
+        rm -rf "$t"
+    done
 
-    echo "Cleaned $removed draft file(s) total."
+    echo "Cleaned $total draft file(s) total."
 }
 
 ws_issue() {

--- a/scripts/ws
+++ b/scripts/ws
@@ -21,7 +21,7 @@
 #   review <comp> <cr#|threads> [options]  CR review comments and threads (see ws review --help)
 #   commit <comp> <bodyfile> Commit with Co-Authored-By trailer (bodyfile-driven; see templates/commit.md)
 #   log [comp] [--oneline] Show commits on current branch vs main
-#   clean             Remove draft files from .issues/, .crs/, .commits/
+#   clean [--force]   Remove draft files from .issues/, .crs/, .commits/, .outputs/, .tmp/ (holds off below the mining threshold unless --force)
 #   exec <comp> <cmd...> Run a command in a component dir (max 6 cmd args)
 #   realm init        Clone template realm for tutorials
 #   realm <url>       Clone a community realm
@@ -62,7 +62,10 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+# Honor a pre-set ROOT_DIR (matches ws-commit.sh) so tests can point the
+# dispatcher at an isolated workspace. Unset in normal use, so this
+# resolves to the script's parent — behavior-preserving in production.
+: "${ROOT_DIR:="$(cd "$SCRIPT_DIR/.." && pwd)"}"
 : "${ECOSYSTEM:="$ROOT_DIR/ecosystem.yaml"}"
 : "${ECOSYSTEM_LOCAL:="$ROOT_DIR/ecosystem.local.yaml"}"
 : "${REALMS_DIR:="$ROOT_DIR/realms"}"
@@ -286,21 +289,98 @@ HELP
 }
 
 ws_clean() {
-    if [[ $# -gt 0 ]]; then
-        echo "Usage: ws clean" >&2
-        echo "" >&2
-        echo "Remove draft files from .issues/, .crs/, .commits/, .outputs/," >&2
-        echo "and the workspace scratch area .tmp/." >&2
-        exit 1
+    local force=0
+    local arg
+    for arg in "$@"; do
+        case "$arg" in
+            --force|--yes) force=1 ;;
+            -h|--help)
+                echo "Usage: ws clean [--force]"
+                echo ""
+                echo "Remove draft files from .issues/, .crs/, .commits/, .outputs/,"
+                echo "and the workspace scratch area .tmp/."
+                echo ""
+                echo "These scratch files double as mining material for the"
+                echo "housekeeping 'mine scratch dirs' step, so ws clean holds off"
+                echo "when fewer than \$WS_CLEAN_MINE_THRESHOLD files (default 50)"
+                echo "would be removed. Pass --force to clean anyway — e.g. right"
+                echo "after a mining pass, or when you explicitly want a clean slate."
+                return 0
+                ;;
+            *)
+                echo "Usage: ws clean [--force]" >&2
+                return 1
+                ;;
+        esac
+    done
+
+    # Below this many scratch files, clean holds off (unless --force) so
+    # the files survive to be mined by the housekeeping "mine scratch
+    # dirs" step instead of being cleared away reflexively. Env-override
+    # for users who want a different floor.
+    local threshold="${WS_CLEAN_MINE_THRESHOLD:-50}"
+    if ! [[ "$threshold" =~ ^[0-9]+$ ]]; then
+        echo "WARNING: WS_CLEAN_MINE_THRESHOLD='$threshold' is not a non-negative integer; using 50." >&2
+        threshold=50
     fi
 
+    # bodyfile dirs hold *.md; .outputs/ holds tool-emitted snapshots in
+    # *.txt. Each spec is `<dir>:<glob>`. The shallow find leaves nested
+    # directories alone — those don't exist here by convention.
+    local bodyfile_specs=('.issues:*.md' '.crs:*.md' '.commits:*.md' '.outputs:*.txt')
+    local tmp_dir="$ROOT_DIR/.tmp"
+
+    # First pass: count what WOULD be removed (per dir), without deleting,
+    # so the threshold decision happens before anything is touched.
     local total=0
-    # Per-dir glob: bodyfile dirs hold *.md; .outputs/ holds tool-emitted
-    # snapshots in *.txt. Each spec is `<dir>:<glob>`. The shallow
-    # find pattern leaves nested directories alone — those don't
-    # exist in these directories by convention.
+    local report=()
     local spec
-    for spec in '.issues:*.md' '.crs:*.md' '.commits:*.md' '.outputs:*.txt'; do
+    for spec in "${bodyfile_specs[@]}"; do
+        local dir="${spec%%:*}"
+        local pattern="${spec#*:}"
+        local dirpath="$ROOT_DIR/$dir"
+        if [[ -d "$dirpath" ]]; then
+            local count
+            count=$(find "$dirpath" -maxdepth 1 -name "$pattern" -type f | wc -l)
+            if [[ "$count" -gt 0 ]]; then
+                report+=("  $dir/  $count file(s)")
+                total=$((total + count))
+            fi
+        fi
+    done
+    local tmp_count=0
+    if [[ -d "$tmp_dir" ]]; then
+        tmp_count=$(find "$tmp_dir" -mindepth 1 -maxdepth 1 | wc -l)
+        if [[ "$tmp_count" -gt 0 ]]; then
+            report+=("  .tmp/  $tmp_count entr(ies)")
+            total=$((total + tmp_count))
+        fi
+    fi
+
+    if [[ "$total" -eq 0 ]]; then
+        echo "(no draft files to clean)"
+        return 0
+    fi
+
+    # Below the mining threshold and not forced: push back instead of
+    # cleaning. The decision is embedded here so callers don't depend on
+    # remembering the convention — a reflexive clean gets a nudge, and
+    # the agent decides whether to honor it (back off) or re-run with
+    # --force (the user asked, or mining already happened).
+    if [[ "$total" -lt "$threshold" && "$force" -eq 0 ]]; then
+        echo "Holding off — only $total scratch file(s), below the mining threshold of $threshold:"
+        printf '%s\n' "${report[@]}"
+        echo ""
+        echo "These accumulate as mining material for housekeeping. If this was a"
+        echo "reflexive cleanup, leave them. To clean anyway (post-mining, or a"
+        echo "deliberate clean slate), re-run: ws clean --force"
+        return 0
+    fi
+
+    # Proceed: delete. Re-run the same finds — the dirs haven't changed
+    # since the count pass, so the per-dir totals match the report above.
+    local removed=0
+    for spec in "${bodyfile_specs[@]}"; do
         local dir="${spec%%:*}"
         local pattern="${spec#*:}"
         local dirpath="$ROOT_DIR/$dir"
@@ -310,33 +390,20 @@ ws_clean() {
             if [[ "$count" -gt 0 ]]; then
                 find "$dirpath" -maxdepth 1 -name "$pattern" -type f -delete
                 echo "  $dir/  $count file(s) removed"
-                total=$((total + count))
+                removed=$((removed + count))
             fi
         fi
     done
-
-    # .tmp/ — workspace scratch area for ad-hoc validation and
-    # write-then-execute script use. Unlike the bodyfile dirs above,
-    # contents are arbitrary and often nested (synthetic git repos,
-    # test fixtures, generated scripts), so recursive cleanup is
-    # appropriate. We blow away top-level entries and recreate
-    # nothing — the directory itself stays for next-use.
-    local tmp_dir="$ROOT_DIR/.tmp"
-    if [[ -d "$tmp_dir" ]]; then
-        local tmp_count
-        tmp_count=$(find "$tmp_dir" -mindepth 1 -maxdepth 1 | wc -l)
-        if [[ "$tmp_count" -gt 0 ]]; then
-            find "$tmp_dir" -mindepth 1 -maxdepth 1 -exec rm -rf {} +
-            echo "  .tmp/  $tmp_count entr(ies) removed"
-            total=$((total + tmp_count))
-        fi
+    # .tmp/ contents are arbitrary and often nested (synthetic git repos,
+    # test fixtures, generated scripts), so recursive cleanup. We blow
+    # away top-level entries; the directory itself stays for next-use.
+    if [[ -d "$tmp_dir" && "$tmp_count" -gt 0 ]]; then
+        find "$tmp_dir" -mindepth 1 -maxdepth 1 -exec rm -rf {} +
+        echo "  .tmp/  $tmp_count entr(ies) removed"
+        removed=$((removed + tmp_count))
     fi
 
-    if [[ "$total" -eq 0 ]]; then
-        echo "(no draft files to clean)"
-    else
-        echo "Cleaned $total draft file(s) total."
-    fi
+    echo "Cleaned $removed draft file(s) total."
 }
 
 ws_issue() {

--- a/tests/ws-clean/clean.bats
+++ b/tests/ws-clean/clean.bats
@@ -39,6 +39,16 @@ setup() {
     [ "$(count_scratch)" -eq 0 ]
 }
 
+@test "force clean handles paths with spaces" {
+    export WS_CLEAN_MINE_THRESHOLD=1
+    printf 'x\n' > "$ROOT_DIR/.commits/with space.md"
+    run_ws clean --force
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Cleaned 1 draft file(s) total."* ]]
+    [ ! -e "$ROOT_DIR/.commits/with space.md" ]
+    [ "$(count_scratch)" -eq 0 ]
+}
+
 @test "at/above threshold without --force: cleans" {
     export WS_CLEAN_MINE_THRESHOLD=2
     make_drafts .commits 2

--- a/tests/ws-clean/clean.bats
+++ b/tests/ws-clean/clean.bats
@@ -1,0 +1,105 @@
+#!/usr/bin/env bats
+
+# Tests for `ws clean` and its mining-threshold push-back.
+#
+# Behavior under test:
+#   - below WS_CLEAN_MINE_THRESHOLD and no --force → hold off, delete
+#     nothing (scratch files survive to be mined by housekeeping)
+#   - below threshold WITH --force → clean anyway
+#   - at/above threshold → clean without --force
+#   - empty scratch dirs → "nothing to clean"
+#   - counts span all scratch dirs incl. .tmp
+#   - env override + invalid-value fallback
+#   - arg handling: --help, unknown flag
+
+load test_helper
+
+setup() {
+    init_clean_workspace
+}
+
+@test "below threshold without --force: holds off and deletes nothing" {
+    export WS_CLEAN_MINE_THRESHOLD=5
+    make_drafts .commits 2
+    run_ws clean
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Holding off"* ]]
+    [[ "$output" == *"threshold of 5"* ]]
+    [[ "$output" == *"ws clean --force"* ]]
+    # Nothing deleted
+    [ "$(count_scratch)" -eq 2 ]
+}
+
+@test "below threshold with --force: cleans" {
+    export WS_CLEAN_MINE_THRESHOLD=5
+    make_drafts .commits 2
+    run_ws clean --force
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Cleaned 2 draft file(s) total."* ]]
+    [ "$(count_scratch)" -eq 0 ]
+}
+
+@test "at/above threshold without --force: cleans" {
+    export WS_CLEAN_MINE_THRESHOLD=2
+    make_drafts .commits 2
+    run_ws clean
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Cleaned 2 draft file(s) total."* ]]
+    [[ "$output" != *"Holding off"* ]]
+    [ "$(count_scratch)" -eq 0 ]
+}
+
+@test "no scratch files: reports nothing to clean" {
+    run_ws clean
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"(no draft files to clean)"* ]]
+}
+
+@test "count spans all scratch dirs including .tmp" {
+    export WS_CLEAN_MINE_THRESHOLD=100
+    make_drafts .commits 2
+    make_drafts .crs 1
+    make_drafts .outputs 3
+    printf 'scratch\n' > "$ROOT_DIR/.tmp/leftover.txt"
+    run_ws clean
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Holding off"* ]]
+    # 2 + 1 + 3 + 1 = 7
+    [[ "$output" == *"only 7 scratch file(s)"* ]]
+    [[ "$output" == *".commits/"* ]]
+    [[ "$output" == *".outputs/"* ]]
+    [[ "$output" == *".tmp/"* ]]
+    [ "$(count_scratch)" -eq 7 ]
+}
+
+@test "env threshold of 1: a single file cleans without --force" {
+    export WS_CLEAN_MINE_THRESHOLD=1
+    make_drafts .crs 1
+    run_ws clean
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Cleaned 1 draft file(s) total."* ]]
+    [ "$(count_scratch)" -eq 0 ]
+}
+
+@test "invalid WS_CLEAN_MINE_THRESHOLD falls back to 50 with a warning" {
+    export WS_CLEAN_MINE_THRESHOLD=abc
+    make_drafts .commits 1
+    run_ws clean
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"not a non-negative integer"* ]]
+    # 1 < 50 fallback → holds off, nothing deleted
+    [[ "$output" == *"Holding off"* ]]
+    [ "$(count_scratch)" -eq 1 ]
+}
+
+@test "--help prints usage and exits 0" {
+    run_ws clean --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage: ws clean [--force]"* ]]
+}
+
+@test "unknown flag errors with usage (exit 1)" {
+    run_ws clean --bogus
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Usage: ws clean [--force]"* ]]
+}

--- a/tests/ws-clean/test_helper.bash
+++ b/tests/ws-clean/test_helper.bash
@@ -10,18 +10,22 @@
 REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
 WS_BIN="$REPO_ROOT/scripts/ws"
 
-if command -v timeout >/dev/null 2>&1; then
-    TIMEOUT_BIN="timeout"
-elif command -v gtimeout >/dev/null 2>&1; then
-    TIMEOUT_BIN="gtimeout"
-else
-    echo "ERROR: neither 'timeout' nor 'gtimeout' found on PATH." >&2
-    echo "  Install GNU coreutils — on macOS: 'brew install coreutils'." >&2
-    echo "  See tests/README.md." >&2
-    exit 1
-fi
+# Resolve `timeout` (Linux/Git Bash) or `gtimeout` (macOS Homebrew
+# coreutils). Called from setup() — NOT at source time — so a missing
+# binary skips the affected tests with a helpful message instead of
+# aborting the whole file's load (which buries the reason in a load error).
+detect_timeout_bin() {
+    if command -v timeout >/dev/null 2>&1; then
+        TIMEOUT_BIN="timeout"
+    elif command -v gtimeout >/dev/null 2>&1; then
+        TIMEOUT_BIN="gtimeout"
+    else
+        skip "neither 'timeout' nor 'gtimeout' found; install GNU coreutils (macOS: brew install coreutils) — see tests/README.md"
+    fi
+}
 
 init_clean_workspace() {
+    detect_timeout_bin
     WORK="$BATS_TEST_TMPDIR/work"
     mkdir -p "$WORK/components" "$WORK/realms" "$WORK/hoards"
     mkdir -p "$WORK/.issues" "$WORK/.crs" "$WORK/.commits" "$WORK/.outputs" "$WORK/.tmp"

--- a/tests/ws-clean/test_helper.bash
+++ b/tests/ws-clean/test_helper.bash
@@ -1,0 +1,74 @@
+# Shared helpers for ws-clean bats tests.
+#
+# Each test gets an isolated $WORK directory under $BATS_TEST_TMPDIR with
+# the scratch dirs ws clean operates on (.issues/.crs/.commits/.outputs/
+# .tmp). Tests invoke the `ws` dispatcher directly (via bash) so the
+# `clean)` routing and arg-parsing are exercised. WS_CLEAN_MINE_THRESHOLD
+# is set per-test to keep the threshold logic testable without creating
+# dozens of files.
+
+REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+WS_BIN="$REPO_ROOT/scripts/ws"
+
+if command -v timeout >/dev/null 2>&1; then
+    TIMEOUT_BIN="timeout"
+elif command -v gtimeout >/dev/null 2>&1; then
+    TIMEOUT_BIN="gtimeout"
+else
+    echo "ERROR: neither 'timeout' nor 'gtimeout' found on PATH." >&2
+    echo "  Install GNU coreutils — on macOS: 'brew install coreutils'." >&2
+    echo "  See tests/README.md." >&2
+    exit 1
+fi
+
+init_clean_workspace() {
+    WORK="$BATS_TEST_TMPDIR/work"
+    mkdir -p "$WORK/components" "$WORK/realms" "$WORK/hoards"
+    mkdir -p "$WORK/.issues" "$WORK/.crs" "$WORK/.commits" "$WORK/.outputs" "$WORK/.tmp"
+    export ROOT_DIR="$WORK"
+    export COMPONENTS_DIR="$WORK/components"
+    export REALMS_DIR="$WORK/realms"
+    export HOARDS_DIR="$WORK/hoards"
+
+    export ECOSYSTEM="$WORK/ecosystem.yaml"
+    cat > "$ECOSYSTEM" <<'YAML'
+identity:
+  human_account: testuser
+components: {}
+YAML
+    export ECOSYSTEM_LOCAL="$WORK/ecosystem.local.yaml"
+    cat > "$ECOSYSTEM_LOCAL" <<'YAML'
+identity:
+  human_account: testuser
+YAML
+
+    export HOSTNAME="testhost"
+}
+
+# Create $2 draft files of the right extension in scratch dir $1
+# (e.g. make_drafts .commits 3, make_drafts .outputs 2).
+make_drafts() {
+    local dir="$1"
+    local n="$2"
+    local ext="md"
+    [[ "$dir" == ".outputs" ]] && ext="txt"
+    local i
+    for (( i = 1; i <= n; i++ )); do
+        printf 'draft %s\n' "$i" > "$ROOT_DIR/$dir/draft-$i.$ext"
+    done
+}
+
+# Count files matching the clean globs across all scratch dirs.
+count_scratch() {
+    local total=0
+    total=$(( total + $(find "$ROOT_DIR/.issues" -maxdepth 1 -name '*.md' -type f | wc -l) ))
+    total=$(( total + $(find "$ROOT_DIR/.crs" -maxdepth 1 -name '*.md' -type f | wc -l) ))
+    total=$(( total + $(find "$ROOT_DIR/.commits" -maxdepth 1 -name '*.md' -type f | wc -l) ))
+    total=$(( total + $(find "$ROOT_DIR/.outputs" -maxdepth 1 -name '*.txt' -type f | wc -l) ))
+    total=$(( total + $(find "$ROOT_DIR/.tmp" -mindepth 1 -maxdepth 1 | wc -l) ))
+    echo "$total"
+}
+
+run_ws() {
+    run "$TIMEOUT_BIN" 10 bash "$WS_BIN" "$@"
+}


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @Cervator via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

`ws clean` now embeds a mining-cadence check instead of deleting unconditionally. The scratch files it sweeps (`.commits/`, `.crs/`, `.issues/`, `.outputs/`, `.tmp/`) double as mining material for the gdd-housekeeping "mine scratch dirs" step — clearing them reflexively after every commit/CR starves that step. The threshold puts the cadence in the tool itself, so it doesn't depend on the agent remembering a convention.

- **Count-first, then decide.** `ws clean` tallies what it would remove. If the total is **below `$WS_CLEAN_MINE_THRESHOLD` (default 50)** and `--force` is not given, it prints a per-dir breakdown + a "holding off" nudge and deletes nothing. At/above threshold, or with `--force`, it cleans as before.
- **`--force` override.** The agent re-runs with `--force` when the user explicitly asked to clean, or right after a mining pass — otherwise it backs off. Env-overridable floor via `WS_CLEAN_MINE_THRESHOLD` (invalid values warn + fall back to 50).
- **Dispatcher `ROOT_DIR` honoring.** Changed the `ws` dispatcher to honor a pre-set `ROOT_DIR` (`: "${ROOT_DIR:=…}"`, matching `ws-commit.sh`) so the new tests can isolate against a temp workspace. Unset in normal use → still resolves to the script's parent, so production behavior is unchanged.

## Test plan

- [x] `bash scripts/ws test yggdrasil` — full suite green (**182** tests, +9 new; 2 platform-skipped on Windows).
- [x] New `tests/ws-clean/` suite: threshold boundary (below holds off, at/above cleans), `--force` override, env threshold + invalid-value fallback, multi-dir + `.tmp` counting, `--help`, unknown-flag error.
- [x] Manual: isolated-dir runs confirm hold-off (3 files / threshold 5) and clean (2 files / threshold 2, and `--force`).

## Notes for reviewers

- The `ROOT_DIR` change is the one bit beyond `ws clean` itself — it's a behavior-preserving consistency fix (the dispatcher was the only thing overwriting an env-supplied `ROOT_DIR`; `ws-commit.sh` already used `:=`). It's what makes the scratch-dir tests isolate instead of operating on the real workspace.
- Default threshold 50 is a starting guess; it's env-tunable, so we can adjust after seeing real accumulation rates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI: `clean` command now supports `--force` and `--help`, performs a two-phase scan of draft and temporary locations, prints a per-location breakdown, respects a configurable threshold (holds off with guidance unless forced), deletes eligible drafts and top-level temp entries while preserving the temp container, and reports a final cleaned-count message.

* **Tests**
  * Added comprehensive tests for threshold gating, `--force`, `--help`, counting across locations, edge cases (spaces, empty scratch), and invalid-threshold handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SiliconSaga/yggdrasil/pull/73?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->