### PR TITLE
fix(hoard): ws hoard upgrade post-merge follow-ups (plan honesty, backup prune, CRLF)

### DIFF
--- a/scripts/ws-hoard-upgrade.sh
+++ b/scripts/ws-hoard-upgrade.sh
@@ -185,6 +185,14 @@ _ws_hoard_backup() {
     local ts snap
     ts="$(date '+%Y%m%d-%H%M%S')"
     mkdir -p "$hoard_dir/.upgrade-backup" || return 1
+    # Ensure git ignores the snapshots. Hoards adopted via --template predate
+    # the template's .gitignore entry, so without this they'd commit backups.
+    if [[ -d "$hoard_dir/.git" ]]; then
+        local gi="$hoard_dir/.gitignore"
+        if ! { [[ -f "$gi" ]] && grep -qxF '.upgrade-backup/' "$gi"; }; then
+            printf '\n# Pre-upgrade snapshots written by `ws hoard upgrade --apply`\n.upgrade-backup/\n' >> "$gi"
+        fi
+    fi
     # mktemp -d adds a random suffix so two snapshots in the same second
     # can't merge into one directory (which would weaken rollback).
     snap="$(mktemp -d "$hoard_dir/.upgrade-backup/${ts}-XXXXXX")" || return 1

--- a/scripts/ws-hoard-upgrade.sh
+++ b/scripts/ws-hoard-upgrade.sh
@@ -114,13 +114,17 @@ _ws_hoard_upgrade_plan() {
         ri=$((ri+1))
     done
 
-    # files_remove: destructive when the target exists.
+    # files_remove: destructive when the target exists AND is a file. apply uses
+    # `rm -f` (which skips directories), so the plan only flags what apply can
+    # actually remove — a directory entry would otherwise show in the plan but
+    # be silently skipped on apply.
     local fn fi rel
     fn="$(yq '.files_remove // [] | length' "$upgrade_yaml")"
     fi=0
     while [[ $fi -lt $fn ]]; do
         rel="$(yq ".files_remove[$fi]" "$upgrade_yaml")"
-        [[ -e "$hoard_dir/$rel" ]] && printf 'destructive\tremove %s\n' "$rel"
+        [[ -e "$hoard_dir/$rel" && ! -d "$hoard_dir/$rel" ]] \
+            && printf 'destructive\tremove %s\n' "$rel"
         fi=$((fi+1))
     done
 
@@ -143,11 +147,20 @@ _ws_hoard_upgrade_plan() {
     # --apply overwrites community-plugins.json with exactly the template ids,
     # so these would be disabled. Surface them so the plan stays truthful.
     if [[ -f "$cp_json" ]]; then
+        # Newline-delimited template ids (NOT -o tsv, which row-orients them onto
+        # one tab-separated line). Membership via a bash `case` substring —
+        # portable (bash 3.2) and avoids a grep-here-string-in-while-read fd
+        # clash on Git Bash. Strip a trailing CR from each enabled id: jq on
+        # Windows emits CRLF, so `read` would otherwise yield "id\r" and never
+        # match a clean template id.
         local tmpl_ids enabled_id
-        tmpl_ids="$(yq -o tsv '.plugins // [] | .[].id' "$upgrade_yaml" 2>/dev/null)"
+        tmpl_ids="$(yq '.plugins // [] | .[].id' "$upgrade_yaml" 2>/dev/null)"
         while IFS= read -r enabled_id; do
+            enabled_id="${enabled_id%$'\r'}"
             [[ -n "$enabled_id" ]] || continue
-            grep -qxF "$enabled_id" <<< "$tmpl_ids" && continue
+            case $'\n'"$tmpl_ids"$'\n' in
+                *$'\n'"$enabled_id"$'\n'*) continue ;;
+            esac
             printf 'destructive\tdisable plugin %s (overwrite of community-plugins.json drops it)\n' "$enabled_id"
         done < <(jq -r '.[]?' "$cp_json" 2>/dev/null)
     fi
@@ -560,6 +573,26 @@ _ws_hoard_upgrade_from_template() {
     _ws_hoard_apply_manifest "$@"
 }
 
+# Keep only the N most recent .upgrade-backup/<ts>/ snapshots (default 3,
+# override with WS_HOARD_BACKUP_KEEP). Portable: collects dirs oldest-first and
+# removes all but the last N (avoids the non-portable `head -n -N`).
+_ws_hoard_prune_backups() {
+    local hoard_dir="$1" keep="${2:-${WS_HOARD_BACKUP_KEEP:-3}}"
+    local backups_dir="$hoard_dir/.upgrade-backup"
+    [[ -d "$backups_dir" ]] || return 0
+    [[ "$keep" =~ ^[0-9]+$ ]] || keep=3
+    local dirs=() d
+    while IFS= read -r d; do
+        dirs+=("$d")
+    done < <(find "$backups_dir" -mindepth 1 -maxdepth 1 -type d | sort)
+    local total=${#dirs[@]} i
+    local to_delete=$(( total - keep ))
+    [[ "$to_delete" -gt 0 ]] || return 0
+    for (( i = 0; i < to_delete; i++ )); do
+        rm -rf "${dirs[$i]}"
+    done
+}
+
 # Apply an upgrade end to end: backup, mechanical manifest apply, region
 # splices, provenance bump. Aborts before any change if the backup fails.
 # Args: <hoard_dir> <template_dir> [adopt_baseline]. When adopt_baseline is
@@ -590,6 +623,10 @@ _ws_hoard_upgrade_apply() {
     local template
     template="$(basename "$template_dir")"
     _ws_hoard_provenance_write "$hoard_dir" "$template" "$version"
+
+    # Self-trim the snapshots so backups don't accumulate forever (no separate
+    # human chore). Best-effort — a prune failure must not fail the upgrade.
+    _ws_hoard_prune_backups "$hoard_dir" || true
 }
 
 # Public command. Resolves the source template from <hoard>/.hoard.yaml

--- a/tests/ws-hoard-upgrade/upgrade.bats
+++ b/tests/ws-hoard-upgrade/upgrade.bats
@@ -128,6 +128,14 @@ plugins:
     [ ! -e "$snap/.upgrade-backup" ]
 }
 
+@test "backup: ensures .upgrade-backup/ is gitignored in a git-tracked hoard" {
+    make_hoard h1
+    mkdir -p "$HOARDS_DIR/h1/.git"
+    printf '.obsidian/\n' > "$HOARDS_DIR/h1/.gitignore"
+    _ws_hoard_backup "$HOARDS_DIR/h1" >/dev/null
+    grep -qxF '.upgrade-backup/' "$HOARDS_DIR/h1/.gitignore"
+}
+
 @test "rollback: restores the latest snapshot" {
     make_hoard h1
     printf 'original\n' > "$HOARDS_DIR/h1/note.md"

--- a/tests/ws-hoard-upgrade/upgrade.bats
+++ b/tests/ws-hoard-upgrade/upgrade.bats
@@ -387,6 +387,39 @@ plugins:
     run _ws_hoard_upgrade_plan "$HOARDS_DIR/h1" "$TEMPLATES_DIR/hoards/thalami"
     [ "$status" -eq 0 ]
     [[ "$output" == *"destructive"*"some-extra-plugin"* ]]
+    # An in-template plugin (dataview) must NOT be flagged — it survives the
+    # overwrite. Regression for the -o tsv false-positive found via live --plan.
+    [[ "$output" != *"dataview"* ]]
+}
+
+@test "plan: a directory in files_remove is not flagged (apply uses rm -f)" {
+    make_template thalami "version: 2
+plugins: []
+files_remove:
+  - somedir"
+    make_hoard h1
+    _ws_hoard_provenance_write "$HOARDS_DIR/h1" thalami 1
+    mkdir -p "$HOARDS_DIR/h1/somedir"
+    run _ws_hoard_upgrade_plan "$HOARDS_DIR/h1" "$TEMPLATES_DIR/hoards/thalami"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"somedir"* ]]
+}
+
+@test "apply: prunes old backups, keeping WS_HOARD_BACKUP_KEEP most recent" {
+    make_template thalami "version: 1
+plugins: []"
+    mkdir -p "$HOARDS_DIR/h1/.obsidian"
+    _ws_hoard_provenance_write "$HOARDS_DIR/h1" thalami 0
+    mkdir -p "$HOARDS_DIR/h1/.upgrade-backup/20260101-000001" \
+             "$HOARDS_DIR/h1/.upgrade-backup/20260101-000002" \
+             "$HOARDS_DIR/h1/.upgrade-backup/20260101-000003" \
+             "$HOARDS_DIR/h1/.upgrade-backup/20260101-000004"
+    export WS_HOARD_BACKUP_KEEP=3
+    run _ws_hoard_upgrade_apply "$HOARDS_DIR/h1" "$TEMPLATES_DIR/hoards/thalami"
+    [ "$status" -eq 0 ]
+    # 4 pre-seeded + 1 from this apply = 5; pruned to the 3 newest.
+    run find "$HOARDS_DIR/h1/.upgrade-backup" -mindepth 1 -maxdepth 1 -type d
+    [ "${#lines[@]}" -eq 3 ]
 }
 
 @test "plan: an existing data.json the template would overlay is destructive" {


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @Cervator via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

Post-merge follow-ups for `ws hoard upgrade` (#74), from the batched review/test findings plus a live `--plan`/`--apply` dry-run against a real thalami hoard.

- **`--plan` plugin false-positive (two stacked bugs).** The destructive-plugin check extracted template ids with `yq -o tsv` (row-orients onto one tab-separated line) and compared them against `jq`-read ids that carry a trailing CR on Windows (`jq` emits CRLF). Result: every in-template plugin (e.g. `dataview`) was wrongly flagged "would be dropped." Fixed: newline-separated `yq` (no `-o tsv`), bash-`case` substring membership (also avoids a grep-here-string-in-`while read` fd clash on Git Bash), and a CR strip on each read id.
- **`files_remove` plan/apply mismatch (CodeRabbit).** Plan used `-e` (matches directories) but apply uses `rm -f` (skips them). Plan now flags only non-directories.
- **`.upgrade-backup/` retention.** `--apply` prunes to the most recent N snapshots (default 3, `WS_HOARD_BACKUP_KEEP`).
- **Auto-ignore `.upgrade-backup/`.** Hoards adopted via `--template` predate the template's `.gitignore`; the backup step now appends the ignore entry so snapshots aren't accidentally committed.

## Test plan

- [x] `bash scripts/ws test yggdrasil` — full suite green (**222**), incl. new tests: in-template plugin not flagged, directory in `files_remove` not flagged, keep-last-N prune, and `.gitignore` auto-ignore.
- [x] Live dry-run: `ws hoard upgrade thalami-Cervator --plan --template thalami` now shows a clean 3-line plan (adopt @ v1, enable Meta Bind, region-insert) with no false `dataview` destructive; `--apply` then installed Meta Bind 1.4.10 and spliced the ArcDashboard controls region successfully.

## Notes for reviewers

- The CRLF and grep-in-loop issues were Git-Bash-specific and slipped the original round-5 test (which only asserted the *expected* destructive id appeared, not the absence of false positives) — the new test asserts the negative.
- One remaining manual check (not code): confirm the `meta-bind-button` block renders as a button on first open in Obsidian.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Automatic pruning of old upgrade backups (keeps most recent snapshots).
  * Automatic `.gitignore` updates to exclude backup snapshots from version control.

* **Improvements**
  * Enhanced plugin conflict detection with safer line-ending handling.
  * Refined directory handling in upgrade planning.

* **Tests**
  * Added comprehensive test coverage for backup management and upgrade operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SiliconSaga/yggdrasil/pull/75?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->