### PR TITLE
feat(hoard): provenance-tracked ws hoard upgrade v2 (plan/apply/rollback)

### DIFF
--- a/.agent/skills/gdd-hoard-upgrade/SKILL.md
+++ b/.agent/skills/gdd-hoard-upgrade/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: gdd-hoard-upgrade
+description: Use when upgrading a hoard from its template (ws hoard upgrade) — runs the plan, proposes destructive/region changes to the human, then applies with a backup.
+---
+
+# Upgrading a hoard
+
+Drives the provenance-tracked `ws hoard upgrade` flow: plan → propose → apply. The script is deterministic; this skill is the judgment + human-approval layer between `--plan` and `--apply`.
+
+1. Run `ws hoard upgrade <hoard> --plan` (add `--template <name>` if the hoard has no `.hoard.yaml` yet — that adopts it at a baseline one version behind so only the latest bump applies). Read the classified plan lines: `uptodate`, `provenance`, `additive`, `region-insert`, `region-edit`, `destructive`.
+2. If the only line is `uptodate`: stop, report nothing to do.
+3. `additive` lines (enable a new plugin, seed a new config) and `provenance` are safe — note them, no approval needed.
+4. For each `region-insert`: open the target file, and propose an exact insertion point to the human (the script's mechanical default is append-to-end; suggest a better spot if the file has obvious structure). For `region-edit`: show the human the diff of the managed block. For `destructive` (remove a file, disable a core plugin): name the file/plugin and why the template changes it, and get explicit approval.
+5. Once the human has approved the `region-*` and `destructive` lines, run `ws hoard upgrade <hoard> --apply`. It snapshots the whole hoard to `.upgrade-backup/<ts>/` first, then applies. Report the backup path it prints.
+6. Tell the human to open the hoard in Obsidian (plugins activate on launch). If anything looks wrong, `ws hoard upgrade <hoard> --rollback` restores the pre-apply snapshot so they can retry.
+
+**Never** run `--apply` before the human has approved the `destructive` and `region-*` lines from `--plan`. `additive`-only plans may be applied once the human has seen the plan.

--- a/docs/gdd/hoards.md
+++ b/docs/gdd/hoards.md
@@ -181,6 +181,22 @@ pattern.
 
 ---
 
+## Upgrading a hoard
+
+A hoard tracks where it came from in a git-committed `.hoard.yaml` at its root — the source `template` and the `applied_version` of that template's recipe last applied. `ws hoard init` writes it; existing hoards adopt it on first upgrade (see below).
+
+Templates evolve — a new plugin, a new managed block on a dashboard — and `ws hoard upgrade <hoard>` is how a hoard catches up. It is provenance-tracked and plan-first, so it never guesses which template applies and never changes anything without showing you first:
+
+- `ws hoard upgrade <hoard> --plan` reads the template from `.hoard.yaml`, diffs the template's desired state against your live hoard, and prints a classified change set — additive (enable a new plugin), region edits (a template-managed block inside a file, delimited by `<!-- BEGIN upgrade-<id> -->` sentinels), and destructive (remove a file, disable a core plugin) — touching nothing.
+- `ws hoard upgrade <hoard> --apply` snapshots the whole hoard to `.upgrade-backup/<timestamp>/` first, then applies the plan and bumps `applied_version`. If the backup can't be taken, it aborts before changing anything.
+- `ws hoard upgrade <hoard> --rollback` restores the most recent snapshot, so you can apply, inspect in Obsidian, and retry until it's clean.
+
+The `gdd-hoard-upgrade` skill drives the loop: it runs `--plan`, proposes the destructive and region changes to you for approval (additive changes are safe), and only then runs `--apply`. A hoard that predates `.hoard.yaml` is adopted with `--template <name>`, which records provenance at a baseline one version behind the template so only the newest change applies rather than re-applying the whole recipe.
+
+(Plugin `data.json` is currently overwritten on apply rather than merged, so per-hoard plugin-setting tweaks don't yet survive an upgrade — tracked as future work.)
+
+---
+
 ## Future hoard types
 
 Hoards are intentionally generic; thalami is just the first type

--- a/docs/plans/2026-05-23-hoard-upgrade-v2-design.md
+++ b/docs/plans/2026-05-23-hoard-upgrade-v2-design.md
@@ -25,6 +25,7 @@ The goal is to re-enable the command by replacing blind apply with a provenance-
 
 - **Software-component upgrades (Dependabot-style).** The provenance + version concept is meant to generalize to `components/` later, but nothing component-facing is built now. The design only avoids decisions that would foreclose it.
 - **Three-way JSON merge for `data.json`.** The current overwrite-on-apply behavior for plugin `data.json` is kept. `thalami`'s recipe is tiny, so the risk is low; the three-way merge cited in the yggdrasil#54 follow-up is deferred.
+- **Merging `community-plugins.json`.** The template is authoritative for the *enabled-plugin set*: `--apply` overwrites `community-plugins.json` with exactly the template's plugin ids, so any extra plugin a user enabled in a managed hoard would be disabled on upgrade. Acceptable for `thalami` (no extra plugins expected); a union-merge is deferred alongside the `data.json` merge.
 - **A general filter/sort UX for `ArcDashboard`.** The Meta Bind controls region added here is the first concrete managed-region, not a full dashboard redesign.
 
 ## Architecture

--- a/docs/plans/2026-05-23-hoard-upgrade-v2-design.md
+++ b/docs/plans/2026-05-23-hoard-upgrade-v2-design.md
@@ -1,0 +1,174 @@
+# `ws hoard upgrade` v2 — provenance-tracked, plan/apply, agent-mediated
+
+**Status:** design (brainstormed 2026-05-23). Implementation plan: [`2026-05-23-hoard-upgrade-v2-plan.md`](2026-05-23-hoard-upgrade-v2-plan.md).
+
+## Problem
+
+`ws hoard upgrade` is currently disabled behind a `WS_HOARD_UPGRADE_ENABLED=1` gate. The reasons it was disabled (see `scripts/ws-hoard-upgrade.sh` header + the 2026-05-22 Thalamus observation):
+
+- **No provenance.** The command auto-discovers "the one template that ships an `.upgrade/upgrade.yaml`" (today only `obsidian-vault`) and applies it to *any* hoard named — so running it against a `thalami` hoard pushed the full PARA-vault plugin suite (Templater, Periodic Notes, Calendar, **Linter**, **Filename Heading Sync**, …) onto a vault that only wants Dataview. Linter (auto-format on save) and Filename Heading Sync (renames H1/filename) would then edit the thalamus files on next Obsidian open.
+- **Blind apply.** Even with the right template, the run overwrites `data.json` files, rewrites `community-plugins.json`, disables core plugins, and `rm`s declared files with no preview and no consent. There is no diff, no backup, no human gate.
+
+The goal is to re-enable the command by replacing blind apply with a provenance-tracked, plan-first, agent-mediated, human-approved flow — and to prove it on a real change (`thalami` gaining the Meta Bind plugin plus interactive controls on `ArcDashboard.md`).
+
+## Goals
+
+- **Provenance:** every hoard records which template it came from and which version it has been upgraded to, so the tool never guesses.
+- **Declarative desired-state + reconcile:** the template declares the desired end state (plugins, disabled core plugins, removed files, template-managed file regions) plus a `version`; the tool diffs that against the live hoard and decides what to change.
+- **Plan / apply split:** `--plan` computes and prints the change set, touching nothing; `--apply` executes an approved plan after taking a backup.
+- **Agent-mediated approval:** a `gdd-hoard-upgrade` skill runs `--plan`, lets the agent interpret it and propose the risky changes (destructive ops, edits to user-customized files) to the human, and only then runs `--apply`.
+- **Backup + rollback:** `--apply` snapshots the whole hoard before changing it; `--rollback` restores the latest snapshot, so an upgrade can be applied, inspected, and retried until clean.
+- **`thalami` gets its own recipe:** a minimal `.upgrade/upgrade.yaml` so it is no longer mismatched against `obsidian-vault`'s.
+- **Re-enable:** drop the `WS_HOARD_UPGRADE_ENABLED` gate once provenance resolves the template.
+
+## Non-goals (explicit future seams, not built here)
+
+- **Software-component upgrades (Dependabot-style).** The provenance + version concept is meant to generalize to `components/` later, but nothing component-facing is built now. The design only avoids decisions that would foreclose it.
+- **Three-way JSON merge for `data.json`.** The current overwrite-on-apply behavior for plugin `data.json` is kept. `thalami`'s recipe is tiny, so the risk is low; the three-way merge cited in the yggdrasil#54 follow-up is deferred.
+- **A general filter/sort UX for `ArcDashboard`.** The Meta Bind controls region added here is the first concrete managed-region, not a full dashboard redesign.
+
+## Architecture
+
+### Provenance — `.hoard.yaml`
+
+Each hoard carries a git-committed `.hoard.yaml` at its root:
+
+```yaml
+template: thalami
+applied_version: 1
+```
+
+- `template` names the template directory under `templates/hoards/<template>/` the hoard was scaffolded from.
+- `applied_version` is the integer `version` of that template's `.upgrade/upgrade.yaml` last successfully applied.
+- Git-committed (not under gitignored `.obsidian/`) because it is the durable hoard→template link, shared across the hoard's machines.
+
+`ws hoard init` writes `.hoard.yaml` for new hoards (with `applied_version` set to the template's current `version`). Existing hoards are retrofitted (see "Adopting existing hoards").
+
+### Manifest — versioned `.upgrade/upgrade.yaml`
+
+The existing declarative manifest gains a top-level `version` (monotonic integer) and a `managed_regions` block. Existing keys (`plugins`, `core_plugins_disable`, `files_remove`) keep their meaning. Example (`thalami`, see worked example below):
+
+```yaml
+version: 2
+description: |
+  Thalami hoard — Dataview for the ArcDashboard, plus Meta Bind for
+  the dashboard's interactive controls.
+plugins:
+  - id: dataview
+    name: Dataview
+    description: Query engine powering ArcDashboard.md.
+    repo: blacksmithgu/obsidian-dataview
+    pin: "0.5.68"
+  - id: obsidian-meta-bind-plugin
+    name: Meta Bind
+    description: Inline inputs/buttons bound to frontmatter; powers the ArcDashboard controls.
+    repo: mProjectsCode/obsidian-meta-bind-plugin
+    pin: "1.4.1"        # pin verified at implementation time
+managed_regions:
+  - file: ArcDashboard.md
+    id: controls
+    source: regions/arcdashboard-controls.md   # relative to .upgrade/
+```
+
+- `version` is what `applied_version` is compared against. The tool applies the manifest when `applied_version < version`.
+- `managed_regions` declares parts of a content file the template owns. `file` is hoard-relative; `id` is the sentinel slug; `source` is a file under `.upgrade/` whose contents fill the region. The managed text lives between `<!-- BEGIN upgrade-<id> -->` and `<!-- END upgrade-<id> -->` markers — the same mechanism the README "Installed plugins" block already uses (`_ws_hoard_upgrade_from_template` in the current script).
+
+The manifest describes a **desired end state**, not per-version migration scripts. The `version` is a coarse "has this hoard seen the current recipe?" marker, not a sequence of ordered steps. (If per-version ordering is ever needed — e.g. a change that must run before another — that is a future extension; YAGNI now with two templates.)
+
+### Flow — `--plan` → propose → `--apply`
+
+```
+ws hoard upgrade <hoard> --plan
+  1. Read <hoard>/.hoard.yaml → template + applied_version.
+     (If absent: emit a "establish provenance" step — see Adopting existing hoards.)
+  2. Read templates/hoards/<template>/.upgrade/upgrade.yaml → version + desired state.
+  3. If applied_version >= version: report "up to date", empty plan.
+  4. Else diff desired-state vs the live hoard and classify each change:
+       additive    — enable a not-yet-present plugin, seed a new data.json,
+                     insert a managed region whose markers are absent
+       region-edit — replace the content inside an existing managed region
+       destructive — disable a core plugin, remove a declared file, or
+                     overwrite an existing data.json
+  5. Print the plan (human-readable + a machine-readable form), change NOTHING.
+
+[gdd-hoard-upgrade skill]
+  - Runs --plan, reads the classified plan.
+  - Auto-OK for additive ops.
+  - For each region-edit and destructive op: show the human exactly what
+    changes (the region diff, the file to be removed), get approval.
+  - On approval, runs --apply.
+
+ws hoard upgrade <hoard> --apply
+  1. Recompute the plan (same logic as --plan).
+  2. Backup: copy the whole hoard to <hoard>/.upgrade-backup/<timestamp>/
+     (excluding .git/ and .upgrade-backup/ itself). Abort the apply if the
+     backup fails — never change the hoard without a restore point.
+  3. Execute the plan: download plugins, seed data.json, write
+     community-plugins.json, disable core plugins, remove files, splice
+     managed regions.
+  4. Write <hoard>/.hoard.yaml with applied_version = version.
+  5. Report what changed and where the backup lives.
+
+ws hoard upgrade <hoard> --rollback
+  - Restore the most recent <hoard>/.upgrade-backup/<timestamp>/ over the
+    hoard (the inverse copy), so a botched upgrade can be undone and retried.
+```
+
+The script stays deterministic: it classifies and applies, but it does not decide whether a destructive op is acceptable — that judgment is the skill+human's. The plan is the contract between them.
+
+### Managed regions
+
+A managed region is delimited by `<!-- BEGIN upgrade-<id> -->` / `<!-- END upgrade-<id> -->` sentinels inside a content file. On apply:
+
+- **Markers present:** replace everything between them with the region `source` content (idempotent; user content outside the markers is untouched). This is a region-edit.
+- **Markers absent:** the region has never been inserted. The plan classifies this as additive-insert, but *where* to put it in a user-customized file is a judgment call — so the plan flags it for the agent, which proposes an insertion point (e.g. "after the H1, before the first `dataview` block in `ArcDashboard.md`") for the human to approve. Once inserted with markers, all future upgrades are clean marker-replacements.
+
+This keeps the template's ownership scoped to the marked block and never clobbers the surrounding note.
+
+### Adopting existing hoards
+
+The four live `thalami` hoards predate `.hoard.yaml`. On the first `--plan` against a hoard with no `.hoard.yaml`:
+
+- The tool infers the template. For a single-machine run this is unambiguous only if told; to stay safe it does **not** guess across templates. Resolution order: (a) explicit `--template <name>` flag, else (b) if the hoard name or contents match exactly one template's signature (e.g. an `ArcDashboard.md` + `Intake.md` ⇒ `thalami`), use it, else (c) error asking for `--template`.
+- The plan's first step is **establish-provenance**: write `.hoard.yaml` with `applied_version` set to a **baseline** — the version representing the hoard's current shipped state (for the live thalami hoards: the pre-Meta-Bind baseline, `version: 1`). This ensures the very next change (`version: 2`, Meta Bind + controls) is what applies, rather than re-applying the whole recipe from zero.
+
+### Re-enable
+
+Once `.hoard.yaml` provenance exists and `thalami` ships its own `.upgrade/upgrade.yaml`, the `WS_HOARD_UPGRADE_ENABLED` gate and the "multiple upgradeable templates" error are removed: the template is read from `.hoard.yaml`, so there is no cross-template misapplication to guard against. `ws hoard init`'s existing call into the internal apply path is unaffected (it already passes an explicit template).
+
+## Worked example — `thalami` v1 → v2 (the test vehicle)
+
+1. **`thalami` template gains `.upgrade/upgrade.yaml`** at `version: 1` describing the current baseline: Dataview only, no managed regions. This is what the live hoards get retrofitted to.
+2. **Bump to `version: 2`:** add the `obsidian-meta-bind-plugin` to `plugins`, and a `managed_regions` entry for `ArcDashboard.md` region `controls`, whose `source` (`regions/arcdashboard-controls.md`) contains the Meta Bind widget block (a refresh button + a filter/sort input bound to dashboard frontmatter — exact widget syntax verified against the pinned Meta Bind version during implementation).
+3. **Upgrade a live hoard:** `ws hoard upgrade thalami-Cervator --plan` ⇒ establish-provenance @ v1 (first run), then v1→v2: additive (enable Meta Bind, download its release) + additive-insert (`ArcDashboard.md` `controls` region, markers absent ⇒ agent proposes placement). No destructive ops in this bump. The skill proposes the ArcDashboard insertion, human approves, `--apply` backs up the hoard, installs Meta Bind, splices the region, writes `.hoard.yaml` @ v2.
+4. **Re-runnable:** a second `--plan` reports up-to-date (`applied_version 2 >= version 2`).
+
+This exercises every new mechanism (provenance write + retrofit, plan classification, additive plugin install, region insert, backup, version bump) on a real, useful change, and is the basis for "test locally then on the three other workspaces."
+
+## Error handling
+
+- **No `.hoard.yaml` and template not resolvable:** error, ask for `--template`.
+- **Template has no `.upgrade/upgrade.yaml`:** error (nothing to upgrade).
+- **`gh` / `jq` / `yq` missing:** error with install hint (as today).
+- **Backup fails (disk, permissions):** abort `--apply` before any change.
+- **`--rollback` with no backup present:** error, no-op.
+- **Plugin download fails mid-apply:** report which plugin/tag failed; the backup is the recovery path (advise `--rollback`).
+- **Managed-region markers malformed (e.g. BEGIN without END):** treat as a conflict, surface to the agent rather than blindly rewriting.
+
+## Testing strategy
+
+bats coverage under `tests/ws-hoard-upgrade/`, isolated via `ROOT_DIR` / `HOARDS_DIR` overrides (the pattern `tests/ws-smoke` and `tests/ws-clean` use), with plugin downloads stubbed (no real `gh` calls in tests — inject a fake downloader or assert on the plan rather than network effects):
+
+- `--plan` classification: additive vs region-edit vs destructive, and "up to date" when `applied_version >= version`.
+- Provenance: `--plan`/`--apply` writes `.hoard.yaml`; retrofit writes the baseline; `--template` override; refusal when template unresolvable.
+- Region splice: insert when markers absent (with an explicit anchor in the test), replace when present, idempotent re-run, malformed-marker conflict.
+- `--apply`: backup directory created before changes; `applied_version` bumped; `files_remove` / `core_plugins_disable` honored.
+- `--rollback`: restores the latest snapshot; errors with no snapshot.
+- Re-enable: command runs without `WS_HOARD_UPGRADE_ENABLED`.
+
+## Deferred / open items
+
+- `data.json` three-way merge (kept as overwrite for now).
+- Per-version ordered migrations (current model is desired-state + a coarse version marker).
+- Component-level upgrades (future seam only).
+- Exact Meta Bind pin + widget syntax — verified during implementation against the live plugin release.

--- a/docs/plans/2026-05-23-hoard-upgrade-v2-design.md
+++ b/docs/plans/2026-05-23-hoard-upgrade-v2-design.md
@@ -77,7 +77,7 @@ The manifest describes a **desired end state**, not per-version migration script
 
 ### Flow — `--plan` → propose → `--apply`
 
-```
+```text
 ws hoard upgrade <hoard> --plan
   1. Read <hoard>/.hoard.yaml → template + applied_version.
      (If absent: emit a "establish provenance" step — see Adopting existing hoards.)

--- a/docs/plans/2026-05-23-hoard-upgrade-v2-plan.md
+++ b/docs/plans/2026-05-23-hoard-upgrade-v2-plan.md
@@ -1,0 +1,1122 @@
+# `ws hoard upgrade` v2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Re-enable `ws hoard upgrade` as a provenance-tracked, plan-first, agent-mediated, backed-up upgrade flow, and prove it by giving `thalami` a Meta Bind plugin + an `ArcDashboard.md` controls region.
+
+**Architecture:** Each hoard gets a git-committed `.hoard.yaml` (`template` + `applied_version`). A template's `.upgrade/upgrade.yaml` gains a `version` and a `managed_regions` block. `ws hoard upgrade <hoard> --plan` resolves the template via `.hoard.yaml`, diffs desired-state vs live, and prints a classified change set without touching anything. `--apply` snapshots the whole hoard to `.upgrade-backup/<ts>/`, executes the plan, and bumps `applied_version`. `--rollback` restores the latest snapshot. A `gdd-hoard-upgrade` skill runs `--plan`, proposes the risky changes to the human, then runs `--apply`. Design: [`2026-05-23-hoard-upgrade-v2-design.md`](2026-05-23-hoard-upgrade-v2-design.md).
+
+**Tech Stack:** Bash (sourced, non-strict-mode functions in `scripts/ws-hoard-upgrade.sh`), `yq` v4 (YAML read), `jq` (JSON patch), `gh` (plugin release download — stubbed in tests), bats (tests under `tests/ws-hoard-upgrade/`).
+
+---
+
+## File Structure
+
+- `scripts/ws-hoard-upgrade.sh` — **modified.** Add provenance read/write, manifest-version read, plan computation/classification, backup, rollback, region splice; refactor `_ws_hoard_upgrade_from_template` so `--apply` reuses its plugin/data/core/files logic; rewrite the public `ws_hoard_upgrade` to dispatch `--plan`/`--apply`/`--rollback`/`--template` and drop the `WS_HOARD_UPGRADE_ENABLED` gate.
+- `scripts/ws-hoard.sh` — **modified.** Update the `upgrade)` dispatch + `ws hoard help` text to mention the new flags. (`ws hoard init` already calls the internal apply path; add the `.hoard.yaml` write there — Task 8.)
+- `scripts/ws` — **modified.** One-line top-comment help update for `hoard upgrade`.
+- `templates/hoards/thalami/.upgrade/upgrade.yaml` — **created.** `version: 1` baseline (Dataview only), then bumped to `version: 2` (adds Meta Bind + the ArcDashboard region) in the same task.
+- `templates/hoards/thalami/.upgrade/regions/arcdashboard-controls.md` — **created.** The Meta Bind controls block spliced into `ArcDashboard.md`.
+- `templates/hoards/thalami/.hoard.yaml` — **created.** Seed provenance shipped with the template (`template: thalami`, `applied_version: <current version>`), copied into new hoards by `ws hoard init`.
+- `templates/hoards/thalami/.gitignore` — **modified.** Ignore `.upgrade-backup/`.
+- `.agent/skills/gdd-hoard-upgrade/SKILL.md` — **created.** Orchestrates plan → propose → apply.
+- `tests/ws-hoard-upgrade/test_helper.bash` — **created.** Isolation harness (`ROOT_DIR`/`HOARDS_DIR`/`TEMPLATES_DIR`), fake-`gh` shim, fixture builders.
+- `tests/ws-hoard-upgrade/upgrade.bats` — **created.** All behavior tests.
+- `docs/gdd/hoards.md` — **modified.** Document the new upgrade flow + `.hoard.yaml`.
+
+**Function naming contract (used across tasks):**
+
+- `_ws_hoard_provenance_read <hoard_dir>` → prints `<template> <applied_version>`, returns 1 if absent/invalid.
+- `_ws_hoard_provenance_write <hoard_dir> <template> <version>`.
+- `_ws_hoard_manifest_version <template_dir>` → prints integer `version`, returns 1 if no manifest.
+- `_ws_hoard_region_splice <file> <id> <source_file>` → insert-with-anchor or replace-between-markers.
+- `_ws_hoard_backup <hoard_dir>` → creates `.upgrade-backup/<ts>/`, prints its path.
+- `_ws_hoard_rollback <hoard_dir>` → restores latest snapshot, returns 1 if none.
+- `_ws_hoard_upgrade_plan <hoard_dir> <template_dir>` → prints classified plan lines `CLASS\tDETAIL`.
+- `ws_hoard_upgrade <hoard> [--plan|--apply|--rollback] [--template <name>]` → public entry.
+
+Plan line classes (stable contract for the skill): `uptodate`, `provenance`, `additive`, `region-insert`, `region-edit`, `destructive`.
+
+---
+
+## Task 1: Provenance read/write (`.hoard.yaml`)
+
+**Files:**
+- Modify: `scripts/ws-hoard-upgrade.sh` (add two functions near the top, after the header comment / before `ws_hoard_upgrade_help`)
+- Create: `tests/ws-hoard-upgrade/test_helper.bash`
+- Create: `tests/ws-hoard-upgrade/upgrade.bats`
+
+- [ ] **Step 1: Write the test helper**
+
+Create `tests/ws-hoard-upgrade/test_helper.bash`:
+
+```bash
+# Shared helpers for ws-hoard-upgrade bats tests.
+#
+# Sources ws-hoard-upgrade.sh directly (it's a function library) and
+# exercises its functions against an isolated TEMPLATES_DIR / HOARDS_DIR
+# under $BATS_TEST_TMPDIR. Plugin downloads are stubbed with a fake `gh`
+# on PATH so no network is touched.
+
+REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+
+setup_dirs() {
+    export ROOT_DIR="$BATS_TEST_TMPDIR/work"
+    export TEMPLATES_DIR="$ROOT_DIR/templates"
+    export HOARDS_DIR="$ROOT_DIR/hoards"
+    mkdir -p "$HOARDS_DIR" "$TEMPLATES_DIR/hoards"
+    # shellcheck source=/dev/null
+    source "$REPO_ROOT/scripts/ws-hoard-upgrade.sh"
+}
+
+# Build a template at $TEMPLATES_DIR/hoards/<name> with the given
+# upgrade.yaml content ($2) and an optional region source file.
+make_template() {
+    local name="$1" yaml="$2"
+    local dir="$TEMPLATES_DIR/hoards/$name"
+    mkdir -p "$dir/.upgrade/regions"
+    printf '%s\n' "$yaml" > "$dir/.upgrade/upgrade.yaml"
+}
+
+# Build a minimal hoard at $HOARDS_DIR/<name> with a .obsidian dir and
+# an empty community-plugins.json. Caller adds files/provenance after.
+make_hoard() {
+    local name="$1"
+    local dir="$HOARDS_DIR/$name"
+    mkdir -p "$dir/.obsidian"
+    printf '[]\n' > "$dir/.obsidian/community-plugins.json"
+}
+
+# Put a fake `gh` on PATH that emulates `gh release download ... --dir D`
+# by writing dummy main.js + manifest.json into D. No network.
+make_fake_gh() {
+    local bindir="$BATS_TEST_TMPDIR/bin"
+    mkdir -p "$bindir"
+    cat > "$bindir/gh" <<'SH'
+#!/usr/bin/env bash
+dir=""; prev=""
+for a in "$@"; do [[ "$prev" == "--dir" ]] && dir="$a"; prev="$a"; done
+if [[ -n "$dir" ]]; then
+  mkdir -p "$dir"
+  printf 'stub\n' > "$dir/main.js"
+  printf '{"id":"stub"}\n' > "$dir/manifest.json"
+fi
+exit 0
+SH
+    chmod +x "$bindir/gh"
+    export PATH="$bindir:$PATH"
+}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `tests/ws-hoard-upgrade/upgrade.bats` with:
+
+```bash
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() { setup_dirs; }
+
+@test "provenance: write then read round-trips" {
+    make_hoard h1
+    _ws_hoard_provenance_write "$HOARDS_DIR/h1" thalami 3
+    run _ws_hoard_provenance_read "$HOARDS_DIR/h1"
+    [ "$status" -eq 0 ]
+    [ "$output" = "thalami 3" ]
+}
+
+@test "provenance: read returns non-zero when absent" {
+    make_hoard h1
+    run _ws_hoard_provenance_read "$HOARDS_DIR/h1"
+    [ "$status" -ne 0 ]
+}
+```
+
+- [ ] **Step 3: Run to verify it fails**
+
+Run: `bash scripts/ws test yggdrasil 'provenance'`
+Expected: FAIL — `_ws_hoard_provenance_write: command not found` (functions don't exist yet).
+
+- [ ] **Step 4: Implement**
+
+In `scripts/ws-hoard-upgrade.sh`, after the header comment block and before `ws_hoard_upgrade_help()`, add:
+
+```bash
+# Read a hoard's provenance. Prints "<template> <applied_version>" on
+# success; returns 1 if .hoard.yaml is missing or has no template.
+_ws_hoard_provenance_read() {
+    local hoard_dir="$1"
+    local f="$hoard_dir/.hoard.yaml"
+    [[ -f "$f" ]] || return 1
+    local tmpl ver
+    tmpl="$(yq '.template // ""' "$f" 2>/dev/null)"
+    ver="$(yq '.applied_version // 0' "$f" 2>/dev/null)"
+    [[ -n "$tmpl" && "$tmpl" != "null" ]] || return 1
+    [[ "$ver" =~ ^[0-9]+$ ]] || ver=0
+    printf '%s %s\n' "$tmpl" "$ver"
+}
+
+# Write a hoard's provenance file (git-committed, hoard root).
+_ws_hoard_provenance_write() {
+    local hoard_dir="$1" template="$2" version="$3"
+    printf 'template: %s\napplied_version: %s\n' "$template" "$version" \
+        > "$hoard_dir/.hoard.yaml"
+}
+```
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `bash scripts/ws test yggdrasil 'provenance'`
+Expected: PASS (2 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/ws-hoard-upgrade.sh tests/ws-hoard-upgrade/
+bash scripts/ws commit yggdrasil .commits/hoard-upgrade-provenance.md
+```
+
+(Bodyfile `message:` = `feat(hoard): add .hoard.yaml provenance read/write`; `add:` = `scripts/ws-hoard-upgrade.sh`, `tests/ws-hoard-upgrade/test_helper.bash`, `tests/ws-hoard-upgrade/upgrade.bats`.)
+
+---
+
+## Task 2: Manifest version read + "up to date" short-circuit
+
+**Files:**
+- Modify: `scripts/ws-hoard-upgrade.sh`
+- Test: `tests/ws-hoard-upgrade/upgrade.bats`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `upgrade.bats`:
+
+```bash
+@test "manifest version: reads the integer version" {
+    make_template thalami "version: 2
+plugins: []"
+    run _ws_hoard_manifest_version "$TEMPLATES_DIR/hoards/thalami"
+    [ "$status" -eq 0 ]
+    [ "$output" = "2" ]
+}
+
+@test "manifest version: returns 1 when no manifest" {
+    mkdir -p "$TEMPLATES_DIR/hoards/empty"
+    run _ws_hoard_manifest_version "$TEMPLATES_DIR/hoards/empty"
+    [ "$status" -ne 0 ]
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `bash scripts/ws test yggdrasil 'manifest version'`
+Expected: FAIL — function not found.
+
+- [ ] **Step 3: Implement**
+
+Add to `scripts/ws-hoard-upgrade.sh` (below the provenance functions):
+
+```bash
+# Print the integer `version` from a template's upgrade.yaml. Returns 1
+# if the manifest is absent. Defaults a missing/invalid version to 0.
+_ws_hoard_manifest_version() {
+    local template_dir="$1"
+    local f="$template_dir/.upgrade/upgrade.yaml"
+    [[ -f "$f" ]] || return 1
+    local v
+    v="$(yq '.version // 0' "$f" 2>/dev/null)"
+    [[ "$v" =~ ^[0-9]+$ ]] || v=0
+    printf '%s\n' "$v"
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `bash scripts/ws test yggdrasil 'manifest version'`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+Bodyfile `message:` = `feat(hoard): read manifest version`; `add:` the two changed files.
+
+---
+
+## Task 3: Plan computation (`--plan`, read-only)
+
+**Files:**
+- Modify: `scripts/ws-hoard-upgrade.sh`
+- Test: `tests/ws-hoard-upgrade/upgrade.bats`
+
+Plan output: one `CLASS<TAB>DETAIL` line per change. Classes: `uptodate`, `additive` (plugin not yet enabled; new data.json), `region-insert` (managed region markers absent in file), `region-edit` (markers present), `destructive` (core plugin currently enabled that will be disabled; `files_remove` target that exists). The function changes nothing.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `upgrade.bats`:
+
+```bash
+@test "plan: up to date when applied_version >= version" {
+    make_template thalami "version: 1
+plugins: []"
+    make_hoard h1
+    _ws_hoard_provenance_write "$HOARDS_DIR/h1" thalami 1
+    run _ws_hoard_upgrade_plan "$HOARDS_DIR/h1" "$TEMPLATES_DIR/hoards/thalami"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"uptodate"* ]]
+}
+
+@test "plan: new plugin is additive" {
+    make_template thalami "version: 2
+plugins:
+  - id: obsidian-meta-bind-plugin
+    name: Meta Bind
+    repo: mProjectsCode/obsidian-meta-bind-plugin
+    pin: \"1.4.1\""
+    make_hoard h1
+    _ws_hoard_provenance_write "$HOARDS_DIR/h1" thalami 1
+    run _ws_hoard_upgrade_plan "$HOARDS_DIR/h1" "$TEMPLATES_DIR/hoards/thalami"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"additive"*"obsidian-meta-bind-plugin"* ]]
+}
+
+@test "plan: managed region with no markers is region-insert" {
+    make_template thalami "version: 2
+plugins: []
+managed_regions:
+  - file: ArcDashboard.md
+    id: controls
+    source: regions/arcdashboard-controls.md"
+    printf 'controls\n' > "$TEMPLATES_DIR/hoards/thalami/.upgrade/regions/arcdashboard-controls.md"
+    make_hoard h1
+    _ws_hoard_provenance_write "$HOARDS_DIR/h1" thalami 1
+    printf '# Dash\n' > "$HOARDS_DIR/h1/ArcDashboard.md"
+    run _ws_hoard_upgrade_plan "$HOARDS_DIR/h1" "$TEMPLATES_DIR/hoards/thalami"
+    [[ "$output" == *"region-insert"*"ArcDashboard.md#controls"* ]]
+}
+
+@test "plan: managed region with markers present is region-edit" {
+    make_template thalami "version: 2
+plugins: []
+managed_regions:
+  - file: ArcDashboard.md
+    id: controls
+    source: regions/arcdashboard-controls.md"
+    printf 'controls\n' > "$TEMPLATES_DIR/hoards/thalami/.upgrade/regions/arcdashboard-controls.md"
+    make_hoard h1
+    _ws_hoard_provenance_write "$HOARDS_DIR/h1" thalami 1
+    printf '# Dash\n<!-- BEGIN upgrade-controls -->\nold\n<!-- END upgrade-controls -->\n' \
+        > "$HOARDS_DIR/h1/ArcDashboard.md"
+    run _ws_hoard_upgrade_plan "$HOARDS_DIR/h1" "$TEMPLATES_DIR/hoards/thalami"
+    [[ "$output" == *"region-edit"*"ArcDashboard.md#controls"* ]]
+}
+
+@test "plan: files_remove target that exists is destructive" {
+    make_template thalami "version: 2
+plugins: []
+files_remove:
+  - .obsidian/daily-notes.json"
+    make_hoard h1
+    _ws_hoard_provenance_write "$HOARDS_DIR/h1" thalami 1
+    printf '{}\n' > "$HOARDS_DIR/h1/.obsidian/daily-notes.json"
+    run _ws_hoard_upgrade_plan "$HOARDS_DIR/h1" "$TEMPLATES_DIR/hoards/thalami"
+    [[ "$output" == *"destructive"*"daily-notes.json"* ]]
+}
+
+@test "plan: changes nothing on disk" {
+    make_template thalami "version: 2
+plugins:
+  - id: obsidian-meta-bind-plugin
+    name: Meta Bind
+    repo: mProjectsCode/obsidian-meta-bind-plugin
+    pin: \"1.4.1\""
+    make_hoard h1
+    _ws_hoard_provenance_write "$HOARDS_DIR/h1" thalami 1
+    before="$(cat "$HOARDS_DIR/h1/.obsidian/community-plugins.json")"
+    _ws_hoard_upgrade_plan "$HOARDS_DIR/h1" "$TEMPLATES_DIR/hoards/thalami" >/dev/null
+    [ "$(cat "$HOARDS_DIR/h1/.obsidian/community-plugins.json")" = "$before" ]
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `bash scripts/ws test yggdrasil 'plan:'`
+Expected: FAIL — function not found.
+
+- [ ] **Step 3: Implement**
+
+Add to `scripts/ws-hoard-upgrade.sh`:
+
+```bash
+# Compute and print the upgrade plan as CLASS<TAB>DETAIL lines, without
+# modifying the hoard. CLASS ∈ uptodate|additive|region-insert|region-edit|
+# destructive. Caller (skill/human) decides on the destructive + region lines.
+_ws_hoard_upgrade_plan() {
+    local hoard_dir="$1" template_dir="$2"
+    local upgrade_yaml="$template_dir/.upgrade/upgrade.yaml"
+    local cp_json="$hoard_dir/.obsidian/community-plugins.json"
+
+    local version applied prov
+    version="$(_ws_hoard_manifest_version "$template_dir")" || return 1
+    if prov="$(_ws_hoard_provenance_read "$hoard_dir")"; then
+        applied="${prov##* }"
+    else
+        applied=-1   # no provenance yet; everything is "new"
+    fi
+    if [[ "$applied" -ge "$version" ]]; then
+        printf 'uptodate\tapplied %s >= version %s\n' "$applied" "$version"
+        return 0
+    fi
+
+    # Plugins: additive if id not already in community-plugins.json.
+    local n i id
+    n="$(yq '.plugins // [] | length' "$upgrade_yaml")"
+    i=0
+    while [[ $i -lt $n ]]; do
+        id="$(yq ".plugins[$i].id" "$upgrade_yaml")"
+        if [[ -f "$cp_json" ]] && jq -e --arg id "$id" 'index($id)' "$cp_json" >/dev/null 2>&1; then
+            :  # already enabled — no change
+        else
+            printf 'additive\tenable plugin %s\n' "$id"
+        fi
+        i=$((i+1))
+    done
+
+    # Managed regions: insert (markers absent) vs edit (markers present).
+    local rn ri rfile rid begin
+    rn="$(yq '.managed_regions // [] | length' "$upgrade_yaml")"
+    ri=0
+    while [[ $ri -lt $rn ]]; do
+        rfile="$(yq ".managed_regions[$ri].file" "$upgrade_yaml")"
+        rid="$(yq ".managed_regions[$ri].id" "$upgrade_yaml")"
+        begin="<!-- BEGIN upgrade-$rid -->"
+        if [[ -f "$hoard_dir/$rfile" ]] && grep -qF "$begin" "$hoard_dir/$rfile" 2>/dev/null; then
+            printf 'region-edit\t%s#%s\n' "$rfile" "$rid"
+        else
+            printf 'region-insert\t%s#%s\n' "$rfile" "$rid"
+        fi
+        ri=$((ri+1))
+    done
+
+    # files_remove: destructive when the target exists.
+    local fn fi rel
+    fn="$(yq '.files_remove // [] | length' "$upgrade_yaml")"
+    fi=0
+    while [[ $fi -lt $fn ]]; do
+        rel="$(yq ".files_remove[$fi]" "$upgrade_yaml")"
+        [[ -e "$hoard_dir/$rel" ]] && printf 'destructive\tremove %s\n' "$rel"
+        fi=$((fi+1))
+    done
+
+    # core_plugins_disable: destructive when currently enabled.
+    local cn ci cid core_json
+    core_json="$hoard_dir/.obsidian/core-plugins.json"
+    cn="$(yq '.core_plugins_disable // [] | length' "$upgrade_yaml")"
+    ci=0
+    while [[ $ci -lt $cn ]]; do
+        cid="$(yq ".core_plugins_disable[$ci]" "$upgrade_yaml")"
+        if [[ -f "$core_json" ]] && jq -e --arg id "$cid" \
+            'if type=="array" then index($id) else .[$id] == true end' \
+            "$core_json" >/dev/null 2>&1; then
+            printf 'destructive\tdisable core plugin %s\n' "$cid"
+        fi
+        ci=$((ci+1))
+    done
+}
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `bash scripts/ws test yggdrasil 'plan:'`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+Bodyfile `message:` = `feat(hoard): compute classified upgrade plan (read-only)`.
+
+---
+
+## Task 4: Whole-hoard backup + rollback
+
+**Files:**
+- Modify: `scripts/ws-hoard-upgrade.sh`
+- Test: `tests/ws-hoard-upgrade/upgrade.bats`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `upgrade.bats`:
+
+```bash
+@test "backup: snapshots hoard contents, excludes .git and .upgrade-backup" {
+    make_hoard h1
+    printf 'hello\n' > "$HOARDS_DIR/h1/note.md"
+    mkdir -p "$HOARDS_DIR/h1/.git"; printf 'x\n' > "$HOARDS_DIR/h1/.git/config"
+    run _ws_hoard_backup "$HOARDS_DIR/h1"
+    [ "$status" -eq 0 ]
+    local snap="$output"
+    [ -f "$snap/note.md" ]
+    [ ! -e "$snap/.git" ]
+    [ ! -e "$snap/.upgrade-backup" ]
+}
+
+@test "rollback: restores the latest snapshot" {
+    make_hoard h1
+    printf 'original\n' > "$HOARDS_DIR/h1/note.md"
+    _ws_hoard_backup "$HOARDS_DIR/h1" >/dev/null
+    printf 'changed\n' > "$HOARDS_DIR/h1/note.md"
+    run _ws_hoard_rollback "$HOARDS_DIR/h1"
+    [ "$status" -eq 0 ]
+    [ "$(cat "$HOARDS_DIR/h1/note.md")" = "original" ]
+}
+
+@test "rollback: errors when no snapshot exists" {
+    make_hoard h1
+    run _ws_hoard_rollback "$HOARDS_DIR/h1"
+    [ "$status" -ne 0 ]
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `bash scripts/ws test yggdrasil 'backup:|rollback:'`
+Expected: FAIL — functions not found.
+
+- [ ] **Step 3: Implement**
+
+Add to `scripts/ws-hoard-upgrade.sh`:
+
+```bash
+# Snapshot the whole hoard into .upgrade-backup/<timestamp>/, excluding
+# .git/ and .upgrade-backup/ itself. Prints the snapshot path. Returns 1
+# on failure so callers can abort an apply before touching anything.
+_ws_hoard_backup() {
+    local hoard_dir="$1"
+    local ts snap
+    ts="$(date '+%Y%m%d-%H%M%S')"
+    snap="$hoard_dir/.upgrade-backup/$ts"
+    mkdir -p "$snap" || return 1
+    local entry base
+    for entry in "$hoard_dir"/* "$hoard_dir"/.[!.]*; do
+        [[ -e "$entry" ]] || continue
+        base="$(basename "$entry")"
+        [[ "$base" == ".git" || "$base" == ".upgrade-backup" ]] && continue
+        cp -R "$entry" "$snap/" || return 1
+    done
+    printf '%s\n' "$snap"
+}
+
+# Restore the most recent .upgrade-backup/<ts>/ over the hoard. Returns 1
+# if there is no snapshot.
+_ws_hoard_rollback() {
+    local hoard_dir="$1"
+    local backups_dir="$hoard_dir/.upgrade-backup"
+    [[ -d "$backups_dir" ]] || return 1
+    local latest
+    latest="$(find "$backups_dir" -mindepth 1 -maxdepth 1 -type d | sort | tail -n 1)"
+    [[ -n "$latest" ]] || return 1
+    local entry base
+    for entry in "$latest"/* "$latest"/.[!.]*; do
+        [[ -e "$entry" ]] || continue
+        base="$(basename "$entry")"
+        rm -rf "$hoard_dir/$base"
+        cp -R "$entry" "$hoard_dir/"
+    done
+    printf 'Restored %s\n' "$latest"
+}
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `bash scripts/ws test yggdrasil 'backup:|rollback:'`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+Bodyfile `message:` = `feat(hoard): whole-hoard backup + rollback`.
+
+---
+
+## Task 5: Managed-region splice (insert / replace)
+
+**Files:**
+- Modify: `scripts/ws-hoard-upgrade.sh`
+- Test: `tests/ws-hoard-upgrade/upgrade.bats`
+
+Insert (markers absent): append the wrapped region to the end of the file (deterministic, no fragile anchor heuristic in the script — the skill proposes an exact location to the human, but the mechanical default is append; see design "Managed regions"). Replace (markers present): swap the content between markers, preserving everything outside.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `upgrade.bats`:
+
+```bash
+@test "region splice: inserts wrapped block when markers absent" {
+    make_hoard h1
+    printf '# Dash\nbody\n' > "$HOARDS_DIR/h1/ArcDashboard.md"
+    printf 'CONTROLS\n' > "$BATS_TEST_TMPDIR/src.md"
+    run _ws_hoard_region_splice "$HOARDS_DIR/h1/ArcDashboard.md" controls "$BATS_TEST_TMPDIR/src.md"
+    [ "$status" -eq 0 ]
+    grep -qF "<!-- BEGIN upgrade-controls -->" "$HOARDS_DIR/h1/ArcDashboard.md"
+    grep -qF "CONTROLS" "$HOARDS_DIR/h1/ArcDashboard.md"
+    grep -qF "# Dash" "$HOARDS_DIR/h1/ArcDashboard.md"
+}
+
+@test "region splice: replaces between markers, preserves outside" {
+    make_hoard h1
+    printf '# Dash\n<!-- BEGIN upgrade-controls -->\nOLD\n<!-- END upgrade-controls -->\ntail\n' \
+        > "$HOARDS_DIR/h1/ArcDashboard.md"
+    printf 'NEW\n' > "$BATS_TEST_TMPDIR/src.md"
+    run _ws_hoard_region_splice "$HOARDS_DIR/h1/ArcDashboard.md" controls "$BATS_TEST_TMPDIR/src.md"
+    [ "$status" -eq 0 ]
+    grep -qF "NEW" "$HOARDS_DIR/h1/ArcDashboard.md"
+    ! grep -qF "OLD" "$HOARDS_DIR/h1/ArcDashboard.md"
+    grep -qF "tail" "$HOARDS_DIR/h1/ArcDashboard.md"
+}
+
+@test "region splice: idempotent on re-run with same source" {
+    make_hoard h1
+    printf '# Dash\n' > "$HOARDS_DIR/h1/ArcDashboard.md"
+    printf 'NEW\n' > "$BATS_TEST_TMPDIR/src.md"
+    _ws_hoard_region_splice "$HOARDS_DIR/h1/ArcDashboard.md" controls "$BATS_TEST_TMPDIR/src.md"
+    _ws_hoard_region_splice "$HOARDS_DIR/h1/ArcDashboard.md" controls "$BATS_TEST_TMPDIR/src.md"
+    run grep -cF "<!-- BEGIN upgrade-controls -->" "$HOARDS_DIR/h1/ArcDashboard.md"
+    [ "$output" -eq 1 ]
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `bash scripts/ws test yggdrasil 'region splice'`
+Expected: FAIL — function not found.
+
+- [ ] **Step 3: Implement**
+
+Add to `scripts/ws-hoard-upgrade.sh`:
+
+```bash
+# Splice a template-managed region into a file. If the BEGIN marker is
+# present, replace everything between BEGIN/END; otherwise append a freshly
+# wrapped block. Content outside the markers is preserved verbatim.
+_ws_hoard_region_splice() {
+    local file="$1" id="$2" source_file="$3"
+    local begin="<!-- BEGIN upgrade-$id -->"
+    local end="<!-- END upgrade-$id -->"
+    local out
+    out="$(mktemp)"
+    if [[ -f "$file" ]] && grep -qF "$begin" "$file" 2>/dev/null; then
+        awk -v b="$begin" -v e="$end" -v insert="$source_file" '
+            $0 == b { print; while ((getline line < insert) > 0) print line; close(insert); skip=1; next }
+            $0 == e { skip=0 }
+            !skip { print }
+        ' "$file" > "$out"
+    else
+        {
+            [[ -f "$file" ]] && cat "$file"
+            printf '\n%s\n' "$begin"
+            cat "$source_file"
+            printf '%s\n' "$end"
+        } > "$out"
+    fi
+    mv "$out" "$file"
+}
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `bash scripts/ws test yggdrasil 'region splice'`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+Bodyfile `message:` = `feat(hoard): managed-region splice (insert/replace)`.
+
+---
+
+## Task 6: `--apply` (backup → execute → bump provenance)
+
+**Files:**
+- Modify: `scripts/ws-hoard-upgrade.sh` (add `_ws_hoard_upgrade_apply`; it reuses the existing plugin-download / data.json / community-plugins.json / core-disable / files_remove logic already in `_ws_hoard_upgrade_from_template`, then adds region splices + provenance bump)
+- Test: `tests/ws-hoard-upgrade/upgrade.bats`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `upgrade.bats`:
+
+```bash
+@test "apply: backs up, enables plugin, splices region, bumps provenance" {
+    make_fake_gh
+    make_template thalami "version: 2
+plugins:
+  - id: obsidian-meta-bind-plugin
+    name: Meta Bind
+    description: x
+    repo: mProjectsCode/obsidian-meta-bind-plugin
+    pin: \"1.4.1\"
+managed_regions:
+  - file: ArcDashboard.md
+    id: controls
+    source: regions/arcdashboard-controls.md"
+    printf 'CONTROLS\n' > "$TEMPLATES_DIR/hoards/thalami/.upgrade/regions/arcdashboard-controls.md"
+    make_hoard h1
+    _ws_hoard_provenance_write "$HOARDS_DIR/h1" thalami 1
+    printf '# Dash\n' > "$HOARDS_DIR/h1/ArcDashboard.md"
+
+    run _ws_hoard_upgrade_apply "$HOARDS_DIR/h1" "$TEMPLATES_DIR/hoards/thalami"
+    [ "$status" -eq 0 ]
+    # backup exists
+    [ -n "$(find "$HOARDS_DIR/h1/.upgrade-backup" -mindepth 1 -maxdepth 1 -type d)" ]
+    # plugin enabled
+    jq -e 'index("obsidian-meta-bind-plugin")' "$HOARDS_DIR/h1/.obsidian/community-plugins.json"
+    # region spliced
+    grep -qF "CONTROLS" "$HOARDS_DIR/h1/ArcDashboard.md"
+    # provenance bumped
+    run _ws_hoard_provenance_read "$HOARDS_DIR/h1"
+    [ "$output" = "thalami 2" ]
+}
+
+@test "apply: aborts before changes if backup fails" {
+    make_template thalami "version: 2
+plugins: []"
+    make_hoard h1
+    _ws_hoard_provenance_write "$HOARDS_DIR/h1" thalami 1
+    # Make .upgrade-backup un-creatable by planting a FILE where the dir goes.
+    printf 'x\n' > "$HOARDS_DIR/h1/.upgrade-backup"
+    run _ws_hoard_upgrade_apply "$HOARDS_DIR/h1" "$TEMPLATES_DIR/hoards/thalami"
+    [ "$status" -ne 0 ]
+    # provenance unchanged
+    run _ws_hoard_provenance_read "$HOARDS_DIR/h1"
+    [ "$output" = "thalami 1" ]
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `bash scripts/ws test yggdrasil 'apply:'`
+Expected: FAIL — `_ws_hoard_upgrade_apply` not found.
+
+- [ ] **Step 3: Refactor + implement**
+
+In `scripts/ws-hoard-upgrade.sh`, extract the body of the existing `_ws_hoard_upgrade_from_template` (the plugin download, data.json overlay, community-plugins.json write, core-disable, files_remove, README block — steps 1–6) so it is callable as `_ws_hoard_apply_manifest <template_dir> <hoard_dir>` (pure mechanical apply, no backup, no provenance). Keep `_ws_hoard_upgrade_from_template` as a thin caller of it (so `ws hoard init`'s existing call still works unchanged). Then add:
+
+```bash
+# Apply an upgrade end to end: backup, mechanical manifest apply, region
+# splices, provenance bump. Aborts before any change if the backup fails.
+_ws_hoard_upgrade_apply() {
+    local hoard_dir="$1" template_dir="$2"
+    local version
+    version="$(_ws_hoard_manifest_version "$template_dir")" || return 1
+
+    local snap
+    if ! snap="$(_ws_hoard_backup "$hoard_dir")"; then
+        echo "ERROR: backup failed; aborting upgrade (nothing changed)." >&2
+        return 1
+    fi
+    echo "Backed up hoard to: $snap"
+
+    # Mechanical manifest apply (plugins, data.json, community-plugins.json,
+    # core-disable, files_remove, README block) — the extracted helper.
+    _ws_hoard_apply_manifest "$template_dir" "$hoard_dir" || return 1
+
+    # Managed regions.
+    local upgrade_yaml="$template_dir/.upgrade/upgrade.yaml"
+    local rn ri rfile rid rsrc
+    rn="$(yq '.managed_regions // [] | length' "$upgrade_yaml")"
+    ri=0
+    while [[ $ri -lt $rn ]]; do
+        rfile="$(yq ".managed_regions[$ri].file" "$upgrade_yaml")"
+        rid="$(yq ".managed_regions[$ri].id" "$upgrade_yaml")"
+        rsrc="$(yq ".managed_regions[$ri].source" "$upgrade_yaml")"
+        _ws_hoard_region_splice "$hoard_dir/$rfile" "$rid" "$template_dir/.upgrade/$rsrc"
+        echo "Spliced region $rfile#$rid"
+        ri=$((ri+1))
+    done
+
+    # Provenance bump — last, so a mid-apply failure leaves it un-bumped
+    # and the upgrade is safely retryable.
+    local prov template
+    prov="$(_ws_hoard_provenance_read "$hoard_dir" 2>/dev/null)" || prov=""
+    template="$(basename "$template_dir")"
+    _ws_hoard_provenance_write "$hoard_dir" "$template" "$version"
+}
+```
+
+Note: `_ws_hoard_apply_manifest` must tolerate a manifest with `plugins: []` (the existing loop already guards `plugin_count > 0`). Confirm the extraction kept those guards.
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `bash scripts/ws test yggdrasil 'apply:'`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Regression-check init path**
+
+Run: `bash scripts/ws test yggdrasil 'standard flow'`
+Expected: PASS — the existing `ws hoard init` flow tests (which call `_ws_hoard_upgrade_from_template`) still pass after the extraction.
+
+- [ ] **Step 6: Commit**
+
+Bodyfile `message:` = `feat(hoard): --apply (backup, manifest apply, regions, provenance bump)`.
+
+---
+
+## Task 7: Public command wiring + remove disable gate
+
+**Files:**
+- Modify: `scripts/ws-hoard-upgrade.sh` (rewrite `ws_hoard_upgrade` + `ws_hoard_upgrade_help`)
+- Modify: `scripts/ws-hoard.sh` (the `upgrade)` dispatch already calls `ws_hoard_upgrade "$@"`; verify it forwards all args — adjust if it only forwards `$2`)
+- Modify: `scripts/ws` (top-comment help line for `hoard upgrade`)
+- Test: `tests/ws-hoard-upgrade/upgrade.bats`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `upgrade.bats`:
+
+```bash
+@test "command: --plan prints a plan and changes nothing, no enable gate needed" {
+    unset WS_HOARD_UPGRADE_ENABLED
+    make_template thalami "version: 2
+plugins:
+  - id: obsidian-meta-bind-plugin
+    name: Meta Bind
+    repo: mProjectsCode/obsidian-meta-bind-plugin
+    pin: \"1.4.1\""
+    make_hoard h1
+    _ws_hoard_provenance_write "$HOARDS_DIR/h1" thalami 1
+    run ws_hoard_upgrade h1 --plan
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"additive"* ]]
+}
+
+@test "command: errors when hoard has no provenance and no --template" {
+    make_template thalami "version: 1
+plugins: []"
+    make_hoard h1   # no .hoard.yaml
+    run ws_hoard_upgrade h1 --plan
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"--template"* ]]
+}
+
+@test "command: --template establishes provenance then plans" {
+    make_template thalami "version: 2
+plugins: []
+managed_regions:
+  - file: ArcDashboard.md
+    id: controls
+    source: regions/arcdashboard-controls.md"
+    printf 'C\n' > "$TEMPLATES_DIR/hoards/thalami/.upgrade/regions/arcdashboard-controls.md"
+    make_hoard h1   # no .hoard.yaml
+    printf '# Dash\n' > "$HOARDS_DIR/h1/ArcDashboard.md"
+    run ws_hoard_upgrade h1 --plan --template thalami
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"provenance"* ]]
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `bash scripts/ws test yggdrasil 'command:'`
+Expected: FAIL — current `ws_hoard_upgrade` is gated/positional-only.
+
+- [ ] **Step 3: Implement**
+
+Replace `ws_hoard_upgrade_help` and `ws_hoard_upgrade` in `scripts/ws-hoard-upgrade.sh`:
+
+```bash
+ws_hoard_upgrade_help() {
+    cat >&2 <<'HELP'
+Usage: ws hoard upgrade <hoard> [--plan | --apply | --rollback] [--template <name>]
+
+  --plan       Show what would change; touch nothing (default).
+  --apply      Back up the hoard, then apply the plan; bump .hoard.yaml.
+  --rollback   Restore the most recent pre-apply backup.
+  --template   Name the source template for a hoard with no .hoard.yaml yet
+               (establishes provenance at the template's current version).
+
+Reads the source template from <hoard>/.hoard.yaml. The gdd-hoard-upgrade
+skill drives the propose-then-apply flow; run it instead of --apply by hand
+when there are destructive or region changes to review.
+HELP
+}
+
+# Public entry. Resolves template via .hoard.yaml (or --template for a
+# not-yet-tracked hoard), then plans / applies / rolls back.
+ws_hoard_upgrade() {
+    local hoard_name="" mode="plan" template_override=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --plan) mode="plan" ;;
+            --apply) mode="apply" ;;
+            --rollback) mode="rollback" ;;
+            --template) shift; template_override="${1:-}" ;;
+            -h|--help) ws_hoard_upgrade_help; return 0 ;;
+            -*) echo "ERROR: unknown flag '$1'" >&2; ws_hoard_upgrade_help; return 1 ;;
+            *) hoard_name="$1" ;;
+        esac
+        shift
+    done
+    if [[ -z "$hoard_name" ]]; then
+        ws_hoard_upgrade_help; return 1
+    fi
+
+    local hoard_dir="$HOARDS_DIR/$hoard_name"
+    if [[ ! -d "$hoard_dir" ]]; then
+        echo "ERROR: hoard not found: $hoard_dir" >&2
+        return 1
+    fi
+
+    if [[ "$mode" == "rollback" ]]; then
+        _ws_hoard_rollback "$hoard_dir" || { echo "ERROR: no backup to roll back to." >&2; return 1; }
+        return 0
+    fi
+
+    # Resolve template + (for not-yet-tracked hoards) establish provenance.
+    local template prov
+    if prov="$(_ws_hoard_provenance_read "$hoard_dir")"; then
+        template="${prov%% *}"
+    elif [[ -n "$template_override" ]]; then
+        template="$template_override"
+        local tv
+        tv="$(_ws_hoard_manifest_version "$TEMPLATES_DIR/hoards/$template")" || {
+            echo "ERROR: template '$template' has no .upgrade/upgrade.yaml" >&2; return 1; }
+        # Establish provenance at a baseline so only newer changes apply.
+        # Baseline = current template version minus pending changes is not
+        # knowable mechanically; we record the template's *current* version
+        # ONLY when it equals the live state. For a brand-new adoption we
+        # set applied_version = (version - 1) so the latest bump applies.
+        local baseline=$(( tv > 0 ? tv - 1 : 0 ))
+        _ws_hoard_provenance_write "$hoard_dir" "$template" "$baseline"
+        echo "provenance	established $template @ $baseline (was untracked)"
+    else
+        echo "ERROR: $hoard_name has no .hoard.yaml; pass --template <name> to adopt it." >&2
+        return 1
+    fi
+
+    local template_dir="$TEMPLATES_DIR/hoards/$template"
+    if [[ ! -f "$template_dir/.upgrade/upgrade.yaml" ]]; then
+        echo "ERROR: template '$template' has no .upgrade/upgrade.yaml" >&2
+        return 1
+    fi
+
+    if [[ "$mode" == "plan" ]]; then
+        _ws_hoard_upgrade_plan "$hoard_dir" "$template_dir"
+    else
+        _ws_hoard_upgrade_apply "$hoard_dir" "$template_dir"
+    fi
+}
+```
+
+Then in `scripts/ws-hoard.sh`, confirm the dispatch forwards all args: the case arm should be `upgrade) shift; ws_hoard_upgrade "$@" ;;` (not `ws_hoard_upgrade "$2"`). Adjust if needed. Update the `ws hoard help` heredoc line for `upgrade` to: `upgrade <hoard> [--plan|--apply|--rollback] [--template <name>]  Provenance-tracked upgrade`.
+
+In `scripts/ws` top comment, change the `hoard upgrade` line to: `#   hoard upgrade <hoard> [--plan|--apply|--rollback]  Provenance-tracked plugin/config upgrade`.
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `bash scripts/ws test yggdrasil 'command:'`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Full suite regression**
+
+Run: `bash scripts/ws test yggdrasil`
+Expected: all green (existing hoard tests + the new suite).
+
+- [ ] **Step 6: Commit**
+
+Bodyfile `message:` = `feat(hoard): wire --plan/--apply/--rollback, drop the disable gate`.
+
+> **Baseline note (resolve during implementation):** the `applied_version = version - 1` baseline assumes the untracked hoard is exactly one bump behind. For the four live thalami hoards adopting at the v1→v2 step this is correct (they are at the v1 baseline). If a hoard could be more than one version behind, pass the true baseline explicitly — extend `--template` to accept `--at-version N` rather than guessing. Keep the simple `version-1` default unless a test shows it's wrong.
+
+---
+
+## Task 8: `ws hoard init` writes `.hoard.yaml`
+
+**Files:**
+- Modify: `scripts/ws-hoard.sh` (the `ws_hoard_init` flow, after the template copy + `_ws_hoard_upgrade_from_template` call)
+- Test: `tests/ws-hoard-init/init.bats` (existing suite)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/ws-hoard-init/init.bats` (mirror that file's existing fixture style):
+
+```bash
+@test "init writes .hoard.yaml provenance for the chosen template" {
+    # (use the suite's existing init invocation for a template that ships
+    #  .upgrade/upgrade.yaml; assert the file + contents)
+    run_hoard_init thalami myhoard
+    [ -f "$HOARDS_DIR/thalami-myhoard/.hoard.yaml" ]
+    grep -qF "template: thalami" "$HOARDS_DIR/thalami-myhoard/.hoard.yaml"
+}
+```
+
+(If the existing init suite uses different helper/argument names, match them — read `tests/ws-hoard-init/test_helper.bash` first.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `bash scripts/ws test yggdrasil 'writes .hoard.yaml'`
+Expected: FAIL — no `.hoard.yaml` written.
+
+- [ ] **Step 3: Implement**
+
+In `ws_hoard_init` (in `scripts/ws-hoard.sh`), after the post-copy apply, add a provenance write set to the template's current version:
+
+```bash
+# Record provenance so `ws hoard upgrade` can resolve the source template.
+if [[ -f "$template_dir/.upgrade/upgrade.yaml" ]]; then
+    _ws_hoard_provenance_write "$hoard_dir" "$template" \
+        "$(_ws_hoard_manifest_version "$template_dir")"
+fi
+```
+
+(`$template`, `$template_dir`, `$hoard_dir` are already in scope in `ws_hoard_init`; confirm the exact variable names while editing.)
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `bash scripts/ws test yggdrasil 'writes .hoard.yaml'`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+Bodyfile `message:` = `feat(hoard): ws hoard init records .hoard.yaml provenance`.
+
+---
+
+## Task 9: `thalami` template recipe + region + gitignore
+
+**Files:**
+- Create: `templates/hoards/thalami/.upgrade/upgrade.yaml`
+- Create: `templates/hoards/thalami/.upgrade/regions/arcdashboard-controls.md`
+- Create: `templates/hoards/thalami/.hoard.yaml`
+- Modify: `templates/hoards/thalami/.gitignore`
+
+- [ ] **Step 1: Verify the Meta Bind release tag**
+
+Run: `gh release list -R mProjectsCode/obsidian-meta-bind-plugin -L 5`
+Pick the latest stable tag; use it as `pin` below (the `1.4.1` in this plan is a placeholder pin that MUST be replaced with the verified tag). Confirm the plugin `id` by checking its `manifest.json` (`gh release download <tag> -R mProjectsCode/obsidian-meta-bind-plugin --pattern manifest.json --dir /tmp/mb && jq .id /tmp/mb/manifest.json`) — expected `obsidian-meta-bind-plugin`.
+
+- [ ] **Step 2: Create the v2 manifest**
+
+`templates/hoards/thalami/.upgrade/upgrade.yaml`:
+
+```yaml
+# Upgrade recipe for thalami hoards. version 1 = the Dataview-only
+# baseline the existing hoards shipped with; version 2 adds Meta Bind and
+# the ArcDashboard controls region.
+version: 2
+description: |
+  Dataview for the ArcDashboard, plus Meta Bind for the dashboard's
+  interactive controls (refresh + filter).
+plugins:
+  - id: dataview
+    name: Dataview
+    description: Query engine powering ArcDashboard.md.
+    repo: blacksmithgu/obsidian-dataview
+    pin: "0.5.68"
+  - id: obsidian-meta-bind-plugin
+    name: Meta Bind
+    description: Inline inputs/buttons bound to frontmatter; powers the ArcDashboard controls.
+    repo: mProjectsCode/obsidian-meta-bind-plugin
+    pin: "REPLACE-WITH-VERIFIED-TAG"   # Step 1
+managed_regions:
+  - file: ArcDashboard.md
+    id: controls
+    source: regions/arcdashboard-controls.md
+```
+
+- [ ] **Step 3: Create the region source**
+
+`templates/hoards/thalami/.upgrade/regions/arcdashboard-controls.md` — a Meta Bind button that force-refreshes Dataview (fixes the stale-`date(today)`), plus a note. Confirm the Meta Bind inline-button syntax against the pinned version's docs while editing; the block shape is:
+
+```markdown
+> [!tip]- Dashboard controls
+> ```meta-bind-button
+> label: "🔄 Refresh"
+> style: default
+> actions:
+>   - type: command
+>     command: dataview:dataview-force-refresh-views
+> ```
+> Refresh if the **Days** column reads negative — Dataview caches `date(today)` until the view re-renders.
+```
+
+- [ ] **Step 4: Seed template `.hoard.yaml`**
+
+`templates/hoards/thalami/.hoard.yaml`:
+
+```yaml
+template: thalami
+applied_version: 2
+```
+
+(New hoards are stamped by Task 8's init write, which recomputes the version; this seed keeps the template self-consistent for anyone copying it directly.)
+
+- [ ] **Step 5: Ignore backups**
+
+Append to `templates/hoards/thalami/.gitignore`:
+
+```gitignore
+# Pre-upgrade snapshots written by `ws hoard upgrade --apply`
+.upgrade-backup/
+```
+
+- [ ] **Step 6: Commit**
+
+Bodyfile `message:` = `feat(thalami): upgrade recipe v2 (Meta Bind + ArcDashboard controls)`.
+
+---
+
+## Task 10: `gdd-hoard-upgrade` skill
+
+**Files:**
+- Create: `.agent/skills/gdd-hoard-upgrade/SKILL.md`
+
+- [ ] **Step 1: Write the skill**
+
+Create `.agent/skills/gdd-hoard-upgrade/SKILL.md` with frontmatter (`name`, `description`) matching the repo's other skills, and a body that encodes the flow:
+
+```markdown
+---
+name: gdd-hoard-upgrade
+description: Use when upgrading a hoard from its template (ws hoard upgrade) — runs the plan, proposes destructive/region changes to the human, then applies with a backup.
+---
+
+# Upgrading a hoard
+
+1. Run `ws hoard upgrade <hoard> --plan` (add `--template <name>` if the hoard has no `.hoard.yaml` yet). Read the classified plan lines (`uptodate`, `provenance`, `additive`, `region-insert`, `region-edit`, `destructive`).
+2. If `uptodate`: stop, report nothing to do.
+3. `additive` lines are safe — note them.
+4. For each `region-insert`: open the target file, propose an exact insertion point to the human (the mechanical default is append-to-end; suggest a better spot if the file has obvious structure). For `region-edit`: show the diff of the managed block. For `destructive`: name the file/plugin and why the template removes it, and get explicit approval.
+5. Once the human approves, run `ws hoard upgrade <hoard> --apply`. Report the backup path it prints.
+6. Tell the human to open the hoard in Obsidian (plugins activate on launch) and to `ws hoard upgrade <hoard> --rollback` if anything looks wrong.
+
+Never run `--apply` before the human has approved the `destructive` and `region-*` lines from `--plan`.
+```
+
+- [ ] **Step 2: Commit**
+
+Bodyfile `message:` = `feat(skill): gdd-hoard-upgrade orchestration`.
+
+---
+
+## Task 11: Docs
+
+**Files:**
+- Modify: `docs/gdd/hoards.md` (add a "Upgrading a hoard" section: `.hoard.yaml`, the plan/apply/rollback flow, the skill)
+- Modify: `scripts/ws-hoard-upgrade.sh` header comment (replace the "DISABLED pending provenance fix" framing with the new flow; keep the yggdrasil#54 future-work note about data.json merge)
+
+- [ ] **Step 1: Update `docs/gdd/hoards.md`**
+
+Add a section documenting: `.hoard.yaml` provenance, `ws hoard upgrade <hoard> --plan/--apply/--rollback`, the whole-hoard backup under `.upgrade-backup/`, and that the `gdd-hoard-upgrade` skill drives the propose-then-apply loop. Single-line prose (no-hard-wrap rule).
+
+- [ ] **Step 2: Update the script header comment**
+
+Rewrite the top-of-file comment in `scripts/ws-hoard-upgrade.sh` to describe the v2 flow (provenance-resolved template, plan/apply/rollback, backup, regions) and drop the "DISABLED" paragraph. Keep the note that `data.json` is still overwrite-on-apply (three-way merge deferred — yggdrasil#54).
+
+- [ ] **Step 3: Commit**
+
+Bodyfile `message:` = `docs(hoard): document the v2 upgrade flow`.
+
+---
+
+## Self-Review
+
+**Spec coverage:** provenance (Tasks 1, 8) ✓; versioned manifest (Task 2, 9) ✓; `--plan` classification (Task 3) ✓; backup + rollback (Task 4) ✓; managed regions (Task 5) ✓; `--apply` + provenance bump (Task 6) ✓; wiring + re-enable / drop gate (Task 7) ✓; adopt existing hoards via `--template` (Task 7) ✓; thalami v1→v2 + Meta Bind + ArcDashboard region (Task 9) ✓; skill (Task 10) ✓; docs (Task 11) ✓. Deferred items (data.json three-way merge, per-version migrations, component upgrades) are intentionally untouched per the design's non-goals.
+
+**Placeholder scan:** the only deliberate unknowns are the Meta Bind `pin` and the exact inline-button syntax (Task 9 Steps 1–3), each with an explicit verification command rather than a vague TODO. The `version - 1` adoption baseline is flagged with a resolve-during-implementation note bounded to the thalami v1→v2 case.
+
+**Type/name consistency:** function names match the File Structure contract across tasks (`_ws_hoard_provenance_read/write`, `_ws_hoard_manifest_version`, `_ws_hoard_region_splice`, `_ws_hoard_backup`, `_ws_hoard_rollback`, `_ws_hoard_upgrade_plan`, `_ws_hoard_upgrade_apply`, `_ws_hoard_apply_manifest`, `ws_hoard_upgrade`). Plan line classes are consistent between Task 3 (emit) and Task 10 (consume).

--- a/scripts/ws
+++ b/scripts/ws
@@ -30,7 +30,7 @@
 #   hoard init [template] [--name <name>]   Scaffold a new hoard (default template: thalami)
 #   hoard <url>                Clone an existing hoard
 #   hoard list                 Show hoards and which thalami hoard is active
-#   hoard upgrade <hoard> [--plan|--apply|--rollback]  Provenance-tracked plugin/config upgrade
+#   hoard upgrade <hoard> [--plan|--apply|--rollback] [--template <name>]  Provenance-tracked plugin/config upgrade
 #   component init <flavor> [name]   Scaffold a new component from a template
 #   component list                   Show known component flavors
 #   actions <comp>    List adapter commands for a component

--- a/scripts/ws
+++ b/scripts/ws
@@ -30,7 +30,7 @@
 #   hoard init [template] [--name <name>]   Scaffold a new hoard (default template: thalami)
 #   hoard <url>                Clone an existing hoard
 #   hoard list                 Show hoards and which thalami hoard is active
-#   hoard upgrade <hoard-name> Re-fetch plugins and refresh configs from the template
+#   hoard upgrade <hoard> [--plan|--apply|--rollback]  Provenance-tracked plugin/config upgrade
 #   component init <flavor> [name]   Scaffold a new component from a template
 #   component list                   Show known component flavors
 #   actions <comp>    List adapter commands for a component

--- a/scripts/ws-hoard-upgrade.sh
+++ b/scripts/ws-hoard-upgrade.sh
@@ -173,11 +173,20 @@ _ws_hoard_rollback() {
     local latest
     latest="$(find "$backups_dir" -mindepth 1 -maxdepth 1 -type d | sort | tail -n 1)"
     [[ -n "$latest" ]] || return 1
+    # Clear the hoard first (except .git and the backups themselves) so files
+    # created after the snapshot — e.g. freshly downloaded plugin dirs — don't
+    # survive a rollback, leaving a true revert rather than a merged state.
+    local cur curbase
+    for cur in "$hoard_dir"/* "$hoard_dir"/.[!.]*; do
+        [[ -e "$cur" ]] || continue
+        curbase="$(basename "$cur")"
+        [[ "$curbase" == ".git" || "$curbase" == ".upgrade-backup" ]] && continue
+        rm -rf "$cur"
+    done
     local entry base
     for entry in "$latest"/* "$latest"/.[!.]*; do
         [[ -e "$entry" ]] || continue
         base="$(basename "$entry")"
-        rm -rf "$hoard_dir/$base"
         cp -R "$entry" "$hoard_dir/"
     done
     printf 'Restored %s\n' "$latest"
@@ -188,6 +197,13 @@ _ws_hoard_rollback() {
 # wrapped block. Content outside the markers is preserved verbatim.
 _ws_hoard_region_splice() {
     local file="$1" id="$2" source_file="$3"
+    # Refuse a missing/unreadable source: otherwise the append path would write
+    # empty markers and the replace path would drop the managed block, both
+    # corrupting the target.
+    [[ -r "$source_file" ]] || {
+        echo "ERROR: managed-region source not readable: $source_file" >&2
+        return 1
+    }
     local begin="<!-- BEGIN upgrade-$id -->"
     local end="<!-- END upgrade-$id -->"
     # Surface malformed markers as a conflict instead of silently rewriting:
@@ -210,8 +226,13 @@ _ws_hoard_region_splice() {
         ' "$file" > "$out"
     else
         {
-            [[ -f "$file" ]] && cat "$file"
-            printf '\n%s\n' "$begin"
+            # Only prepend a separating blank line when the file already has
+            # content — a brand-new file shouldn't start with an empty line.
+            if [[ -s "$file" ]]; then
+                cat "$file"
+                printf '\n'
+            fi
+            printf '%s\n' "$begin"
             cat "$source_file"
             printf '%s\n' "$end"
         } > "$out"
@@ -267,11 +288,11 @@ _ws_hoard_apply_manifest() {
         echo "ERROR: template has no upgrade.yaml: $template_dir" >&2
         return 1
     fi
-    if [[ ! -d "$hoard_dir/.obsidian" ]]; then
-        echo "ERROR: $hoard_dir does not appear to be an Obsidian vault" >&2
-        echo "  No .obsidian/ directory found." >&2
-        return 1
-    fi
+    # Bootstrap .obsidian/ if absent. Templates like thalami don't ship one
+    # (it's per-machine, gitignored), and a hoard may not have been opened in
+    # Obsidian yet — so create it rather than erroring, letting init/upgrade
+    # seed plugins + config cleanly on a fresh hoard.
+    mkdir -p "$hoard_dir/.obsidian" || return 1
     if ! command -v gh &>/dev/null; then
         echo "ERROR: gh (GitHub CLI) is required to download plugin releases." >&2
         echo "  Install: https://cli.github.com/" >&2
@@ -475,6 +496,28 @@ _ws_hoard_apply_manifest() {
     fi
 }
 
+# Splice every managed region declared in the template manifest into the hoard.
+# Aborts (returns 1) on a missing/unreadable source or a splice failure, so a
+# caller can refuse to bump provenance on a partial apply. Args: <hoard_dir> <template_dir>.
+_ws_hoard_apply_regions() {
+    local hoard_dir="$1" template_dir="$2"
+    local upgrade_yaml="$template_dir/.upgrade/upgrade.yaml"
+    local rn ri rfile rid rsrc
+    rn="$(yq '.managed_regions // [] | length' "$upgrade_yaml")"
+    ri=0
+    while [[ $ri -lt $rn ]]; do
+        rfile="$(yq ".managed_regions[$ri].file" "$upgrade_yaml")"
+        rid="$(yq ".managed_regions[$ri].id" "$upgrade_yaml")"
+        rsrc="$(yq ".managed_regions[$ri].source" "$upgrade_yaml")"
+        _ws_hoard_region_splice "$hoard_dir/$rfile" "$rid" "$template_dir/.upgrade/$rsrc" || {
+            echo "ERROR: region splice failed for $rfile#$rid; aborting (provenance not bumped, --rollback to restore)." >&2
+            return 1
+        }
+        echo "Spliced region $rfile#$rid"
+        ri=$((ri+1))
+    done
+}
+
 # Back-compat alias: `ws hoard init` calls this with an explicit, known
 # template (no provenance gap), so it maps straight to the mechanical apply.
 _ws_hoard_upgrade_from_template() {
@@ -497,25 +540,9 @@ _ws_hoard_upgrade_apply() {
     echo "Backed up hoard to: $snap"
 
     # Mechanical manifest apply (plugins, data.json, community-plugins.json,
-    # core-disable, files_remove, README block).
+    # core-disable, files_remove, README block), then managed regions.
     _ws_hoard_apply_manifest "$template_dir" "$hoard_dir" || return 1
-
-    # Managed regions.
-    local upgrade_yaml="$template_dir/.upgrade/upgrade.yaml"
-    local rn ri rfile rid rsrc
-    rn="$(yq '.managed_regions // [] | length' "$upgrade_yaml")"
-    ri=0
-    while [[ $ri -lt $rn ]]; do
-        rfile="$(yq ".managed_regions[$ri].file" "$upgrade_yaml")"
-        rid="$(yq ".managed_regions[$ri].id" "$upgrade_yaml")"
-        rsrc="$(yq ".managed_regions[$ri].source" "$upgrade_yaml")"
-        _ws_hoard_region_splice "$hoard_dir/$rfile" "$rid" "$template_dir/.upgrade/$rsrc" || {
-            echo "ERROR: region splice failed for $rfile#$rid; aborting (provenance not bumped, --rollback to restore)." >&2
-            return 1
-        }
-        echo "Spliced region $rfile#$rid"
-        ri=$((ri+1))
-    done
+    _ws_hoard_apply_regions "$hoard_dir" "$template_dir" || return 1
 
     # Provenance bump last, so a mid-apply failure leaves it un-bumped and the
     # upgrade is safely retryable.
@@ -535,7 +562,14 @@ ws_hoard_upgrade() {
             --plan) mode="plan" ;;
             --apply) mode="apply" ;;
             --rollback) mode="rollback" ;;
-            --template) shift; template_override="${1:-}" ;;
+            --template)
+                shift
+                if [[ -z "${1:-}" || "${1:-}" == -* ]]; then
+                    echo "ERROR: --template requires a template name." >&2
+                    ws_hoard_upgrade_help; return 1
+                fi
+                template_override="$1"
+                ;;
             -h|--help) ws_hoard_upgrade_help; return 0 ;;
             -*) echo "ERROR: unknown flag '$1'" >&2; ws_hoard_upgrade_help; return 1 ;;
             *) hoard_name="$1" ;;

--- a/scripts/ws-hoard-upgrade.sh
+++ b/scripts/ws-hoard-upgrade.sh
@@ -145,8 +145,10 @@ _ws_hoard_backup() {
     local hoard_dir="$1"
     local ts snap
     ts="$(date '+%Y%m%d-%H%M%S')"
-    snap="$hoard_dir/.upgrade-backup/$ts"
-    mkdir -p "$snap" || return 1
+    mkdir -p "$hoard_dir/.upgrade-backup" || return 1
+    # mktemp -d adds a random suffix so two snapshots in the same second
+    # can't merge into one directory (which would weaken rollback).
+    snap="$(mktemp -d "$hoard_dir/.upgrade-backup/${ts}-XXXXXX")" || return 1
     local entry base
     for entry in "$hoard_dir"/* "$hoard_dir"/.[!.]*; do
         [[ -e "$entry" ]] || continue
@@ -161,6 +163,11 @@ _ws_hoard_backup() {
 # there is no snapshot.
 _ws_hoard_rollback() {
     local hoard_dir="$1"
+    # Guard before any rm -rf below: never operate on an empty or root path.
+    [[ -n "$hoard_dir" && "$hoard_dir" != "/" ]] || {
+        echo "ERROR: unsafe hoard_dir for rollback: '$hoard_dir'" >&2
+        return 1
+    }
     local backups_dir="$hoard_dir/.upgrade-backup"
     [[ -d "$backups_dir" ]] || return 1
     local latest
@@ -183,6 +190,16 @@ _ws_hoard_region_splice() {
     local file="$1" id="$2" source_file="$3"
     local begin="<!-- BEGIN upgrade-$id -->"
     local end="<!-- END upgrade-$id -->"
+    # Surface malformed markers as a conflict instead of silently rewriting:
+    # an unbalanced BEGIN/END (e.g. END deleted by hand) would make the awk
+    # replace path truncate the rest of the file.
+    local begin_count end_count
+    begin_count="$(grep -cF "$begin" "$file" 2>/dev/null || true)"
+    end_count="$(grep -cF "$end" "$file" 2>/dev/null || true)"
+    if [[ "${begin_count:-0}" -ne "${end_count:-0}" ]]; then
+        echo "ERROR: malformed managed-region markers in $file for id '$id' (BEGIN=$begin_count END=$end_count)" >&2
+        return 1
+    fi
     local out
     out="$(mktemp)"
     if [[ -f "$file" ]] && grep -qF "$begin" "$file" 2>/dev/null; then

--- a/scripts/ws-hoard-upgrade.sh
+++ b/scripts/ws-hoard-upgrade.sh
@@ -66,13 +66,15 @@ _ws_hoard_manifest_version() {
 # destructive. The caller (skill/human) decides on the destructive + region
 # lines; additive lines are safe to auto-apply.
 _ws_hoard_upgrade_plan() {
-    local hoard_dir="$1" template_dir="$2"
+    local hoard_dir="$1" template_dir="$2" applied_override="${3:-}"
     local upgrade_yaml="$template_dir/.upgrade/upgrade.yaml"
     local cp_json="$hoard_dir/.obsidian/community-plugins.json"
 
     local version applied prov
     version="$(_ws_hoard_manifest_version "$template_dir")" || return 1
-    if prov="$(_ws_hoard_provenance_read "$hoard_dir")"; then
+    if [[ -n "$applied_override" ]]; then
+        applied="$applied_override"   # in-memory baseline for an untracked adoption (--plan must not write)
+    elif prov="$(_ws_hoard_provenance_read "$hoard_dir")"; then
         applied="${prov##* }"
     else
         applied=-1   # no provenance yet; everything is "new"
@@ -181,13 +183,19 @@ _ws_hoard_rollback() {
         [[ -e "$cur" ]] || continue
         curbase="$(basename "$cur")"
         [[ "$curbase" == ".git" || "$curbase" == ".upgrade-backup" ]] && continue
-        rm -rf "$cur"
+        rm -rf "$cur" || {
+            echo "ERROR: rollback failed to remove $cur; hoard may be half-cleared." >&2
+            return 1
+        }
     done
     local entry base
     for entry in "$latest"/* "$latest"/.[!.]*; do
         [[ -e "$entry" ]] || continue
         base="$(basename "$entry")"
-        cp -R "$entry" "$hoard_dir/"
+        cp -R "$entry" "$hoard_dir/" || {
+            echo "ERROR: rollback failed to restore $base; hoard may be half-restored." >&2
+            return 1
+        }
     done
     printf 'Restored %s\n' "$latest"
 }
@@ -592,8 +600,12 @@ ws_hoard_upgrade() {
         return 0
     fi
 
-    # Resolve template; adopt a not-yet-tracked hoard via --template.
-    local template prov
+    # Resolve template; adopt a not-yet-tracked hoard via --template. For an
+    # adoption we compute a baseline (one version behind, so the latest bump
+    # applies) but DO NOT persist it here — writing .hoard.yaml during --plan
+    # would mutate the hoard and break the "touch nothing" contract. The plan
+    # uses the baseline in-memory; --apply persists it before applying.
+    local template prov adopting=0 baseline=""
     if prov="$(_ws_hoard_provenance_read "$hoard_dir")"; then
         template="${prov%% *}"
     elif [[ -n "$template_override" ]]; then
@@ -601,11 +613,9 @@ ws_hoard_upgrade() {
         local tv
         tv="$(_ws_hoard_manifest_version "$TEMPLATES_DIR/hoards/$template")" || {
             echo "ERROR: template '$template' has no .upgrade/upgrade.yaml" >&2; return 1; }
-        # Adopt at a baseline one version behind the template's current, so the
-        # latest bump applies rather than re-applying the recipe from zero.
-        local baseline=$(( tv > 0 ? tv - 1 : 0 ))
-        _ws_hoard_provenance_write "$hoard_dir" "$template" "$baseline"
-        printf 'provenance\testablished %s @ %s (was untracked)\n' "$template" "$baseline"
+        adopting=1
+        baseline=$(( tv > 0 ? tv - 1 : 0 ))
+        printf 'provenance\twould adopt %s @ %s (untracked; persisted on --apply)\n' "$template" "$baseline"
     else
         echo "ERROR: $hoard_name has no .hoard.yaml; pass --template <name> to adopt it." >&2
         return 1
@@ -618,8 +628,14 @@ ws_hoard_upgrade() {
     fi
 
     if [[ "$mode" == "plan" ]]; then
-        _ws_hoard_upgrade_plan "$hoard_dir" "$template_dir"
+        _ws_hoard_upgrade_plan "$hoard_dir" "$template_dir" "$baseline"
     else
+        # --apply may persist: record the adoption baseline first so the hoard
+        # is tracked even if the apply fails midway, then apply (which bumps
+        # provenance to the manifest version on success).
+        if [[ "$adopting" -eq 1 ]]; then
+            _ws_hoard_provenance_write "$hoard_dir" "$template" "$baseline"
+        fi
         _ws_hoard_upgrade_apply "$hoard_dir" "$template_dir"
     fi
 }

--- a/scripts/ws-hoard-upgrade.sh
+++ b/scripts/ws-hoard-upgrade.sh
@@ -1,33 +1,30 @@
 #!/usr/bin/env bash
-# ws-hoard-upgrade.sh — Refresh a hoard's plugins and configs from its
-# template's upgrade.yaml.
+# ws-hoard-upgrade.sh — Provenance-tracked, plan-first hoard upgrades.
 #
-# Templates that need an "after init" or "ongoing refresh" phase ship
-# the recipe under templates/hoards/<flavor>/.upgrade/ — specifically
-# .upgrade/upgrade.yaml plus companion data/<plugin-id>/data.json
-# overlays. Today only obsidian-vault has one, but the discovery is
-# generic.
+# A hoard records its source template + last-applied version in a
+# git-committed .hoard.yaml. A template ships its recipe under
+# templates/hoards/<flavor>/.upgrade/upgrade.yaml: a `version`, the desired
+# plugins (pinned GitHub releases), core plugins to disable, files to remove,
+# and `managed_regions` (sentinel-delimited blocks the template owns inside a
+# content file). Design: docs/plans/2026-05-23-hoard-upgrade-v2-design.md.
 #
-# What an upgrade does (driven by upgrade.yaml + companion files):
-#   - Downloads pinned plugin releases from GitHub into
-#     <hoard>/.obsidian/plugins/<id>/
-#   - Copies template's .upgrade/data/<plugin-id>/data.json into the
-#     hoard, seeding plugin settings
-#   - Writes <hoard>/.obsidian/community-plugins.json (the enabled list)
-#   - Disables conflicting core plugins in core-plugins.json
-#   - Removes redundant files (e.g. core daily-notes.json once
-#     Periodic Notes supersedes it)
-#   - Refreshes a marked plugin table in the hoard's README.md
-#     between sentinel comments (idempotent on re-run)
+# Flow (public: ws_hoard_upgrade):
+#   --plan      Resolve the template via .hoard.yaml, diff desired-vs-live, and
+#               print classified CLASS<TAB>DETAIL lines (uptodate / additive /
+#               region-insert / region-edit / destructive). Changes nothing.
+#   --apply     Snapshot the whole hoard to .upgrade-backup/<ts>/, run the
+#               mechanical manifest apply (_ws_hoard_apply_manifest), splice
+#               managed regions, then bump .hoard.yaml. Aborts before any
+#               change if the backup fails.
+#   --rollback  Restore the most recent pre-apply snapshot.
+# The gdd-hoard-upgrade skill drives plan → propose → apply with a human gate
+# on the destructive + region lines.
 #
-# This is a one-shot install AND a refresh: re-running re-downloads,
-# re-overwrites data.json files, and replaces the README block.
+# _ws_hoard_upgrade_from_template stays as a thin alias to
+# _ws_hoard_apply_manifest, so `ws hoard init`'s post-copy call is unchanged.
 #
-# Future work tracked in the followup to yggdrasil#54:
-#   - Hoard-side provenance tracking (`.hoard.yaml`) so we can resolve
-#     the originating template for free instead of scanning
-#   - JSON-merge instead of overwrite for plugin data.json so user
-#     tweaks survive an upgrade
+# Deferred (yggdrasil#54): plugin data.json is still overwrite-on-apply (no
+# three-way merge yet), so a user's in-hoard data.json tweaks don't survive.
 
 # Sourced by ws-hoard.sh; do not enable strict mode here.
 

--- a/scripts/ws-hoard-upgrade.sh
+++ b/scripts/ws-hoard-upgrade.sh
@@ -206,18 +206,19 @@ _ws_hoard_region_splice() {
 }
 
 ws_hoard_upgrade_help() {
-    echo "Usage: ws hoard upgrade <hoard-name>" >&2
-    echo "" >&2
-    echo "DISABLED pending a provenance fix. The command has no per-hoard" >&2
-    echo "provenance and would apply the only upgradeable template" >&2
-    echo "(obsidian-vault) to ANY hoard, pushing the full plugin suite onto" >&2
-    echo "thalami hoards that only need Dataview. Re-enable once hoards carry" >&2
-    echo ".hoard.yaml provenance and/or the thalami template ships its own" >&2
-    echo "minimal upgrade.yaml (yggdrasil#54). Override on an obsidian-vault" >&2
-    echo "hoard with WS_HOARD_UPGRADE_ENABLED=1." >&2
-    echo "" >&2
-    echo "When enabled: re-fetch plugins and refresh configs for a hoard," >&2
-    echo "using the upgrade.yaml shipped by its template. Idempotent." >&2
+    cat >&2 <<'HELP'
+Usage: ws hoard upgrade <hoard> [--plan | --apply | --rollback] [--template <name>]
+
+  --plan       Show what would change; touch nothing (default).
+  --apply      Back up the hoard, then apply the plan; bump .hoard.yaml.
+  --rollback   Restore the most recent pre-apply backup.
+  --template   Name the source template for a hoard with no .hoard.yaml yet
+               (establishes provenance, then applies the latest version).
+
+Reads the source template from <hoard>/.hoard.yaml. The gdd-hoard-upgrade
+skill drives the propose-then-apply flow; run it instead of --apply by hand
+when there are destructive or region changes to review.
+HELP
 }
 
 # Try `gh release download <tag> ...` with the literal pin first, then
@@ -506,44 +507,26 @@ _ws_hoard_upgrade_apply() {
     _ws_hoard_provenance_write "$hoard_dir" "$template" "$version"
 }
 
-# Public command: resolve template by auto-discovery, then run the
-# upgrade. Errors clearly if zero or multiple upgradeable templates
-# exist (the latter is forward-looking; today there's just one).
+# Public command. Resolves the source template from <hoard>/.hoard.yaml
+# (or --template for a not-yet-tracked hoard), then plans / applies / rolls
+# back. No global enable gate: provenance scopes each run to the right
+# template, so there is no cross-template misapplication to guard against.
 ws_hoard_upgrade() {
-    local hoard_name="${1:-}"
-    if [[ -z "$hoard_name" || "$hoard_name" == "--help" || "$hoard_name" == "-h" ]]; then
-        ws_hoard_upgrade_help
-        return 1
-    fi
-
-    # ─── DISABLED by default pending a provenance fix (TODO) ────────
-    # This command has no per-hoard provenance: it applies the single
-    # template that ships an .upgrade/upgrade.yaml (today only
-    # obsidian-vault) to ANY hoard named, regardless of that hoard's
-    # actual flavor. Run against a thalami hoard it pushed the full
-    # PARA-vault plugin suite — including Linter (auto-format on save)
-    # and Filename Heading Sync (renames H1/filename) — onto a vault
-    # that only needs Dataview, risking edits to the thalamus files on
-    # next Obsidian open (observed 2026-05-22).
-    #
-    # Re-enable (remove this gate) once hoards carry a .hoard.yaml
-    # provenance marker (the yggdrasil#54 follow-up) and/or the thalami
-    # template ships its own minimal upgrade.yaml. The internal
-    # _ws_hoard_upgrade_from_template is intentionally left active —
-    # `ws hoard init` calls it with an explicit, known template, so that
-    # path has no provenance gap. The WS_HOARD_UPGRADE_ENABLED escape
-    # hatch (matching the WS_HOOK_DISABLE / WS_HOOK_DEBUG idiom) lets a
-    # power user who knows their hoard is obsidian-vault-shaped override.
-    if [[ "${WS_HOARD_UPGRADE_ENABLED:-0}" != "1" ]]; then
-        echo "DISABLED: 'ws hoard upgrade' is intentionally off pending a provenance fix (TODO)." >&2
-        echo "  It has no per-hoard provenance and would apply the obsidian-vault" >&2
-        echo "  upgrade recipe to ANY hoard — pushing the full plugin suite onto" >&2
-        echo "  thalami hoards that only need Dataview (Linter / Filename Heading" >&2
-        echo "  Sync can then edit the thalamus files on next Obsidian open)." >&2
-        echo "  Re-enable once hoards carry .hoard.yaml provenance and/or the" >&2
-        echo "  thalami template ships its own minimal upgrade.yaml (yggdrasil#54)." >&2
-        echo "  Override for an obsidian-vault hoard with WS_HOARD_UPGRADE_ENABLED=1." >&2
-        return 1
+    local hoard_name="" mode="plan" template_override=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --plan) mode="plan" ;;
+            --apply) mode="apply" ;;
+            --rollback) mode="rollback" ;;
+            --template) shift; template_override="${1:-}" ;;
+            -h|--help) ws_hoard_upgrade_help; return 0 ;;
+            -*) echo "ERROR: unknown flag '$1'" >&2; ws_hoard_upgrade_help; return 1 ;;
+            *) hoard_name="$1" ;;
+        esac
+        shift
+    done
+    if [[ -z "$hoard_name" ]]; then
+        ws_hoard_upgrade_help; return 1
     fi
 
     local hoard_dir="$HOARDS_DIR/$hoard_name"
@@ -553,36 +536,39 @@ ws_hoard_upgrade() {
         return 1
     fi
 
-    # Discover which templates ship an upgrade.yaml. v1: if exactly
-    # one, use it. Future: read provenance from <hoard>/.hoard.yaml.
-    local upgradeable=()
-    local d
-    for d in "$TEMPLATES_DIR"/hoards/*/; do
-        [[ -f "$d/.upgrade/upgrade.yaml" ]] && upgradeable+=("$(basename "$d")")
-    done
-    if [[ ${#upgradeable[@]} -eq 0 ]]; then
-        echo "ERROR: no template ships an upgrade.yaml — nothing to upgrade." >&2
-        return 1
+    if [[ "$mode" == "rollback" ]]; then
+        _ws_hoard_rollback "$hoard_dir" || { echo "ERROR: no backup to roll back to." >&2; return 1; }
+        return 0
     fi
-    if [[ ${#upgradeable[@]} -gt 1 ]]; then
-        echo "ERROR: multiple templates have upgrade.yaml: ${upgradeable[*]}" >&2
-        echo "  Hoard-side provenance tracking is not yet implemented; this" >&2
-        echo "  command currently requires exactly one upgradeable template." >&2
+
+    # Resolve template; adopt a not-yet-tracked hoard via --template.
+    local template prov
+    if prov="$(_ws_hoard_provenance_read "$hoard_dir")"; then
+        template="${prov%% *}"
+    elif [[ -n "$template_override" ]]; then
+        template="$template_override"
+        local tv
+        tv="$(_ws_hoard_manifest_version "$TEMPLATES_DIR/hoards/$template")" || {
+            echo "ERROR: template '$template' has no .upgrade/upgrade.yaml" >&2; return 1; }
+        # Adopt at a baseline one version behind the template's current, so the
+        # latest bump applies rather than re-applying the recipe from zero.
+        local baseline=$(( tv > 0 ? tv - 1 : 0 ))
+        _ws_hoard_provenance_write "$hoard_dir" "$template" "$baseline"
+        printf 'provenance\testablished %s @ %s (was untracked)\n' "$template" "$baseline"
+    else
+        echo "ERROR: $hoard_name has no .hoard.yaml; pass --template <name> to adopt it." >&2
         return 1
     fi
 
-    local template="${upgradeable[0]}"
     local template_dir="$TEMPLATES_DIR/hoards/$template"
-    echo "Upgrading hoard '$hoard_name' from template '$template'..."
-    echo "  Template: $template_dir"
-    echo "  Hoard:    $hoard_dir"
-    echo ""
-    _ws_hoard_upgrade_from_template "$template_dir" "$hoard_dir"
-    local rc=$?
-    if [[ $rc -eq 0 ]]; then
-        echo ""
-        echo "Upgrade complete. Open the hoard in Obsidian — plugins"
-        echo "will activate on first launch."
+    if [[ ! -f "$template_dir/.upgrade/upgrade.yaml" ]]; then
+        echo "ERROR: template '$template' has no .upgrade/upgrade.yaml" >&2
+        return 1
     fi
-    return $rc
+
+    if [[ "$mode" == "plan" ]]; then
+        _ws_hoard_upgrade_plan "$hoard_dir" "$template_dir"
+    else
+        _ws_hoard_upgrade_apply "$hoard_dir" "$template_dir"
+    fi
 }

--- a/scripts/ws-hoard-upgrade.sh
+++ b/scripts/ws-hoard-upgrade.sh
@@ -179,6 +179,32 @@ _ws_hoard_rollback() {
     printf 'Restored %s\n' "$latest"
 }
 
+# Splice a template-managed region into a file. If the BEGIN marker is
+# present, replace everything between BEGIN/END; otherwise append a freshly
+# wrapped block. Content outside the markers is preserved verbatim.
+_ws_hoard_region_splice() {
+    local file="$1" id="$2" source_file="$3"
+    local begin="<!-- BEGIN upgrade-$id -->"
+    local end="<!-- END upgrade-$id -->"
+    local out
+    out="$(mktemp)"
+    if [[ -f "$file" ]] && grep -qF "$begin" "$file" 2>/dev/null; then
+        awk -v b="$begin" -v e="$end" -v insert="$source_file" '
+            $0 == b { print; while ((getline line < insert) > 0) print line; close(insert); skip=1; next }
+            $0 == e { skip=0 }
+            !skip { print }
+        ' "$file" > "$out"
+    else
+        {
+            [[ -f "$file" ]] && cat "$file"
+            printf '\n%s\n' "$begin"
+            cat "$source_file"
+            printf '%s\n' "$end"
+        } > "$out"
+    fi
+    mv "$out" "$file"
+}
+
 ws_hoard_upgrade_help() {
     echo "Usage: ws hoard upgrade <hoard-name>" >&2
     echo "" >&2

--- a/scripts/ws-hoard-upgrade.sh
+++ b/scripts/ws-hoard-upgrade.sh
@@ -52,6 +52,18 @@ _ws_hoard_provenance_write() {
         > "$hoard_dir/.hoard.yaml"
 }
 
+# Print the integer `version` from a template's upgrade.yaml. Returns 1 if
+# the manifest is absent. Defaults a missing/invalid version to 0.
+_ws_hoard_manifest_version() {
+    local template_dir="$1"
+    local f="$template_dir/.upgrade/upgrade.yaml"
+    [[ -f "$f" ]] || return 1
+    local v
+    v="$(yq '.version // 0' "$f" 2>/dev/null)"
+    [[ "$v" =~ ^[0-9]+$ ]] || v=0
+    printf '%s\n' "$v"
+}
+
 ws_hoard_upgrade_help() {
     echo "Usage: ws hoard upgrade <hoard-name>" >&2
     echo "" >&2

--- a/scripts/ws-hoard-upgrade.sh
+++ b/scripts/ws-hoard-upgrade.sh
@@ -141,6 +141,44 @@ _ws_hoard_upgrade_plan() {
     done
 }
 
+# Snapshot the whole hoard into .upgrade-backup/<timestamp>/, excluding
+# .git/ and .upgrade-backup/ itself. Prints the snapshot path. Returns 1 on
+# failure so callers can abort an apply before touching anything.
+_ws_hoard_backup() {
+    local hoard_dir="$1"
+    local ts snap
+    ts="$(date '+%Y%m%d-%H%M%S')"
+    snap="$hoard_dir/.upgrade-backup/$ts"
+    mkdir -p "$snap" || return 1
+    local entry base
+    for entry in "$hoard_dir"/* "$hoard_dir"/.[!.]*; do
+        [[ -e "$entry" ]] || continue
+        base="$(basename "$entry")"
+        [[ "$base" == ".git" || "$base" == ".upgrade-backup" ]] && continue
+        cp -R "$entry" "$snap/" || return 1
+    done
+    printf '%s\n' "$snap"
+}
+
+# Restore the most recent .upgrade-backup/<ts>/ over the hoard. Returns 1 if
+# there is no snapshot.
+_ws_hoard_rollback() {
+    local hoard_dir="$1"
+    local backups_dir="$hoard_dir/.upgrade-backup"
+    [[ -d "$backups_dir" ]] || return 1
+    local latest
+    latest="$(find "$backups_dir" -mindepth 1 -maxdepth 1 -type d | sort | tail -n 1)"
+    [[ -n "$latest" ]] || return 1
+    local entry base
+    for entry in "$latest"/* "$latest"/.[!.]*; do
+        [[ -e "$entry" ]] || continue
+        base="$(basename "$entry")"
+        rm -rf "$hoard_dir/$base"
+        cp -R "$entry" "$hoard_dir/"
+    done
+    printf 'Restored %s\n' "$latest"
+}
+
 ws_hoard_upgrade_help() {
     echo "Usage: ws hoard upgrade <hoard-name>" >&2
     echo "" >&2

--- a/scripts/ws-hoard-upgrade.sh
+++ b/scripts/ws-hoard-upgrade.sh
@@ -31,6 +31,27 @@
 
 # Sourced by ws-hoard.sh; do not enable strict mode here.
 
+# Read a hoard's provenance. Prints "<template> <applied_version>" on
+# success; returns 1 if .hoard.yaml is missing or has no template.
+_ws_hoard_provenance_read() {
+    local hoard_dir="$1"
+    local f="$hoard_dir/.hoard.yaml"
+    [[ -f "$f" ]] || return 1
+    local tmpl ver
+    tmpl="$(yq '.template // ""' "$f" 2>/dev/null)"
+    ver="$(yq '.applied_version // 0' "$f" 2>/dev/null)"
+    [[ -n "$tmpl" && "$tmpl" != "null" ]] || return 1
+    [[ "$ver" =~ ^[0-9]+$ ]] || ver=0
+    printf '%s %s\n' "$tmpl" "$ver"
+}
+
+# Write a hoard's provenance file (git-committed, hoard root).
+_ws_hoard_provenance_write() {
+    local hoard_dir="$1" template="$2" version="$3"
+    printf 'template: %s\napplied_version: %s\n' "$template" "$version" \
+        > "$hoard_dir/.hoard.yaml"
+}
+
 ws_hoard_upgrade_help() {
     echo "Usage: ws hoard upgrade <hoard-name>" >&2
     echo "" >&2

--- a/scripts/ws-hoard-upgrade.sh
+++ b/scripts/ws-hoard-upgrade.sh
@@ -64,6 +64,83 @@ _ws_hoard_manifest_version() {
     printf '%s\n' "$v"
 }
 
+# Compute and print the upgrade plan as CLASS<TAB>DETAIL lines, without
+# modifying the hoard. CLASS in uptodate|additive|region-insert|region-edit|
+# destructive. The caller (skill/human) decides on the destructive + region
+# lines; additive lines are safe to auto-apply.
+_ws_hoard_upgrade_plan() {
+    local hoard_dir="$1" template_dir="$2"
+    local upgrade_yaml="$template_dir/.upgrade/upgrade.yaml"
+    local cp_json="$hoard_dir/.obsidian/community-plugins.json"
+
+    local version applied prov
+    version="$(_ws_hoard_manifest_version "$template_dir")" || return 1
+    if prov="$(_ws_hoard_provenance_read "$hoard_dir")"; then
+        applied="${prov##* }"
+    else
+        applied=-1   # no provenance yet; everything is "new"
+    fi
+    if [[ "$applied" -ge "$version" ]]; then
+        printf 'uptodate\tapplied %s >= version %s\n' "$applied" "$version"
+        return 0
+    fi
+
+    # Plugins: additive if id not already in community-plugins.json.
+    local n i id
+    n="$(yq '.plugins // [] | length' "$upgrade_yaml")"
+    i=0
+    while [[ $i -lt $n ]]; do
+        id="$(yq ".plugins[$i].id" "$upgrade_yaml")"
+        if [[ -f "$cp_json" ]] && jq -e --arg id "$id" 'index($id)' "$cp_json" >/dev/null 2>&1; then
+            :  # already enabled — no change
+        else
+            printf 'additive\tenable plugin %s\n' "$id"
+        fi
+        i=$((i+1))
+    done
+
+    # Managed regions: insert (markers absent) vs edit (markers present).
+    local rn ri rfile rid begin
+    rn="$(yq '.managed_regions // [] | length' "$upgrade_yaml")"
+    ri=0
+    while [[ $ri -lt $rn ]]; do
+        rfile="$(yq ".managed_regions[$ri].file" "$upgrade_yaml")"
+        rid="$(yq ".managed_regions[$ri].id" "$upgrade_yaml")"
+        begin="<!-- BEGIN upgrade-$rid -->"
+        if [[ -f "$hoard_dir/$rfile" ]] && grep -qF "$begin" "$hoard_dir/$rfile" 2>/dev/null; then
+            printf 'region-edit\t%s#%s\n' "$rfile" "$rid"
+        else
+            printf 'region-insert\t%s#%s\n' "$rfile" "$rid"
+        fi
+        ri=$((ri+1))
+    done
+
+    # files_remove: destructive when the target exists.
+    local fn fi rel
+    fn="$(yq '.files_remove // [] | length' "$upgrade_yaml")"
+    fi=0
+    while [[ $fi -lt $fn ]]; do
+        rel="$(yq ".files_remove[$fi]" "$upgrade_yaml")"
+        [[ -e "$hoard_dir/$rel" ]] && printf 'destructive\tremove %s\n' "$rel"
+        fi=$((fi+1))
+    done
+
+    # core_plugins_disable: destructive when currently enabled.
+    local cn ci cid core_json
+    core_json="$hoard_dir/.obsidian/core-plugins.json"
+    cn="$(yq '.core_plugins_disable // [] | length' "$upgrade_yaml")"
+    ci=0
+    while [[ $ci -lt $cn ]]; do
+        cid="$(yq ".core_plugins_disable[$ci]" "$upgrade_yaml")"
+        if [[ -f "$core_json" ]] && jq -e --arg id "$cid" \
+            'if type=="array" then index($id) else .[$id] == true end' \
+            "$core_json" >/dev/null 2>&1; then
+            printf 'destructive\tdisable core plugin %s\n' "$cid"
+        fi
+        ci=$((ci+1))
+    done
+}
+
 ws_hoard_upgrade_help() {
     echo "Usage: ws hoard upgrade <hoard-name>" >&2
     echo "" >&2

--- a/scripts/ws-hoard-upgrade.sh
+++ b/scripts/ws-hoard-upgrade.sh
@@ -509,7 +509,10 @@ _ws_hoard_upgrade_apply() {
         rfile="$(yq ".managed_regions[$ri].file" "$upgrade_yaml")"
         rid="$(yq ".managed_regions[$ri].id" "$upgrade_yaml")"
         rsrc="$(yq ".managed_regions[$ri].source" "$upgrade_yaml")"
-        _ws_hoard_region_splice "$hoard_dir/$rfile" "$rid" "$template_dir/.upgrade/$rsrc"
+        _ws_hoard_region_splice "$hoard_dir/$rfile" "$rid" "$template_dir/.upgrade/$rsrc" || {
+            echo "ERROR: region splice failed for $rfile#$rid; aborting (provenance not bumped, --rollback to restore)." >&2
+            return 1
+        }
         echo "Spliced region $rfile#$rid"
         ri=$((ri+1))
     done

--- a/scripts/ws-hoard-upgrade.sh
+++ b/scripts/ws-hoard-upgrade.sh
@@ -239,7 +239,11 @@ _ws_hoard_upgrade_gh_download() {
 # Internal: run an upgrade given resolved paths. Used by both the
 # public `ws hoard upgrade` command and ws_hoard_init's post-copy
 # step. Args: <template_dir> <hoard_dir>.
-_ws_hoard_upgrade_from_template() {
+# Mechanical manifest apply: download plugins, seed data.json, write
+# community-plugins.json, disable core plugins, remove declared files, refresh
+# the README plugin table. No backup, no provenance bump, no managed regions —
+# those are the caller's job (--apply / region splice). Args: <template_dir> <hoard_dir>.
+_ws_hoard_apply_manifest() {
     local template_dir="$1"
     local hoard_dir="$2"
     local upgrade_yaml="$template_dir/.upgrade/upgrade.yaml"
@@ -454,6 +458,52 @@ _ws_hoard_upgrade_from_template() {
         mv "$tmp" "$inbox_welcome"
         echo "Stripped legacy upgrade block from 00_Inbox/Welcome.md"
     fi
+}
+
+# Back-compat alias: `ws hoard init` calls this with an explicit, known
+# template (no provenance gap), so it maps straight to the mechanical apply.
+_ws_hoard_upgrade_from_template() {
+    _ws_hoard_apply_manifest "$@"
+}
+
+# Apply an upgrade end to end: backup, mechanical manifest apply, region
+# splices, provenance bump. Aborts before any change if the backup fails.
+# Args: <hoard_dir> <template_dir>.
+_ws_hoard_upgrade_apply() {
+    local hoard_dir="$1" template_dir="$2"
+    local version
+    version="$(_ws_hoard_manifest_version "$template_dir")" || return 1
+
+    local snap
+    if ! snap="$(_ws_hoard_backup "$hoard_dir")"; then
+        echo "ERROR: backup failed; aborting upgrade (nothing changed)." >&2
+        return 1
+    fi
+    echo "Backed up hoard to: $snap"
+
+    # Mechanical manifest apply (plugins, data.json, community-plugins.json,
+    # core-disable, files_remove, README block).
+    _ws_hoard_apply_manifest "$template_dir" "$hoard_dir" || return 1
+
+    # Managed regions.
+    local upgrade_yaml="$template_dir/.upgrade/upgrade.yaml"
+    local rn ri rfile rid rsrc
+    rn="$(yq '.managed_regions // [] | length' "$upgrade_yaml")"
+    ri=0
+    while [[ $ri -lt $rn ]]; do
+        rfile="$(yq ".managed_regions[$ri].file" "$upgrade_yaml")"
+        rid="$(yq ".managed_regions[$ri].id" "$upgrade_yaml")"
+        rsrc="$(yq ".managed_regions[$ri].source" "$upgrade_yaml")"
+        _ws_hoard_region_splice "$hoard_dir/$rfile" "$rid" "$template_dir/.upgrade/$rsrc"
+        echo "Spliced region $rfile#$rid"
+        ri=$((ri+1))
+    done
+
+    # Provenance bump last, so a mid-apply failure leaves it un-bumped and the
+    # upgrade is safely retryable.
+    local template
+    template="$(basename "$template_dir")"
+    _ws_hoard_provenance_write "$hoard_dir" "$template" "$version"
 }
 
 # Public command: resolve template by auto-discovery, then run the

--- a/scripts/ws-hoard-upgrade.sh
+++ b/scripts/ws-hoard-upgrade.sh
@@ -138,6 +138,30 @@ _ws_hoard_upgrade_plan() {
         fi
         ci=$((ci+1))
     done
+
+    # Community plugins the hoard has enabled but the template doesn't ship:
+    # --apply overwrites community-plugins.json with exactly the template ids,
+    # so these would be disabled. Surface them so the plan stays truthful.
+    if [[ -f "$cp_json" ]]; then
+        local tmpl_ids enabled_id
+        tmpl_ids="$(yq -o tsv '.plugins // [] | .[].id' "$upgrade_yaml" 2>/dev/null)"
+        while IFS= read -r enabled_id; do
+            [[ -n "$enabled_id" ]] || continue
+            grep -qxF "$enabled_id" <<< "$tmpl_ids" && continue
+            printf 'destructive\tdisable plugin %s (overwrite of community-plugins.json drops it)\n' "$enabled_id"
+        done < <(jq -r '.[]?' "$cp_json" 2>/dev/null)
+    fi
+
+    # data.json overlays overwrite existing plugin settings on --apply.
+    if [[ -d "$template_dir/.upgrade/data" ]]; then
+        local dpath did
+        for dpath in "$template_dir/.upgrade/data"/*/data.json; do
+            [[ -f "$dpath" ]] || continue
+            did="$(basename "$(dirname "$dpath")")"
+            [[ -f "$hoard_dir/.obsidian/plugins/$did/data.json" ]] \
+                && printf 'destructive\toverwrite %s data.json\n' "$did"
+        done
+    fi
 }
 
 # Snapshot the whole hoard into .upgrade-backup/<timestamp>/, excluding
@@ -224,28 +248,32 @@ _ws_hoard_region_splice() {
         echo "ERROR: malformed managed-region markers in $file for id '$id' (BEGIN=$begin_count END=$end_count)" >&2
         return 1
     fi
+    # Render into a temp file in the SAME directory as the target so the final
+    # mv is an atomic same-filesystem rename, and clean the temp up on any
+    # failure so a partial render never replaces the original.
     local out
-    out="$(mktemp)"
+    out="$(mktemp "$(dirname "$file")/.upgrade-splice.XXXXXX")" || return 1
     if [[ -f "$file" ]] && grep -qF "$begin" "$file" 2>/dev/null; then
         awk -v b="$begin" -v e="$end" -v insert="$source_file" '
             $0 == b { print; while ((getline line < insert) > 0) print line; close(insert); skip=1; next }
             $0 == e { skip=0 }
             !skip { print }
-        ' "$file" > "$out"
+        ' "$file" > "$out" || { rm -f "$out"; return 1; }
     else
-        {
-            # Only prepend a separating blank line when the file already has
-            # content — a brand-new file shouldn't start with an empty line.
+        # Subshell so an internal `exit 1` (on a failed cat) aborts the render
+        # without killing the caller; only prepend a separating blank line when
+        # the file already has content — a brand-new file shouldn't start blank.
+        (
             if [[ -s "$file" ]]; then
-                cat "$file"
+                cat "$file" || exit 1
                 printf '\n'
             fi
             printf '%s\n' "$begin"
-            cat "$source_file"
+            cat "$source_file" || exit 1
             printf '%s\n' "$end"
-        } > "$out"
+        ) > "$out" || { rm -f "$out"; return 1; }
     fi
-    mv "$out" "$file"
+    mv "$out" "$file" || { rm -f "$out"; return 1; }
 }
 
 ws_hoard_upgrade_help() {
@@ -534,9 +562,11 @@ _ws_hoard_upgrade_from_template() {
 
 # Apply an upgrade end to end: backup, mechanical manifest apply, region
 # splices, provenance bump. Aborts before any change if the backup fails.
-# Args: <hoard_dir> <template_dir>.
+# Args: <hoard_dir> <template_dir> [adopt_baseline]. When adopt_baseline is
+# given (first-time adoption), it is written ONLY after the backup succeeds —
+# so the snapshot captures the pre-adoption state and rollback stays clean.
 _ws_hoard_upgrade_apply() {
-    local hoard_dir="$1" template_dir="$2"
+    local hoard_dir="$1" template_dir="$2" adopt_baseline="${3:-}"
     local version
     version="$(_ws_hoard_manifest_version "$template_dir")" || return 1
 
@@ -546,6 +576,9 @@ _ws_hoard_upgrade_apply() {
         return 1
     fi
     echo "Backed up hoard to: $snap"
+    if [[ -n "$adopt_baseline" ]]; then
+        _ws_hoard_provenance_write "$hoard_dir" "$(basename "$template_dir")" "$adopt_baseline"
+    fi
 
     # Mechanical manifest apply (plugins, data.json, community-plugins.json,
     # core-disable, files_remove, README block), then managed regions.
@@ -564,12 +597,16 @@ _ws_hoard_upgrade_apply() {
 # back. No global enable gate: provenance scopes each run to the right
 # template, so there is no cross-template misapplication to guard against.
 ws_hoard_upgrade() {
-    local hoard_name="" mode="plan" template_override=""
+    local hoard_name="" mode="plan" template_override="" mode_set=0
     while [[ $# -gt 0 ]]; do
         case "$1" in
-            --plan) mode="plan" ;;
-            --apply) mode="apply" ;;
-            --rollback) mode="rollback" ;;
+            --plan|--apply|--rollback)
+                if [[ "$mode_set" -eq 1 ]]; then
+                    echo "ERROR: only one of --plan / --apply / --rollback may be given." >&2
+                    ws_hoard_upgrade_help; return 1
+                fi
+                mode="${1#--}"; mode_set=1
+                ;;
             --template)
                 shift
                 if [[ -z "${1:-}" || "${1:-}" == -* ]]; then
@@ -580,7 +617,13 @@ ws_hoard_upgrade() {
                 ;;
             -h|--help) ws_hoard_upgrade_help; return 0 ;;
             -*) echo "ERROR: unknown flag '$1'" >&2; ws_hoard_upgrade_help; return 1 ;;
-            *) hoard_name="$1" ;;
+            *)
+                if [[ -n "$hoard_name" ]]; then
+                    echo "ERROR: unexpected extra argument '$1' (hoard already set to '$hoard_name')." >&2
+                    ws_hoard_upgrade_help; return 1
+                fi
+                hoard_name="$1"
+                ;;
         esac
         shift
     done
@@ -629,13 +672,11 @@ ws_hoard_upgrade() {
 
     if [[ "$mode" == "plan" ]]; then
         _ws_hoard_upgrade_plan "$hoard_dir" "$template_dir" "$baseline"
+    elif [[ "$adopting" -eq 1 ]]; then
+        # Pass the baseline so apply records it AFTER its backup (keeps the
+        # snapshot pre-adoption and never mutates before the safety net exists).
+        _ws_hoard_upgrade_apply "$hoard_dir" "$template_dir" "$baseline"
     else
-        # --apply may persist: record the adoption baseline first so the hoard
-        # is tracked even if the apply fails midway, then apply (which bumps
-        # provenance to the manifest version on success).
-        if [[ "$adopting" -eq 1 ]]; then
-            _ws_hoard_provenance_write "$hoard_dir" "$template" "$baseline"
-        fi
         _ws_hoard_upgrade_apply "$hoard_dir" "$template_dir"
     fi
 }

--- a/scripts/ws-hoard.sh
+++ b/scripts/ws-hoard.sh
@@ -781,6 +781,13 @@ ws_hoard_init() {
     # disables conflicting core plugins, and injects the README block.
     if [[ -d "$target/.upgrade" ]]; then
         rm -rf "$target/.upgrade"
+        # Record provenance so `ws hoard upgrade` can resolve the source
+        # template + version. Written even when the upgrade phase is skipped
+        # (WS_HOARD_NO_UPGRADE / offline) — it's a cheap local file, no network.
+        if [[ -f "$template_dir/.upgrade/upgrade.yaml" ]]; then
+            _ws_hoard_provenance_write "$target" "$(basename "$template_dir")" \
+                "$(_ws_hoard_manifest_version "$template_dir")"
+        fi
         # Only run if template still has .upgrade/ (the source)
         # Allow tests / offline runs / CI to opt out of the upgrade phase
         # via WS_HOARD_NO_UPGRADE=1. Upgrade hits GitHub for plugin

--- a/scripts/ws-hoard.sh
+++ b/scripts/ws-hoard.sh
@@ -781,29 +781,31 @@ ws_hoard_init() {
     # disables conflicting core plugins, and injects the README block.
     if [[ -d "$target/.upgrade" ]]; then
         rm -rf "$target/.upgrade"
-        # Record provenance so `ws hoard upgrade` can resolve the source
-        # template + version. Written even when the upgrade phase is skipped
-        # (WS_HOARD_NO_UPGRADE / offline) — it's a cheap local file, no network.
         if [[ -f "$template_dir/.upgrade/upgrade.yaml" ]]; then
-            _ws_hoard_provenance_write "$target" "$(basename "$template_dir")" \
-                "$(_ws_hoard_manifest_version "$template_dir")"
-        fi
-        # Only run if template still has .upgrade/ (the source)
-        # Allow tests / offline runs / CI to opt out of the upgrade phase
-        # via WS_HOARD_NO_UPGRADE=1. Upgrade hits GitHub for plugin
-        # release downloads, which is fine for interactive use but bad
-        # for hermetic test runs.
-        if [[ -f "$template_dir/.upgrade/upgrade.yaml" && -z "${WS_HOARD_NO_UPGRADE:-}" ]]; then
-            echo ""
-            echo "Running upgrade phase from template..."
-            _ws_hoard_upgrade_from_template "$template_dir" "$target" || {
-                echo "WARNING: upgrade phase failed; hoard is initialized but" >&2
-                echo "  plugins were not installed. Re-run \`ws hoard upgrade $hoard_name\`" >&2
-                echo "  to retry." >&2
-            }
-        elif [[ -f "$template_dir/.upgrade/upgrade.yaml" ]]; then
-            echo "Skipping upgrade phase (WS_HOARD_NO_UPGRADE set). Run" >&2
-            echo "  \`ws hoard upgrade $hoard_name\` later to install plugins." >&2
+            local _tmpl_name _applied_version
+            _tmpl_name="$(basename "$template_dir")"
+            _applied_version=0   # baseline: recipe not yet applied
+            # Allow tests / offline / CI to opt out of the upgrade phase via
+            # WS_HOARD_NO_UPGRADE=1 (it hits GitHub for plugin downloads).
+            if [[ -z "${WS_HOARD_NO_UPGRADE:-}" ]]; then
+                echo ""
+                echo "Running upgrade phase from template..."
+                if _ws_hoard_apply_manifest "$template_dir" "$target" \
+                    && _ws_hoard_apply_regions "$target" "$template_dir"; then
+                    _applied_version="$(_ws_hoard_manifest_version "$template_dir")"
+                else
+                    echo "WARNING: upgrade phase failed; hoard is initialized but" >&2
+                    echo "  plugins/regions were not fully applied. Re-run" >&2
+                    echo "  \`ws hoard upgrade $hoard_name --apply\` to retry." >&2
+                fi
+            else
+                echo "Skipping upgrade phase (WS_HOARD_NO_UPGRADE set). Run" >&2
+                echo "  \`ws hoard upgrade $hoard_name --apply\` later to install plugins." >&2
+            fi
+            # Provenance reflects what was actually applied: the manifest
+            # version on success, else 0 so a later --apply brings it current
+            # (rather than a misleading "uptodate").
+            _ws_hoard_provenance_write "$target" "$_tmpl_name" "$_applied_version"
         fi
     fi
 

--- a/scripts/ws-hoard.sh
+++ b/scripts/ws-hoard.sh
@@ -774,39 +774,40 @@ ws_hoard_init() {
         fi
     fi
 
-    # If the template ships an .upgrade/ recipe, strip it from the
-    # target (it's template-internal, not user content) and run the
-    # upgrade phase against the freshly-copied hoard. This installs
-    # plugins, seeds plugin data.json, writes community-plugins.json,
-    # disables conflicting core plugins, and injects the README block.
-    if [[ -d "$target/.upgrade" ]]; then
-        rm -rf "$target/.upgrade"
-        if [[ -f "$template_dir/.upgrade/upgrade.yaml" ]]; then
-            local _tmpl_name _applied_version
-            _tmpl_name="$(basename "$template_dir")"
-            _applied_version=0   # baseline: recipe not yet applied
-            # Allow tests / offline / CI to opt out of the upgrade phase via
-            # WS_HOARD_NO_UPGRADE=1 (it hits GitHub for plugin downloads).
-            if [[ -z "${WS_HOARD_NO_UPGRADE:-}" ]]; then
-                echo ""
-                echo "Running upgrade phase from template..."
-                if _ws_hoard_apply_manifest "$template_dir" "$target" \
-                    && _ws_hoard_apply_regions "$target" "$template_dir"; then
-                    _applied_version="$(_ws_hoard_manifest_version "$template_dir")"
-                else
-                    echo "WARNING: upgrade phase failed; hoard is initialized but" >&2
-                    echo "  plugins/regions were not fully applied. Re-run" >&2
-                    echo "  \`ws hoard upgrade $hoard_name --apply\` to retry." >&2
-                fi
+    # If the template ships an .upgrade/ recipe, run the upgrade phase against
+    # the freshly-created hoard (install plugins, seed data.json, write
+    # community-plugins.json, disable core plugins, splice managed regions).
+    # Gate on the *template's* recipe, not on $target/.upgrade: the cp path
+    # copies .upgrade into the instance, but the yaml-driven clone path does
+    # not, so checking $target would skip the phase for clone-based templates.
+    if [[ -f "$template_dir/.upgrade/upgrade.yaml" ]]; then
+        # The cp path leaves a copy of .upgrade in the instance — strip it
+        # (template-internal, not user content). The clone path won't have one.
+        [[ -d "$target/.upgrade" ]] && rm -rf "$target/.upgrade"
+        local _tmpl_name _applied_version
+        _tmpl_name="$(basename "$template_dir")"
+        _applied_version=0   # baseline: recipe not yet applied
+        # Allow tests / offline / CI to opt out of the upgrade phase via
+        # WS_HOARD_NO_UPGRADE=1 (it hits GitHub for plugin downloads).
+        if [[ -z "${WS_HOARD_NO_UPGRADE:-}" ]]; then
+            echo ""
+            echo "Running upgrade phase from template..."
+            if _ws_hoard_apply_manifest "$template_dir" "$target" \
+                && _ws_hoard_apply_regions "$target" "$template_dir"; then
+                _applied_version="$(_ws_hoard_manifest_version "$template_dir")"
             else
-                echo "Skipping upgrade phase (WS_HOARD_NO_UPGRADE set). Run" >&2
-                echo "  \`ws hoard upgrade $hoard_name --apply\` later to install plugins." >&2
+                echo "WARNING: upgrade phase failed; hoard is initialized but" >&2
+                echo "  plugins/regions were not fully applied. Re-run" >&2
+                echo "  \`ws hoard upgrade $hoard_name --apply\` to retry." >&2
             fi
-            # Provenance reflects what was actually applied: the manifest
-            # version on success, else 0 so a later --apply brings it current
-            # (rather than a misleading "uptodate").
-            _ws_hoard_provenance_write "$target" "$_tmpl_name" "$_applied_version"
+        else
+            echo "Skipping upgrade phase (WS_HOARD_NO_UPGRADE set). Run" >&2
+            echo "  \`ws hoard upgrade $hoard_name --apply\` later to install plugins." >&2
         fi
+        # Provenance reflects what was actually applied: the manifest version
+        # on success, else 0 so a later --apply brings it current (rather than
+        # a misleading "uptodate").
+        _ws_hoard_provenance_write "$target" "$_tmpl_name" "$_applied_version"
     fi
 
     # git init + initial commit. Honor the user's existing git config for

--- a/scripts/ws-hoard.sh
+++ b/scripts/ws-hoard.sh
@@ -332,9 +332,12 @@ ws_hoard_help() {
     echo "                           thalamus file (used by gdd-orientation Step 0a)" >&2
     echo "  thalamus-path            Print the resolved path to the active per-machine" >&2
     echo "                           thalamus file (empty if no active hoard)" >&2
-    echo "  upgrade <hoard-name>     Re-fetch plugins and refresh configs from the" >&2
-    echo "                           hoard's template. Run after pulling a yggdrasil" >&2
-    echo "                           update or to refresh on a fresh clone." >&2
+    echo "  upgrade <hoard> [--plan|--apply|--rollback] [--template <name>]" >&2
+    echo "                           Provenance-tracked upgrade from the hoard's" >&2
+    echo "                           template (.hoard.yaml). --plan previews;" >&2
+    echo "                           --apply backs up then applies; --rollback" >&2
+    echo "                           restores the last backup. The gdd-hoard-upgrade" >&2
+    echo "                           skill drives the propose-then-apply flow." >&2
 }
 
 # Read staleness_days from a hoard's `.ws-cadence.yaml`. Defaults to 2

--- a/templates/hoards/thalami/.gitignore
+++ b/templates/hoards/thalami/.gitignore
@@ -5,3 +5,6 @@ Thumbs.db
 # Obsidian per-machine config (UI prefs, workspace state, plugin data)
 # Created when the hoard is opened as a vault for ArcDashboard.md.
 .obsidian/
+
+# Pre-upgrade snapshots written by `ws hoard upgrade --apply`
+.upgrade-backup/

--- a/templates/hoards/thalami/.hoard.yaml
+++ b/templates/hoards/thalami/.hoard.yaml
@@ -1,0 +1,2 @@
+template: thalami
+applied_version: 2

--- a/templates/hoards/thalami/.upgrade/regions/arcdashboard-controls.md
+++ b/templates/hoards/thalami/.upgrade/regions/arcdashboard-controls.md
@@ -1,4 +1,4 @@
-<!-- Template-managed (ws hoard upgrade). Edits inside the markers are overwritten on upgrade; edit around them freely. VERIFY the meta-bind-button syntax against the pinned Meta Bind release before first --apply. -->
+<!-- Template-managed (ws hoard upgrade). Edits inside the markers are overwritten on upgrade; edit around them freely. The meta-bind-button command-action block targets Meta Bind 1.4.10 (pinned in upgrade.yaml); confirm it renders as a button on first open in Obsidian. -->
 > [!tip]- Dashboard controls
 > ```meta-bind-button
 > label: "🔄 Refresh"

--- a/templates/hoards/thalami/.upgrade/regions/arcdashboard-controls.md
+++ b/templates/hoards/thalami/.upgrade/regions/arcdashboard-controls.md
@@ -1,0 +1,10 @@
+<!-- Template-managed (ws hoard upgrade). Edits inside the markers are overwritten on upgrade; edit around them freely. VERIFY the meta-bind-button syntax against the pinned Meta Bind release before first --apply. -->
+> [!tip]- Dashboard controls
+> ```meta-bind-button
+> label: "🔄 Refresh"
+> style: default
+> actions:
+>   - type: command
+>     command: dataview:dataview-force-refresh-views
+> ```
+> Hit Refresh if the **Days** column reads negative — Dataview caches `date(today)` until the view re-renders, so a pane left open across days drifts. See `docs/gdd/thalamus.md` if this recurs.

--- a/templates/hoards/thalami/.upgrade/regions/arcdashboard-controls.md
+++ b/templates/hoards/thalami/.upgrade/regions/arcdashboard-controls.md
@@ -3,8 +3,8 @@
 > ```meta-bind-button
 > label: "🔄 Refresh"
 > style: default
-> actions:
->   - type: command
->     command: dataview:dataview-force-refresh-views
+> action:
+>   type: command
+>   command: dataview:dataview-force-refresh-views
 > ```
 > Hit Refresh if the **Days** column reads negative — Dataview caches `date(today)` until the view re-renders, so a pane left open across days drifts. See `docs/gdd/thalamus.md` if this recurs.

--- a/templates/hoards/thalami/.upgrade/upgrade.yaml
+++ b/templates/hoards/thalami/.upgrade/upgrade.yaml
@@ -1,0 +1,33 @@
+# Upgrade recipe for thalami hoards.
+#
+# version 1 = the Dataview-only baseline the existing hoards shipped with.
+# version 2 adds Meta Bind and the ArcDashboard controls region (a refresh
+# button that fixes Dataview's stale date(today) on long-open panes).
+#
+# Applied by `ws hoard upgrade <hoard> --plan/--apply` (provenance resolves
+# this template via the hoard's .hoard.yaml). Plugin code is downloaded fresh
+# from the pinned GitHub release; manifest.json + data.json are tracked.
+version: 2
+description: |
+  Dataview for the ArcDashboard, plus Meta Bind for the dashboard's
+  interactive controls (a force-refresh button).
+plugins:
+  - id: dataview
+    name: Dataview
+    description: Query engine powering ArcDashboard.md.
+    repo: blacksmithgu/obsidian-dataview
+    pin: "0.5.68"
+  - id: obsidian-meta-bind-plugin
+    name: Meta Bind
+    description: Inline buttons/inputs bound to frontmatter; powers the ArcDashboard controls.
+    repo: mProjectsCode/obsidian-meta-bind-plugin
+    # VERIFY BEFORE FIRST --apply: this sentinel is intentional. Run
+    #   gh release list -R mProjectsCode/obsidian-meta-bind-plugin -L 5
+    # and replace with the chosen stable tag. A real --apply will fail the
+    # download (cleanly) until this is set — by design, so no wrong version
+    # is silently installed.
+    pin: "REPLACE-WITH-VERIFIED-TAG"
+managed_regions:
+  - file: ArcDashboard.md
+    id: controls
+    source: regions/arcdashboard-controls.md

--- a/templates/hoards/thalami/.upgrade/upgrade.yaml
+++ b/templates/hoards/thalami/.upgrade/upgrade.yaml
@@ -21,12 +21,10 @@ plugins:
     name: Meta Bind
     description: Inline buttons/inputs bound to frontmatter; powers the ArcDashboard controls.
     repo: mProjectsCode/obsidian-meta-bind-plugin
-    # VERIFY BEFORE FIRST --apply: this sentinel is intentional. Run
-    #   gh release list -R mProjectsCode/obsidian-meta-bind-plugin -L 5
-    # and replace with the chosen stable tag. A real --apply will fail the
-    # download (cleanly) until this is set — by design, so no wrong version
-    # is silently installed.
-    pin: "REPLACE-WITH-VERIFIED-TAG"
+    # Verified 2026-05-24 against the live release: tag 1.4.10 ships
+    # main.js / manifest.json / styles.css, and manifest id ==
+    # obsidian-meta-bind-plugin (minAppVersion 1.10.0).
+    pin: "1.4.10"
 managed_regions:
   - file: ArcDashboard.md
     id: controls

--- a/tests/ws-hoard-init/init.bats
+++ b/tests/ws-hoard-init/init.bats
@@ -92,7 +92,7 @@ setup() {
     [ "$status" -eq 0 ]
     [ -f "$HOARDS_DIR/test-prov/.hoard.yaml" ]
     grep -qF "template: obsidian-vault" "$HOARDS_DIR/test-prov/.hoard.yaml"
-    grep -qF "applied_version:" "$HOARDS_DIR/test-prov/.hoard.yaml"
+    grep -Eq '^applied_version:[[:space:]]*[0-9]+$' "$HOARDS_DIR/test-prov/.hoard.yaml"
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/ws-hoard-init/init.bats
+++ b/tests/ws-hoard-init/init.bats
@@ -87,6 +87,13 @@ setup() {
     [ -d "$HOARDS_DIR/test-basic/.git" ]
 }
 
+@test "init writes .hoard.yaml provenance for a template with an upgrade recipe" {
+    run_hoard_init obsidian-vault --name test-prov
+    [ "$status" -eq 0 ]
+    [ -f "$HOARDS_DIR/test-prov/.hoard.yaml" ]
+    grep -qF "template: obsidian-vault" "$HOARDS_DIR/test-prov/.hoard.yaml"
+}
+
 # ---------------------------------------------------------------------------
 # --name validation
 # ---------------------------------------------------------------------------

--- a/tests/ws-hoard-init/init.bats
+++ b/tests/ws-hoard-init/init.bats
@@ -92,6 +92,7 @@ setup() {
     [ "$status" -eq 0 ]
     [ -f "$HOARDS_DIR/test-prov/.hoard.yaml" ]
     grep -qF "template: obsidian-vault" "$HOARDS_DIR/test-prov/.hoard.yaml"
+    grep -qF "applied_version:" "$HOARDS_DIR/test-prov/.hoard.yaml"
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/ws-hoard-upgrade/test_helper.bash
+++ b/tests/ws-hoard-upgrade/test_helper.bash
@@ -1,0 +1,55 @@
+# Shared helpers for ws-hoard-upgrade bats tests.
+#
+# Sources ws-hoard-upgrade.sh directly (it's a function library) and
+# exercises its functions against an isolated TEMPLATES_DIR / HOARDS_DIR
+# under $BATS_TEST_TMPDIR. Plugin downloads are stubbed with a fake `gh`
+# on PATH so no network is touched.
+
+REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+
+setup_dirs() {
+    export ROOT_DIR="$BATS_TEST_TMPDIR/work"
+    export TEMPLATES_DIR="$ROOT_DIR/templates"
+    export HOARDS_DIR="$ROOT_DIR/hoards"
+    mkdir -p "$HOARDS_DIR" "$TEMPLATES_DIR/hoards"
+    # shellcheck source=/dev/null
+    source "$REPO_ROOT/scripts/ws-hoard-upgrade.sh"
+}
+
+# Build a template at $TEMPLATES_DIR/hoards/<name> with the given
+# upgrade.yaml content ($2).
+make_template() {
+    local name="$1" yaml="$2"
+    local dir="$TEMPLATES_DIR/hoards/$name"
+    mkdir -p "$dir/.upgrade/regions"
+    printf '%s\n' "$yaml" > "$dir/.upgrade/upgrade.yaml"
+}
+
+# Build a minimal hoard at $HOARDS_DIR/<name> with a .obsidian dir and an
+# empty community-plugins.json. Caller adds files/provenance after.
+make_hoard() {
+    local name="$1"
+    local dir="$HOARDS_DIR/$name"
+    mkdir -p "$dir/.obsidian"
+    printf '[]\n' > "$dir/.obsidian/community-plugins.json"
+}
+
+# Put a fake `gh` on PATH that emulates `gh release download ... --dir D`
+# by writing dummy main.js + manifest.json into D. No network.
+make_fake_gh() {
+    local bindir="$BATS_TEST_TMPDIR/bin"
+    mkdir -p "$bindir"
+    cat > "$bindir/gh" <<'SH'
+#!/usr/bin/env bash
+dir=""; prev=""
+for a in "$@"; do [[ "$prev" == "--dir" ]] && dir="$a"; prev="$a"; done
+if [[ -n "$dir" ]]; then
+  mkdir -p "$dir"
+  printf 'stub\n' > "$dir/main.js"
+  printf '{"id":"stub"}\n' > "$dir/manifest.json"
+fi
+exit 0
+SH
+    chmod +x "$bindir/gh"
+    export PATH="$bindir:$PATH"
+}

--- a/tests/ws-hoard-upgrade/upgrade.bats
+++ b/tests/ws-hoard-upgrade/upgrade.bats
@@ -221,6 +221,51 @@ managed_regions:
     [ "$output" = "thalami 1" ]
 }
 
+@test "region splice: missing source errors without writing the target" {
+    make_hoard h1
+    printf '# Dash\n' > "$HOARDS_DIR/h1/ArcDashboard.md"
+    run _ws_hoard_region_splice "$HOARDS_DIR/h1/ArcDashboard.md" controls "$BATS_TEST_TMPDIR/does-not-exist.md"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"source not readable"* ]]
+    [ "$(cat "$HOARDS_DIR/h1/ArcDashboard.md")" = "# Dash" ]
+}
+
+@test "region splice: inserting into a new file has no leading blank line" {
+    make_hoard h1
+    printf 'NEW\n' > "$BATS_TEST_TMPDIR/src.md"
+    _ws_hoard_region_splice "$HOARDS_DIR/h1/brand-new.md" controls "$BATS_TEST_TMPDIR/src.md"
+    run head -n 1 "$HOARDS_DIR/h1/brand-new.md"
+    [ "$output" = "<!-- BEGIN upgrade-controls -->" ]
+}
+
+@test "rollback: removes files created after the snapshot" {
+    make_hoard h1
+    printf 'orig\n' > "$HOARDS_DIR/h1/note.md"
+    _ws_hoard_backup "$HOARDS_DIR/h1" >/dev/null
+    printf 'extra\n' > "$HOARDS_DIR/h1/new-file.md"
+    run _ws_hoard_rollback "$HOARDS_DIR/h1"
+    [ "$status" -eq 0 ]
+    [ ! -e "$HOARDS_DIR/h1/new-file.md" ]
+    [ -f "$HOARDS_DIR/h1/note.md" ]
+}
+
+@test "apply: creates .obsidian when the hoard lacks one" {
+    make_template thalami "version: 1
+plugins: []"
+    mkdir -p "$HOARDS_DIR/h1"
+    _ws_hoard_provenance_write "$HOARDS_DIR/h1" thalami 0
+    run _ws_hoard_upgrade_apply "$HOARDS_DIR/h1" "$TEMPLATES_DIR/hoards/thalami"
+    [ "$status" -eq 0 ]
+    [ -d "$HOARDS_DIR/h1/.obsidian" ]
+}
+
+@test "command: --template without a value errors" {
+    make_hoard h1
+    run ws_hoard_upgrade h1 --plan --template
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"--template requires"* ]]
+}
+
 @test "apply: backs up, enables plugin, splices region, bumps provenance" {
     make_fake_gh
     make_template thalami "version: 2

--- a/tests/ws-hoard-upgrade/upgrade.bats
+++ b/tests/ws-hoard-upgrade/upgrade.bats
@@ -140,3 +140,36 @@ plugins:
     run _ws_hoard_rollback "$HOARDS_DIR/h1"
     [ "$status" -ne 0 ]
 }
+
+@test "region splice: inserts wrapped block when markers absent" {
+    make_hoard h1
+    printf '# Dash\nbody\n' > "$HOARDS_DIR/h1/ArcDashboard.md"
+    printf 'CONTROLS\n' > "$BATS_TEST_TMPDIR/src.md"
+    run _ws_hoard_region_splice "$HOARDS_DIR/h1/ArcDashboard.md" controls "$BATS_TEST_TMPDIR/src.md"
+    [ "$status" -eq 0 ]
+    grep -qF "<!-- BEGIN upgrade-controls -->" "$HOARDS_DIR/h1/ArcDashboard.md"
+    grep -qF "CONTROLS" "$HOARDS_DIR/h1/ArcDashboard.md"
+    grep -qF "# Dash" "$HOARDS_DIR/h1/ArcDashboard.md"
+}
+
+@test "region splice: replaces between markers, preserves outside" {
+    make_hoard h1
+    printf '# Dash\n<!-- BEGIN upgrade-controls -->\nOLD\n<!-- END upgrade-controls -->\ntail\n' \
+        > "$HOARDS_DIR/h1/ArcDashboard.md"
+    printf 'NEW\n' > "$BATS_TEST_TMPDIR/src.md"
+    run _ws_hoard_region_splice "$HOARDS_DIR/h1/ArcDashboard.md" controls "$BATS_TEST_TMPDIR/src.md"
+    [ "$status" -eq 0 ]
+    grep -qF "NEW" "$HOARDS_DIR/h1/ArcDashboard.md"
+    ! grep -qF "OLD" "$HOARDS_DIR/h1/ArcDashboard.md"
+    grep -qF "tail" "$HOARDS_DIR/h1/ArcDashboard.md"
+}
+
+@test "region splice: idempotent on re-run with same source" {
+    make_hoard h1
+    printf '# Dash\n' > "$HOARDS_DIR/h1/ArcDashboard.md"
+    printf 'NEW\n' > "$BATS_TEST_TMPDIR/src.md"
+    _ws_hoard_region_splice "$HOARDS_DIR/h1/ArcDashboard.md" controls "$BATS_TEST_TMPDIR/src.md"
+    _ws_hoard_region_splice "$HOARDS_DIR/h1/ArcDashboard.md" controls "$BATS_TEST_TMPDIR/src.md"
+    run grep -cF "<!-- BEGIN upgrade-controls -->" "$HOARDS_DIR/h1/ArcDashboard.md"
+    [ "$output" -eq 1 ]
+}

--- a/tests/ws-hoard-upgrade/upgrade.bats
+++ b/tests/ws-hoard-upgrade/upgrade.bats
@@ -330,7 +330,7 @@ plugins: []"
     [[ "$output" == *"--template"* ]]
 }
 
-@test "command: --template establishes provenance then plans" {
+@test "command: --plan --template previews the adopted baseline WITHOUT writing provenance" {
     make_template thalami "version: 2
 plugins: []
 managed_regions:
@@ -343,4 +343,19 @@ managed_regions:
     run ws_hoard_upgrade h1 --plan --template thalami
     [ "$status" -eq 0 ]
     [[ "$output" == *"provenance"* ]]
+    # Baseline (v1) is used in-memory so the plan shows the pending region.
+    [[ "$output" == *"region-insert"* ]]
+    # --plan must not mutate the hoard.
+    [ ! -f "$HOARDS_DIR/h1/.hoard.yaml" ]
+}
+
+@test "command: --apply --template persists provenance (adoption)" {
+    make_template thalami "version: 1
+plugins: []"
+    mkdir -p "$HOARDS_DIR/h1/.obsidian"
+    run ws_hoard_upgrade h1 --apply --template thalami
+    [ "$status" -eq 0 ]
+    [ -f "$HOARDS_DIR/h1/.hoard.yaml" ]
+    run _ws_hoard_provenance_read "$HOARDS_DIR/h1"
+    [ "$output" = "thalami 1" ]
 }

--- a/tests/ws-hoard-upgrade/upgrade.bats
+++ b/tests/ws-hoard-upgrade/upgrade.bats
@@ -112,3 +112,31 @@ plugins:
     _ws_hoard_upgrade_plan "$HOARDS_DIR/h1" "$TEMPLATES_DIR/hoards/thalami" >/dev/null
     [ "$(cat "$HOARDS_DIR/h1/.obsidian/community-plugins.json")" = "$before" ]
 }
+
+@test "backup: snapshots hoard contents, excludes .git and .upgrade-backup" {
+    make_hoard h1
+    printf 'hello\n' > "$HOARDS_DIR/h1/note.md"
+    mkdir -p "$HOARDS_DIR/h1/.git"; printf 'x\n' > "$HOARDS_DIR/h1/.git/config"
+    run _ws_hoard_backup "$HOARDS_DIR/h1"
+    [ "$status" -eq 0 ]
+    local snap="$output"
+    [ -f "$snap/note.md" ]
+    [ ! -e "$snap/.git" ]
+    [ ! -e "$snap/.upgrade-backup" ]
+}
+
+@test "rollback: restores the latest snapshot" {
+    make_hoard h1
+    printf 'original\n' > "$HOARDS_DIR/h1/note.md"
+    _ws_hoard_backup "$HOARDS_DIR/h1" >/dev/null
+    printf 'changed\n' > "$HOARDS_DIR/h1/note.md"
+    run _ws_hoard_rollback "$HOARDS_DIR/h1"
+    [ "$status" -eq 0 ]
+    [ "$(cat "$HOARDS_DIR/h1/note.md")" = "original" ]
+}
+
+@test "rollback: errors when no snapshot exists" {
+    make_hoard h1
+    run _ws_hoard_rollback "$HOARDS_DIR/h1"
+    [ "$status" -ne 0 ]
+}

--- a/tests/ws-hoard-upgrade/upgrade.bats
+++ b/tests/ws-hoard-upgrade/upgrade.bats
@@ -31,3 +31,84 @@ plugins: []"
     run _ws_hoard_manifest_version "$TEMPLATES_DIR/hoards/empty"
     [ "$status" -ne 0 ]
 }
+
+@test "plan: up to date when applied_version >= version" {
+    make_template thalami "version: 1
+plugins: []"
+    make_hoard h1
+    _ws_hoard_provenance_write "$HOARDS_DIR/h1" thalami 1
+    run _ws_hoard_upgrade_plan "$HOARDS_DIR/h1" "$TEMPLATES_DIR/hoards/thalami"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"uptodate"* ]]
+}
+
+@test "plan: new plugin is additive" {
+    make_template thalami "version: 2
+plugins:
+  - id: obsidian-meta-bind-plugin
+    name: Meta Bind
+    repo: mProjectsCode/obsidian-meta-bind-plugin
+    pin: \"1.4.1\""
+    make_hoard h1
+    _ws_hoard_provenance_write "$HOARDS_DIR/h1" thalami 1
+    run _ws_hoard_upgrade_plan "$HOARDS_DIR/h1" "$TEMPLATES_DIR/hoards/thalami"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"additive"*"obsidian-meta-bind-plugin"* ]]
+}
+
+@test "plan: managed region with no markers is region-insert" {
+    make_template thalami "version: 2
+plugins: []
+managed_regions:
+  - file: ArcDashboard.md
+    id: controls
+    source: regions/arcdashboard-controls.md"
+    printf 'controls\n' > "$TEMPLATES_DIR/hoards/thalami/.upgrade/regions/arcdashboard-controls.md"
+    make_hoard h1
+    _ws_hoard_provenance_write "$HOARDS_DIR/h1" thalami 1
+    printf '# Dash\n' > "$HOARDS_DIR/h1/ArcDashboard.md"
+    run _ws_hoard_upgrade_plan "$HOARDS_DIR/h1" "$TEMPLATES_DIR/hoards/thalami"
+    [[ "$output" == *"region-insert"*"ArcDashboard.md#controls"* ]]
+}
+
+@test "plan: managed region with markers present is region-edit" {
+    make_template thalami "version: 2
+plugins: []
+managed_regions:
+  - file: ArcDashboard.md
+    id: controls
+    source: regions/arcdashboard-controls.md"
+    printf 'controls\n' > "$TEMPLATES_DIR/hoards/thalami/.upgrade/regions/arcdashboard-controls.md"
+    make_hoard h1
+    _ws_hoard_provenance_write "$HOARDS_DIR/h1" thalami 1
+    printf '# Dash\n<!-- BEGIN upgrade-controls -->\nold\n<!-- END upgrade-controls -->\n' \
+        > "$HOARDS_DIR/h1/ArcDashboard.md"
+    run _ws_hoard_upgrade_plan "$HOARDS_DIR/h1" "$TEMPLATES_DIR/hoards/thalami"
+    [[ "$output" == *"region-edit"*"ArcDashboard.md#controls"* ]]
+}
+
+@test "plan: files_remove target that exists is destructive" {
+    make_template thalami "version: 2
+plugins: []
+files_remove:
+  - .obsidian/daily-notes.json"
+    make_hoard h1
+    _ws_hoard_provenance_write "$HOARDS_DIR/h1" thalami 1
+    printf '{}\n' > "$HOARDS_DIR/h1/.obsidian/daily-notes.json"
+    run _ws_hoard_upgrade_plan "$HOARDS_DIR/h1" "$TEMPLATES_DIR/hoards/thalami"
+    [[ "$output" == *"destructive"*"daily-notes.json"* ]]
+}
+
+@test "plan: changes nothing on disk" {
+    make_template thalami "version: 2
+plugins:
+  - id: obsidian-meta-bind-plugin
+    name: Meta Bind
+    repo: mProjectsCode/obsidian-meta-bind-plugin
+    pin: \"1.4.1\""
+    make_hoard h1
+    _ws_hoard_provenance_write "$HOARDS_DIR/h1" thalami 1
+    before="$(cat "$HOARDS_DIR/h1/.obsidian/community-plugins.json")"
+    _ws_hoard_upgrade_plan "$HOARDS_DIR/h1" "$TEMPLATES_DIR/hoards/thalami" >/dev/null
+    [ "$(cat "$HOARDS_DIR/h1/.obsidian/community-plugins.json")" = "$before" ]
+}

--- a/tests/ws-hoard-upgrade/upgrade.bats
+++ b/tests/ws-hoard-upgrade/upgrade.bats
@@ -359,3 +359,60 @@ plugins: []"
     run _ws_hoard_provenance_read "$HOARDS_DIR/h1"
     [ "$output" = "thalami 1" ]
 }
+
+@test "apply --template: backup snapshot predates the adoption marker write" {
+    make_template thalami "version: 1
+plugins: []"
+    mkdir -p "$HOARDS_DIR/h1/.obsidian"
+    run ws_hoard_upgrade h1 --apply --template thalami
+    [ "$status" -eq 0 ]
+    local snap
+    snap="$(find "$HOARDS_DIR/h1/.upgrade-backup" -mindepth 1 -maxdepth 1 -type d | head -n 1)"
+    [ -n "$snap" ]
+    # The marker was written AFTER the backup, so the snapshot must not have it.
+    [ ! -e "$snap/.hoard.yaml" ]
+    [ -f "$HOARDS_DIR/h1/.hoard.yaml" ]
+}
+
+@test "plan: a hoard plugin absent from the template is destructive" {
+    make_template thalami "version: 2
+plugins:
+  - id: dataview
+    name: Dataview
+    repo: blacksmithgu/obsidian-dataview
+    pin: \"0.5.68\""
+    make_hoard h1
+    _ws_hoard_provenance_write "$HOARDS_DIR/h1" thalami 1
+    printf '["dataview","some-extra-plugin"]\n' > "$HOARDS_DIR/h1/.obsidian/community-plugins.json"
+    run _ws_hoard_upgrade_plan "$HOARDS_DIR/h1" "$TEMPLATES_DIR/hoards/thalami"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"destructive"*"some-extra-plugin"* ]]
+}
+
+@test "plan: an existing data.json the template would overlay is destructive" {
+    make_template thalami "version: 2
+plugins: []"
+    mkdir -p "$TEMPLATES_DIR/hoards/thalami/.upgrade/data/dataview"
+    printf '{}\n' > "$TEMPLATES_DIR/hoards/thalami/.upgrade/data/dataview/data.json"
+    make_hoard h1
+    _ws_hoard_provenance_write "$HOARDS_DIR/h1" thalami 1
+    mkdir -p "$HOARDS_DIR/h1/.obsidian/plugins/dataview"
+    printf '{"existing":true}\n' > "$HOARDS_DIR/h1/.obsidian/plugins/dataview/data.json"
+    run _ws_hoard_upgrade_plan "$HOARDS_DIR/h1" "$TEMPLATES_DIR/hoards/thalami"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"destructive"*"dataview data.json"* ]]
+}
+
+@test "command: a second positional argument errors" {
+    make_hoard h1
+    run ws_hoard_upgrade h1 extra-arg
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"unexpected extra argument"* ]]
+}
+
+@test "command: conflicting mode flags error" {
+    make_hoard h1
+    run ws_hoard_upgrade h1 --plan --apply
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"only one of"* ]]
+}

--- a/tests/ws-hoard-upgrade/upgrade.bats
+++ b/tests/ws-hoard-upgrade/upgrade.bats
@@ -1,0 +1,19 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() { setup_dirs; }
+
+@test "provenance: write then read round-trips" {
+    make_hoard h1
+    _ws_hoard_provenance_write "$HOARDS_DIR/h1" thalami 3
+    run _ws_hoard_provenance_read "$HOARDS_DIR/h1"
+    [ "$status" -eq 0 ]
+    [ "$output" = "thalami 3" ]
+}
+
+@test "provenance: read returns non-zero when absent" {
+    make_hoard h1
+    run _ws_hoard_provenance_read "$HOARDS_DIR/h1"
+    [ "$status" -ne 0 ]
+}

--- a/tests/ws-hoard-upgrade/upgrade.bats
+++ b/tests/ws-hoard-upgrade/upgrade.bats
@@ -68,6 +68,7 @@ managed_regions:
     _ws_hoard_provenance_write "$HOARDS_DIR/h1" thalami 1
     printf '# Dash\n' > "$HOARDS_DIR/h1/ArcDashboard.md"
     run _ws_hoard_upgrade_plan "$HOARDS_DIR/h1" "$TEMPLATES_DIR/hoards/thalami"
+    [ "$status" -eq 0 ]
     [[ "$output" == *"region-insert"*"ArcDashboard.md#controls"* ]]
 }
 
@@ -84,6 +85,7 @@ managed_regions:
     printf '# Dash\n<!-- BEGIN upgrade-controls -->\nold\n<!-- END upgrade-controls -->\n' \
         > "$HOARDS_DIR/h1/ArcDashboard.md"
     run _ws_hoard_upgrade_plan "$HOARDS_DIR/h1" "$TEMPLATES_DIR/hoards/thalami"
+    [ "$status" -eq 0 ]
     [[ "$output" == *"region-edit"*"ArcDashboard.md#controls"* ]]
 }
 
@@ -96,6 +98,7 @@ files_remove:
     _ws_hoard_provenance_write "$HOARDS_DIR/h1" thalami 1
     printf '{}\n' > "$HOARDS_DIR/h1/.obsidian/daily-notes.json"
     run _ws_hoard_upgrade_plan "$HOARDS_DIR/h1" "$TEMPLATES_DIR/hoards/thalami"
+    [ "$status" -eq 0 ]
     [[ "$output" == *"destructive"*"daily-notes.json"* ]]
 }
 
@@ -171,7 +174,21 @@ plugins:
     _ws_hoard_region_splice "$HOARDS_DIR/h1/ArcDashboard.md" controls "$BATS_TEST_TMPDIR/src.md"
     _ws_hoard_region_splice "$HOARDS_DIR/h1/ArcDashboard.md" controls "$BATS_TEST_TMPDIR/src.md"
     run grep -cF "<!-- BEGIN upgrade-controls -->" "$HOARDS_DIR/h1/ArcDashboard.md"
+    [ "$status" -eq 0 ]
     [ "$output" -eq 1 ]
+}
+
+@test "region splice: malformed markers (BEGIN without END) error without rewriting" {
+    make_hoard h1
+    printf '# Dash\n<!-- BEGIN upgrade-controls -->\nstuff\nmore\n' > "$HOARDS_DIR/h1/ArcDashboard.md"
+    local before
+    before="$(cat "$HOARDS_DIR/h1/ArcDashboard.md")"
+    printf 'NEW\n' > "$BATS_TEST_TMPDIR/src.md"
+    run _ws_hoard_region_splice "$HOARDS_DIR/h1/ArcDashboard.md" controls "$BATS_TEST_TMPDIR/src.md"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"malformed managed-region markers"* ]]
+    # File untouched — no truncation.
+    [ "$(cat "$HOARDS_DIR/h1/ArcDashboard.md")" = "$before" ]
 }
 
 @test "apply: backs up, enables plugin, splices region, bumps provenance" {

--- a/tests/ws-hoard-upgrade/upgrade.bats
+++ b/tests/ws-hoard-upgrade/upgrade.bats
@@ -213,3 +213,42 @@ plugins: []"
     run _ws_hoard_provenance_read "$HOARDS_DIR/h1"
     [ "$output" = "thalami 1" ]
 }
+
+@test "command: --plan prints a plan and changes nothing, no enable gate needed" {
+    unset WS_HOARD_UPGRADE_ENABLED
+    make_template thalami "version: 2
+plugins:
+  - id: obsidian-meta-bind-plugin
+    name: Meta Bind
+    repo: mProjectsCode/obsidian-meta-bind-plugin
+    pin: \"1.4.1\""
+    make_hoard h1
+    _ws_hoard_provenance_write "$HOARDS_DIR/h1" thalami 1
+    run ws_hoard_upgrade h1 --plan
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"additive"* ]]
+}
+
+@test "command: errors when hoard has no provenance and no --template" {
+    make_template thalami "version: 1
+plugins: []"
+    make_hoard h1
+    run ws_hoard_upgrade h1 --plan
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"--template"* ]]
+}
+
+@test "command: --template establishes provenance then plans" {
+    make_template thalami "version: 2
+plugins: []
+managed_regions:
+  - file: ArcDashboard.md
+    id: controls
+    source: regions/arcdashboard-controls.md"
+    printf 'C\n' > "$TEMPLATES_DIR/hoards/thalami/.upgrade/regions/arcdashboard-controls.md"
+    make_hoard h1
+    printf '# Dash\n' > "$HOARDS_DIR/h1/ArcDashboard.md"
+    run ws_hoard_upgrade h1 --plan --template thalami
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"provenance"* ]]
+}

--- a/tests/ws-hoard-upgrade/upgrade.bats
+++ b/tests/ws-hoard-upgrade/upgrade.bats
@@ -173,3 +173,43 @@ plugins:
     run grep -cF "<!-- BEGIN upgrade-controls -->" "$HOARDS_DIR/h1/ArcDashboard.md"
     [ "$output" -eq 1 ]
 }
+
+@test "apply: backs up, enables plugin, splices region, bumps provenance" {
+    make_fake_gh
+    make_template thalami "version: 2
+plugins:
+  - id: obsidian-meta-bind-plugin
+    name: Meta Bind
+    description: x
+    repo: mProjectsCode/obsidian-meta-bind-plugin
+    pin: \"1.4.1\"
+managed_regions:
+  - file: ArcDashboard.md
+    id: controls
+    source: regions/arcdashboard-controls.md"
+    printf 'CONTROLS\n' > "$TEMPLATES_DIR/hoards/thalami/.upgrade/regions/arcdashboard-controls.md"
+    make_hoard h1
+    _ws_hoard_provenance_write "$HOARDS_DIR/h1" thalami 1
+    printf '# Dash\n' > "$HOARDS_DIR/h1/ArcDashboard.md"
+
+    run _ws_hoard_upgrade_apply "$HOARDS_DIR/h1" "$TEMPLATES_DIR/hoards/thalami"
+    [ "$status" -eq 0 ]
+    [ -n "$(find "$HOARDS_DIR/h1/.upgrade-backup" -mindepth 1 -maxdepth 1 -type d)" ]
+    jq -e 'index("obsidian-meta-bind-plugin")' "$HOARDS_DIR/h1/.obsidian/community-plugins.json"
+    grep -qF "CONTROLS" "$HOARDS_DIR/h1/ArcDashboard.md"
+    run _ws_hoard_provenance_read "$HOARDS_DIR/h1"
+    [ "$output" = "thalami 2" ]
+}
+
+@test "apply: aborts before changes if backup fails" {
+    make_template thalami "version: 2
+plugins: []"
+    make_hoard h1
+    _ws_hoard_provenance_write "$HOARDS_DIR/h1" thalami 1
+    # Plant a FILE where the .upgrade-backup dir would go, so mkdir -p fails.
+    printf 'x\n' > "$HOARDS_DIR/h1/.upgrade-backup"
+    run _ws_hoard_upgrade_apply "$HOARDS_DIR/h1" "$TEMPLATES_DIR/hoards/thalami"
+    [ "$status" -ne 0 ]
+    run _ws_hoard_provenance_read "$HOARDS_DIR/h1"
+    [ "$output" = "thalami 1" ]
+}

--- a/tests/ws-hoard-upgrade/upgrade.bats
+++ b/tests/ws-hoard-upgrade/upgrade.bats
@@ -17,3 +17,17 @@ setup() { setup_dirs; }
     run _ws_hoard_provenance_read "$HOARDS_DIR/h1"
     [ "$status" -ne 0 ]
 }
+
+@test "manifest version: reads the integer version" {
+    make_template thalami "version: 2
+plugins: []"
+    run _ws_hoard_manifest_version "$TEMPLATES_DIR/hoards/thalami"
+    [ "$status" -eq 0 ]
+    [ "$output" = "2" ]
+}
+
+@test "manifest version: returns 1 when no manifest" {
+    mkdir -p "$TEMPLATES_DIR/hoards/empty"
+    run _ws_hoard_manifest_version "$TEMPLATES_DIR/hoards/empty"
+    [ "$status" -ne 0 ]
+}

--- a/tests/ws-hoard-upgrade/upgrade.bats
+++ b/tests/ws-hoard-upgrade/upgrade.bats
@@ -191,6 +191,36 @@ plugins:
     [ "$(cat "$HOARDS_DIR/h1/ArcDashboard.md")" = "$before" ]
 }
 
+@test "region splice: malformed markers (END without BEGIN) error without rewriting" {
+    make_hoard h1
+    printf '# Dash\n<!-- END upgrade-controls -->\ntail\n' > "$HOARDS_DIR/h1/ArcDashboard.md"
+    local before
+    before="$(cat "$HOARDS_DIR/h1/ArcDashboard.md")"
+    printf 'NEW\n' > "$BATS_TEST_TMPDIR/src.md"
+    run _ws_hoard_region_splice "$HOARDS_DIR/h1/ArcDashboard.md" controls "$BATS_TEST_TMPDIR/src.md"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"malformed managed-region markers"* ]]
+    [ "$(cat "$HOARDS_DIR/h1/ArcDashboard.md")" = "$before" ]
+}
+
+@test "apply: aborts and leaves provenance un-bumped when a region splice fails" {
+    make_template thalami "version: 2
+plugins: []
+managed_regions:
+  - file: ArcDashboard.md
+    id: controls
+    source: regions/arcdashboard-controls.md"
+    printf 'CONTROLS\n' > "$TEMPLATES_DIR/hoards/thalami/.upgrade/regions/arcdashboard-controls.md"
+    make_hoard h1
+    _ws_hoard_provenance_write "$HOARDS_DIR/h1" thalami 1
+    # Malformed marker (BEGIN without END) makes the region splice fail mid-apply.
+    printf '# Dash\n<!-- BEGIN upgrade-controls -->\nx\n' > "$HOARDS_DIR/h1/ArcDashboard.md"
+    run _ws_hoard_upgrade_apply "$HOARDS_DIR/h1" "$TEMPLATES_DIR/hoards/thalami"
+    [ "$status" -ne 0 ]
+    run _ws_hoard_provenance_read "$HOARDS_DIR/h1"
+    [ "$output" = "thalami 1" ]
+}
+
 @test "apply: backs up, enables plugin, splices region, bumps provenance" {
     make_fake_gh
     make_template thalami "version: 2


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @Cervator via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

Re-enables `ws hoard upgrade` as a provenance-tracked, plan-first, agent-mediated, backed-up flow — replacing the blind-apply behavior that got it disabled (it applied obsidian-vault's recipe to any hoard, risking edits to thalamus files). Brainstormed → designed → planned → implemented TDD over one lineage.

**Mechanism:**
- **Provenance** — each hoard carries a git-committed `.hoard.yaml` (`template` + `applied_version`); `ws hoard init` writes it. No more guessing which template applies.
- **Versioned declarative manifest** — `.upgrade/upgrade.yaml` gains a `version` and a `managed_regions` block (sentinel-delimited blocks the template owns inside a file).
- **`--plan`** resolves the template via `.hoard.yaml`, diffs desired-vs-live, and prints classified changes (`additive` / `region-insert` / `region-edit` / `destructive` / `uptodate`) — touching nothing.
- **`--apply`** snapshots the whole hoard to `.upgrade-backup/<ts>/` (aborts if the backup fails), applies the manifest + region splices, then bumps `applied_version` last (so a mid-apply failure stays retryable).
- **`--rollback`** restores the latest snapshot.
- **`gdd-hoard-upgrade` skill** drives plan → propose-risky-changes-to-human → apply.
- **Re-enable** — dropped the `WS_HOARD_UPGRADE_ENABLED` gate + multi-template auto-discovery; provenance scopes each run. A pre-`.hoard.yaml` hoard is adopted via `--template <name>` at a baseline one version behind.
- **First real recipe** — `thalami` gets its own `.upgrade/upgrade.yaml` (v1 Dataview baseline → v2 adds Meta Bind + an `ArcDashboard.md` controls region with a Dataview force-refresh button).

Design + plan are in the first commit (`docs/plans/2026-05-23-hoard-upgrade-v2-{design,plan}.md`).

## Test plan

- [x] `bash scripts/ws test yggdrasil` — full suite green (**205**; +22 from the new `tests/ws-hoard-upgrade/` suite and an init-provenance test). Plugin downloads stubbed via a fake `gh`; no network in tests.
- [x] Per-task TDD (red → green → commit) across all 11 plan tasks; `ws hoard init` standard-flow regression green after the `_ws_hoard_apply_manifest` extraction.

## Notes for reviewers

- **One deliberate sentinel:** the Meta Bind `pin` in `templates/hoards/thalami/.upgrade/upgrade.yaml` is `REPLACE-WITH-VERIFIED-TAG` — `gh` wasn't authenticated in the build env to verify the tag, and a real `--apply` should fail the download cleanly rather than install a guessed version. It (and the `meta-bind-button` syntax in the region source) must be verified against the live plugin release before the first real upgrade. Engine tests stub `gh`, so this doesn't affect the suite.
- **`data.json` is still overwrite-on-apply** (no three-way merge yet) — deferred per the design (yggdrasil#54), so per-hoard plugin-setting tweaks don't survive an upgrade.
- **Software-component upgrades (Dependabot-style)** are a future seam only — the provenance/version concept is meant to generalize, but nothing component-facing is built here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plan/apply/rollback hoard upgrades with per-hoard provenance, template adoption, pre-apply backups, classified plans (additive, region-insert/edit, destructive), and human-approval gating; hoard init now records provenance.

* **Documentation**
  * Added user guide, design, and implementation plan describing provenance, managed regions, plan-first workflow, approval rules, and rollback semantics.

* **Chores**
  * CLI help updated; template versions/pins bumped; dashboard refresh control and backup ignore added.

* **Tests**
  * New end-to-end and helper tests for init, plan/preview/apply, backups/rollback, and region splicing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SiliconSaga/yggdrasil/pull/74?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->