### PR TITLE
feat(thalami): ArcDashboard filter + sort controls

### DIFF
--- a/templates/hoards/thalami/.upgrade/regions/arcdashboard-controls.md
+++ b/templates/hoards/thalami/.upgrade/regions/arcdashboard-controls.md
@@ -1,10 +1,11 @@
-<!-- Template-managed (ws hoard upgrade). Edits inside the markers are overwritten on upgrade; edit around them freely. The meta-bind-button command-action block targets Meta Bind 1.4.10 (pinned in upgrade.yaml); confirm it renders as a button on first open in Obsidian. -->
-> [!tip]- Dashboard controls
-> ```meta-bind-button
-> label: "🔄 Refresh"
-> style: default
-> action:
->   type: command
->   command: dataview:dataview-force-refresh-views
-> ```
-> Hit Refresh if the **Days** column reads negative — Dataview caches `date(today)` until the view re-renders, so a pane left open across days drifts. See `docs/gdd/thalamus.md` if this recurs.
+<!-- Template-managed (ws hoard upgrade); edit the region source in the template, not here. -->
+```meta-bind-button
+label: "🔄 Refresh"
+style: default
+id: arc-refresh
+hidden: true
+action:
+  type: command
+  command: dataview:dataview-force-refresh-views
+```
+**Filter** `INPUT[text:filter]` · **Sort by** `INPUT[inlineSelect(option(Status), option(Touched, Last touched), option(Arc), option(Host), option(Age), option(Impact), option(Urgency)):sortby]` · **Desc** `INPUT[toggle:descending]` · `BUTTON[arc-refresh]`

--- a/templates/hoards/thalami/.upgrade/upgrade.yaml
+++ b/templates/hoards/thalami/.upgrade/upgrade.yaml
@@ -1,8 +1,11 @@
 # Upgrade recipe for thalami hoards.
 #
 # version 1 = the Dataview-only baseline the existing hoards shipped with.
-# version 2 adds Meta Bind and the ArcDashboard controls region (a refresh
-# button that fixes Dataview's stale date(today) on long-open panes).
+# version 2 adds Meta Bind and the ArcDashboard controls region: a refresh
+# button (fixes Dataview's stale date(today) on long-open panes), a filter
+# box, and a sort-by dropdown with direction toggle. The query logic those
+# controls drive lives in the base ArcDashboard.md (delivered on init), so
+# the controls region only renders correctly atop a v2 base dashboard.
 #
 # Applied by `ws hoard upgrade <hoard> --plan/--apply` (provenance resolves
 # this template via the hoard's .hoard.yaml). Plugin code is downloaded fresh
@@ -10,7 +13,7 @@
 version: 2
 description: |
   Dataview for the ArcDashboard, plus Meta Bind for the dashboard's
-  interactive controls (a force-refresh button).
+  interactive controls (force-refresh button, filter box, sort dropdown).
 plugins:
   - id: dataview
     name: Dataview

--- a/templates/hoards/thalami/ArcDashboard.md
+++ b/templates/hoards/thalami/ArcDashboard.md
@@ -1,10 +1,29 @@
+---
+filter: ""
+sortby: Status
+descending: false
+---
 # Thalami Arc Dashboard
 
-Live cross-host view of in-flight work. Renders when this hoard is opened as an Obsidian vault with the Dataview plugin installed (see this hoard's `README.md` for one-time setup).
+Live cross-host view of in-flight work. Renders when this hoard is opened as an Obsidian vault with the Dataview and Meta Bind plugins installed (see this hoard's `README.md` for one-time setup). The Filter, Sort, and Refresh controls by the table can take a few seconds to update after you use them.
 
 ## Arcs
 
-Each row is one (host, arc) pair. Arcs that span hosts share an `id` slug and appear as adjacent rows under the status sort.
+Each row is one (host, arc) pair. Arcs that span hosts share an `id` slug and appear as adjacent rows under the default status sort. Refresh if the **Age** column reads negative — Dataview caches `date(today)` until the view re-renders.
+
+<!-- BEGIN upgrade-controls -->
+<!-- Template-managed (ws hoard upgrade); edit the region source in the template, not here. -->
+```meta-bind-button
+label: "🔄 Refresh"
+style: default
+id: arc-refresh
+hidden: true
+action:
+  type: command
+  command: dataview:dataview-force-refresh-views
+```
+**Filter** `INPUT[text:filter]` · **Sort by** `INPUT[inlineSelect(option(Status), option(Touched, Last touched), option(Arc), option(Host), option(Age), option(Impact), option(Urgency)):sortby]` · **Desc** `INPUT[toggle:descending]` · `BUTTON[arc-refresh]`
+<!-- END upgrade-controls -->
 
 ```dataview
 TABLE WITHOUT ID
@@ -23,11 +42,14 @@ TABLE WITHOUT ID
   arc.impact AS "Impact",
   arc.urgency AS "Urgency",
   regexreplace(file.name, "-thalamus$", "") AS "Host",
-  (date(today) - date(arc.started)).days AS "Days"
+  arc.last_touched AS "Touched",
+  (date(today) - date(arc.started)).days AS "Age"
 FROM ""
 WHERE arcs
 FLATTEN arcs AS arc
-SORT arc.status ASC, arc.last_touched DESC
+WHERE this.filter = null OR this.filter = "" OR contains(lower(string(arc.id) + " " + string(arc.name) + " " + string(arc.status) + " " + regexreplace(file.name, "-thalamus$", "") + " " + string(arc.tags)), lower(this.filter))
+FLATTEN choice(this.sortby = "Arc", arc.id, choice(this.sortby = "Host", regexreplace(file.name, "-thalamus$", ""), choice(this.sortby = "Age", (date(today) - date(arc.started)).days, choice(this.sortby = "Touched", arc.last_touched, choice(this.sortby = "Impact", choice(arc.impact = "high", 0, choice(arc.impact = "medium", 1, choice(arc.impact = "low", 2, 3))), choice(this.sortby = "Urgency", choice(arc.urgency = "asap", 0, choice(arc.urgency = "next", 1, choice(arc.urgency = "soon", 2, choice(arc.urgency = "later", 3, 4)))), arc.status)))))) AS sortkey
+SORT choice(this.descending, null, sortkey) ASC, choice(this.descending, sortkey, null) DESC, arc.last_touched DESC
 ```
 
 ## Vibe legend & count

--- a/templates/hoards/thalami/README.md
+++ b/templates/hoards/thalami/README.md
@@ -50,12 +50,17 @@ This hoard ships an `ArcDashboard.md` that renders an at-a-glance table of in-fl
 
 ### Setup (one-time, per machine)
 
+Follow these steps, or better yet see the shortcut at the end.
+
 1. **Open this folder as an Obsidian vault.** In Obsidian: `File → Open vault → Open folder as vault`, point at this hoard's directory.
 2. **Install the Dataview plugin.** `Settings → Community plugins → Browse`, search for *Dataview*, install, then enable. After enabling, open `Settings → Dataview` and turn on **"Enable JavaScript Queries"** — required for the dashboard's tags and per-host one-liner blocks.
-3. **Recommended: disable readable-line-length.** `Settings → Editor → Readable line length` → toggle off. Lets the dashboard table use the full window width. The vault is single-purpose (thalamus files + dashboard); the prose-readability cap isn't useful here.
-4. **Open `ArcDashboard.md`.** The query blocks render as live tables.
+3. **Install the Meta Bind plugin.** Same `Browse` flow, search for *Meta Bind*, install, then enable. It powers the dashboard's Filter box, Sort dropdown, and Refresh button above the table.
+4. **Recommended: disable readable-line-length.** `Settings → Editor → Readable line length` → toggle off. Lets the dashboard table use the full window width. The vault is single-purpose (thalamus files + dashboard); the prose-readability cap isn't useful here.
+5. **Open `ArcDashboard.md`.** The query blocks render as live tables, and the controls above the table become interactive.
 
 Obsidian creates a `.obsidian/` directory the first time you open the vault; that's gitignored by default since it's a per-machine UI preference store, not shared state.
+
+**Shortcut:** instead of installing the two plugins by hand, `ws hoard upgrade thalami --apply` downloads and enables the pinned Dataview + Meta Bind releases into this vault's `.obsidian/` for you. You still do steps 1, 4, and 5.
 
 ---
 


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @Cervator via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

Expands the thalami v2 ArcDashboard controls region beyond the refresh button into a full inline control bar — a live filter box and a sort-by dropdown with direction toggle — bound to dashboard frontmatter via Meta Bind and driven by the Dataview query. Stays `version: 2` (no other hoard has adopted v2 yet, so this folds in rather than minting v3).

- **Filter** — `INPUT[text:filter]` writes a `filter` frontmatter key; the table query gains a `WHERE` clause that substring-matches across arc id / name / status / host / tags (empty shows all).
- **Sort by + Desc** — an `inlineSelect` dropdown (`sortby`) and a `toggle` (`descending`) drive a `FLATTEN … AS sortkey` + `SORT`. Direction is dynamic via the null-key trick (DQL can't take a dynamic ASC/DESC keyword). Impact/Urgency sort by priority rank, not alphabetically.
- **Touched** column added; **Days → Age** rename.
- **De-callout** — the controls were wrapped in a collapsible `> [!tip]-` callout that swallowed button clicks; they now render as one inline line with a hidden button definition referenced via inline `BUTTON[arc-refresh]`.
- **Placement** — the `<!-- BEGIN/END upgrade-controls -->` markers are pre-placed in the base template below the Arcs intro, so a fresh `ws hoard init` splices the controls above the table rather than appending at the bottom.
- **README** — adds a Meta Bind install step and a `ws hoard upgrade --apply` shortcut that auto-installs the pinned plugins.

## Known limitation

The controls' query logic lives in the base `ArcDashboard.md` (frontmatter + dataview block), not in the managed region — the comment-marker mechanism can't wrap frontmatter or be split across non-contiguous spans. So a fresh `ws hoard init` gets everything, but a hypothetical *pre-v2* hoard running upgrade-only would get the controls spliced atop an old query and they'd be inert. No such hoard exists today (documented in `upgrade.yaml`). The broader "how should multi-site upgrades work" question is being tracked separately.

## Test plan

- [x] Live-tested on a real thalami hoard in Obsidian (Reading + Live Preview): filter narrows the table as you type; sort dropdown + Desc toggle reorder correctly in both directions; Refresh button fires.
- [ ] `bash scripts/ws test yggdrasil` — confirm the hoard-upgrade suite stays green (tests build synthetic templates in temp dirs, so they don't read these files, but worth a sanity run).
- [ ] Fresh `ws hoard init` of a thalami hoard renders the controls above the table on first open.

## Notes for reviewers

- The button-click fix (de-callout) and the controls placement were both found during live Obsidian testing, not unit tests.
- `version` intentionally stays 2; see the Summary rationale.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard now supports text filtering, multi-field sorting (Status/Touched/Arc/Host/Age/Impact/Urgency), and sort direction toggle.

* **Documentation**
  * Updated setup instructions with Meta Bind plugin installation steps and clarified upgrade workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SiliconSaga/yggdrasil/pull/76?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->