### PR TITLE
skill: add kube-prometheus-stack (chart wiring + GKE dual-stack cost discipline)

### DIFF
--- a/.agent/skills/kube-prometheus-stack/SKILL.md
+++ b/.agent/skills/kube-prometheus-stack/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: kube-prometheus-stack
+description: Use when configuring the kube-prometheus-stack helm chart — chart wiring + cross-namespace selectors, the `release:` label requirement on ServiceMonitor/PrometheusRule, `Recreate` strategy for single-replica RWO workloads, taming the noisy default `*Down` alerts on managed K8s (GKE/EKS/AKS) where the control plane is hidden, and the GKE dual-stack-cost recipe for fluent-bit↔plugin meta-chatter on `127.0.0.1:2021`. Defers to `grafana/skills` for PromQL/dashboarding/Loki/Tempo and `alertmanager-config` for native AM routing.
+---
+
+# kube-prometheus-stack
+
+## Overview
+
+`kube-prometheus-stack` (Prometheus Operator chart) is the canonical opinionated bundle for self-hosted Prometheus + AlertManager + Grafana on Kubernetes. Most of its gotchas are *integration* concerns: how the Operator selects your CRs (ServiceMonitor / PrometheusRule), what breaks on managed K8s where the control plane is hidden, and how to keep your observability stack from doubling your cloud-logging bill.
+
+## When to Use
+
+- Writing or debugging helm values for `prometheus-community/kube-prometheus-stack`.
+- Authoring `ServiceMonitor` / `PodMonitor` / `PrometheusRule` CRs the Operator should pick up.
+- Deploying on a managed cluster (GKE/EKS/AKS) and seeing constantly-firing default `*Down` alerts.
+- Cloud Logging bill spiked after adding your own observability stack on GKE.
+
+NOT for native AlertManager routing/templating — see `alertmanager-config`. NOT for PromQL / Grafana dashboards / Loki / Tempo content — adopt `grafana/skills`.
+
+## Quick Reference
+
+| Goal | Pattern | Gotcha |
+|------|---------|--------|
+| Operator picks up your CR | Label `ServiceMonitor`/`PrometheusRule` with `release: <chart-release-name>` | Default selector is `release=<release>`. **Missing this is the #1 silent-invisibility cause** — Prometheus doesn't scrape, rules don't fire, no error. |
+| Pick up CRs from other namespaces | `prometheus.prometheusSpec.{serviceMonitor,podMonitor,rule,probe}SelectorNilUsesHelmValues: false` + `serviceMonitorNamespaceSelector: {}` (and the matching `*NamespaceSelector` fields) | Default is "same namespace as the Prometheus CR only." |
+| Grafana admin password from Secret | `grafana.admin.existingSecret: <name>` + `passwordKey: password` | Legacy `grafana.adminPassword: <value>` works but bakes plaintext into helm values. Chart-version drift: `helm show values prometheus-community/kube-prometheus-stack` to confirm the current path. |
+| Scrape interval | `30s` is production-safe | Matches the chart's own cadence and 5m alert windows. |
+| `up == 0` `job` label | Operator-generated label is usually `<namespace>/<servicemonitor-name>` | If `up{job="…"} == 0` never matches, query bare `up{}` to see the actual label value. |
+
+## Single-Replica RWO Workloads: `strategy: Recreate`
+
+Any single-replica Deployment that mounts a `ReadWriteOnce` PVC (single-replica Loki, AlertManager with persistence, Grafana with a PVC, ntfy-style sidecar apps) **must** use `strategy: Recreate`. Default RollingUpdate deadlocks on the RWO volume:
+
+- The new pod can't attach the PV the old pod still holds → `Multi-Attach error`.
+- maxUnavailable rounds to 0 at 1 replica → the deployment controller refuses to scale old down → pod stuck `ContainerCreating` forever.
+- On GKE PD-backed `standard-rwo`, the volume is genuinely single-attach.
+
+`Recreate` kills the old pod first → volume detaches → new pod attaches cleanly. Brief downtime, deterministic.
+
+**In-place migration trap:** SSA-patching an existing `RollingUpdate` Deployment to `Recreate` fails — the API forbids `spec.strategy.rollingUpdate` under `type: Recreate` and provider-kubernetes/SSA can't clear the defaulted field. Delete the live Deployment once so the controller recreates it cleanly from the manifest.
+
+## Noisy Default Alerts on Managed K8s
+
+`kube-prometheus-stack` bundles the upstream `kubernetes-mixin` rules, which assume self-managed control-plane components are scrape-exposed. On GKE/EKS/AKS the masters are hidden — targets are absent — `*Down` alerts fire forever:
+
+- `KubeControllerManagerDown`, `KubeSchedulerDown` — components run on the managed master.
+- `KubeProxyDown` — on GKE Dataplane V2 (Cilium) there's no kube-proxy at all.
+- `etcd*Down` / `etcdInsufficientMembers` — etcd is master-side.
+- `AlertmanagerClusterDown` — fires when AM is `replicas: 1` (rule expects a cluster).
+
+`Watchdog` **always fires by design** — it's the heartbeat for dead-man's-switch integrations. Don't disable it. See `alertmanager-config` → "Watchdog canary."
+
+**Tame at install** (best — both removes the rules AND stops the operator from creating the broken scrape jobs):
+
+```yaml
+defaultRules:
+  rules:
+    kubeControllerManager: false
+    kubeSchedulerAlerts: false
+    kubeProxy: false
+    etcd: false
+kubeControllerManager: { enabled: false }
+kubeScheduler:         { enabled: false }
+kubeProxy:             { enabled: false }
+kubeEtcd:              { enabled: false }
+```
+
+Alternative — route the alertnames to `'null'` in AlertManager (clutters Prometheus's ALERTS table but suppresses notifications).
+
+## Running on Managed K8s: Dual-Stack Cost Discipline
+
+On managed K8s you have **two parallel log pipes** whether you want them or not:
+
+1. Container stdout → node logging agent → **GCP Cloud Logging / CloudWatch / Azure Monitor** (always-on, charged per GiB).
+2. Container stdout → **Promtail → Loki** (your stack, your cost).
+
+You pay the cloud regardless. Discipline: drop the cloud-side ingestion for **your own observability stack's meta-chatter** — it adds no signal (you have it in Loki) but doubles ingest cost.
+
+### Bucket vs sink (the common gcloud confusion)
+
+`--restricted-fields` on a **bucket** is field-level *access control* (which fields can be returned during reads). It does NOT reduce ingestion or cost. Ingestion exclusions live on **sinks** — they drop matching logs before billing. Same filter logic, different verb.
+
+### GKE: the fluent-bit ↔ plugin meta-chatter
+
+The managed `fluentbit-gke` DaemonSet runs a main `fluentbit` container that POSTs every log batch over localhost to a `fluentbit-gke` sidecar plugin server on **`127.0.0.1:2021`** (plugin startup logs: `Starting Fluent Bit GKE plugin server with ... Port:2021`). Each successful POST emits a structured log:
+
+```json
+{"message": "127.0.0.1:2021, HTTP status=200", "plugin": "output:http:http.0"}
+```
+
+INFO severity, scales with cluster log throughput. `fluentbit-gke` is GKE-managed → unconfigurable → the only path is a Cloud Logging exclusion.
+
+### The exclusion (apply once per project)
+
+**Always verify the filter matches first** — pins down field/payload structure before you commit a no-op:
+
+```bash
+gcloud logging read \
+  'logName="projects/YOUR_PROJECT_ID/logs/fluentbit" AND jsonPayload.message:"127.0.0.1:2021"' \
+  --limit=1 --format=json
+```
+
+Then apply:
+
+```bash
+gcloud logging sinks update _Default \
+  --project=YOUR_PROJECT_ID \
+  --add-exclusion='name=fluentbit-localhost-2021-noise,description=Drop fluent-bit GKE-plugin forward chatter,filter=logName="projects/YOUR_PROJECT_ID/logs/fluentbit" AND jsonPayload.message:"127.0.0.1:2021"'
+```
+
+Confirm:
+
+```bash
+gcloud logging sinks describe _Default --format=yaml
+# look for exclusions: -> your name + filter
+```
+
+Reversal:
+
+```bash
+gcloud logging sinks update _Default \
+  --project=YOUR_PROJECT_ID \
+  --remove-exclusions=fluentbit-localhost-2021-noise
+```
+
+**Filter-field gotcha:** fluent-bit-gke emits structured JSON, so the match is on `jsonPayload.message`, NOT `textPayload`. A filter like `textPayload:"HTTP status="` silently matches nothing — wrong field, no cost reduction.
+
+**Pin the match string narrowly.** `"127.0.0.1:2021"` is the unique meta-chatter marker. Broad markers like `"HTTP status="` would catch unrelated workloads.
+
+**gcloud version drift:** `gcloud logging exclusions create` (older project-level API) was removed in modern gcloud — `sinks update ... --add-exclusion` is the current form. If you're on an older SDK, the fallback is `gcloud logging exclusions create NAME --log-filter=... --description=...`.
+
+**Bake into IaC** for fresh bootstraps: Terraform `google_logging_project_exclusion`, or Crossplane `provider-gcp` `LogExclusion`. Hand-applied exclusions don't survive a project recreate.
+
+## Common Mistakes
+
+- **Forgetting `release: <chart-release>` label** on a ServiceMonitor/PrometheusRule → Operator selector won't pick it up → silent invisibility.
+- **`textPayload:` filter against JSON-payload logs** → exclusion silently matches nothing → no cost reduction. Verify the field with `gcloud logging read` first.
+- **`--restricted-fields` on a bucket to reduce ingestion cost** → wrong knob (access control, not ingestion). Use sink exclusions.
+- **Default `RollingUpdate` on single-replica RWO Deployments** → Multi-Attach deadlock. Use `Recreate`.
+- **Leaving control-plane `*Down` alerts enabled on managed K8s** → pager noise / ALERTS-table pollution from alerts that physically cannot resolve. Disable in `defaultRules.rules.*` and `kubeXxx.enabled: false`.
+- **`grafana.adminPassword:` in helm values** → plaintext secret in your IaC. Use `grafana.admin.existingSecret`.
+- **Disabling `Watchdog`** → kills your dead-man's-switch signal. It's supposed to always fire — wire it to a heartbeat receiver (see `alertmanager-config`).
+
+## Sources
+
+- [kube-prometheus-stack chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) — `helm show values` for current paths
+- [Prometheus Operator CRDs](https://prometheus-operator.dev/docs/)
+- [Cloud Logging — Routing & exclusions](https://cloud.google.com/logging/docs/routing/overview#exclusions)
+- For PromQL / dashboards / Loki / Tempo → adopt [grafana/skills](https://github.com/grafana/skills)
+- For native AlertManager routing/templating → `alertmanager-config` skill

--- a/.agent/skills/kube-prometheus-stack/SKILL.md
+++ b/.agent/skills/kube-prometheus-stack/SKILL.md
@@ -23,14 +23,16 @@ NOT for native AlertManager routing/templating — see `alertmanager-config`. NO
 | Goal | Pattern | Gotcha |
 |------|---------|--------|
 | Operator picks up your CR | Label `ServiceMonitor`/`PrometheusRule` with `release: <chart-release-name>` | Default selector is `release=<release>`. **Missing this is the #1 silent-invisibility cause** — Prometheus doesn't scrape, rules don't fire, no error. |
-| Pick up CRs from other namespaces | `prometheus.prometheusSpec.{serviceMonitor,podMonitor,rule,probe}SelectorNilUsesHelmValues: false` + `serviceMonitorNamespaceSelector: {}` (and the matching `*NamespaceSelector` fields) | Default is "same namespace as the Prometheus CR only." |
+| Pick up CRs from other namespaces | `prometheus.prometheusSpec.serviceMonitorNamespaceSelector: {}` (and matching `podMonitor`/`rule`/`probe` `*NamespaceSelector` fields) — empty selector matches **all** namespaces. | Default is "same namespace as the Prometheus CR only." Don't conflate with `*Selector` (object-label match) — those are independent knobs. Flipping `*SelectorNilUsesHelmValues: false` does NOT control namespace scope; it makes the *object* selector match everything when empty, which sidesteps the `release:` label requirement above. |
 | Grafana admin password from Secret | `grafana.admin.existingSecret: <name>` + `passwordKey: password` | Legacy `grafana.adminPassword: <value>` works but bakes plaintext into helm values. Chart-version drift: `helm show values prometheus-community/kube-prometheus-stack` to confirm the current path. |
 | Scrape interval | `30s` is production-safe | Matches the chart's own cadence and 5m alert windows. |
 | `up == 0` `job` label | Operator-generated label is usually `<namespace>/<servicemonitor-name>` | If `up{job="…"} == 0` never matches, query bare `up{}` to see the actual label value. |
 
 ## Single-Replica RWO Workloads: `strategy: Recreate`
 
-Any single-replica Deployment that mounts a `ReadWriteOnce` PVC (single-replica Loki, AlertManager with persistence, Grafana with a PVC, ntfy-style sidecar apps) **must** use `strategy: Recreate`. Default RollingUpdate deadlocks on the RWO volume:
+Any single-replica Deployment that mounts a `ReadWriteOnce` PVC (single-replica Loki, Grafana with a PVC, ntfy-style sidecar apps) **must** use `strategy: Recreate`. Default RollingUpdate deadlocks on the RWO volume:
+
+(The Operator-deployed Prometheus and AlertManager pods are StatefulSets, not Deployments — they use `podManagementPolicy` + ordered restarts, not `strategy.type`. This section is about *Deployment* workloads with attached storage.)
 
 - The new pod can't attach the PV the old pod still holds → `Multi-Attach error`.
 - maxUnavailable rounds to 0 at 1 replica → the deployment controller refuses to scale old down → pod stuck `ContainerCreating` forever.
@@ -128,7 +130,7 @@ gcloud logging sinks update _Default \
 
 **Pin the match string narrowly.** `"127.0.0.1:2021"` is the unique meta-chatter marker. Broad markers like `"HTTP status="` would catch unrelated workloads.
 
-**gcloud version drift:** `gcloud logging exclusions create` (older project-level API) was removed in modern gcloud — `sinks update ... --add-exclusion` is the current form. If you're on an older SDK, the fallback is `gcloud logging exclusions create NAME --log-filter=... --description=...`.
+**gcloud surface for exclusions:** there is no `gcloud logging exclusions create` command — the underlying REST API has an `exclusions.create` method, but in the CLI exclusions are managed as properties of sinks via `gcloud logging sinks update _Default --add-exclusion=...` (or on a custom sink at create-time via `--exclusion=...`). If you see older blog snippets using `gcloud logging exclusions create`, they're conflating the API surface with the CLI surface; the command doesn't exist.
 
 **Bake into IaC** for fresh bootstraps: Terraform `google_logging_project_exclusion`, or Crossplane `provider-gcp` `LogExclusion`. Hand-applied exclusions don't survive a project recreate.
 


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @Cervator via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

- Adds a new root capability skill `kube-prometheus-stack` covering chart wiring (cross-namespace `ServiceMonitor`/`PrometheusRule` selectors, the `release:` label requirement as the #1 silent-invisibility cause), single-replica RWO + `Recreate` strategy + the in-place SSA-migration trap, taming the noisy default `*Down` alerts that fire continuously on managed K8s (GKE/EKS/AKS) where the control plane is hidden, and the "Running on managed K8s: dual-stack cost discipline" section — including the GKE `fluentbit-gke` ↔ plugin meta-chatter on `127.0.0.1:2021`, the bucket-vs-sink distinction, and the Cloud Logging sink-exclusion recipe (with verify-first and reversal commands).
- Phase 1 (gaps-first) of the SiliconSaga skill taxonomy design at `realms/realm-siliconsaga/docs/plans/2026-05-30-skill-taxonomy-design.md`. Defers to `grafana/skills` for PromQL/dashboarding/Loki/Tempo, and to the companion `alertmanager-config` skill (#78) for native AM routing/templating.

## Test plan

Per `superpowers:writing-skills` (TDD for documentation), RED-GREEN-REFACTOR cycle:

- [x] **RED** — baseline subagent given the scenario (helm values for cross-namespace wiring + storage + Grafana secret + AM webhook, ServiceMonitor + PrometheusRule for a payments-api workload, GKE Cloud Logging exclusion, RWO strategy, noisy-default alerts). Produced a strong config but used `textPayload:` for fluent-bit-gke's JSON-payload logs (silent-no-op exclusion) and `"HTTP status="` (too broad); did not surface verify-first or bucket-vs-sink framing.
- [x] **GREEN** — skill pins `jsonPayload.message:"127.0.0.1:2021"`, the bucket-vs-sink distinction, the verify-the-filter-first step, the dual-stack-cost framing, and the SSA migration trap.
- [x] **VERIFY GREEN** — re-dispatched subagent cited skill sections, used the correct field + narrow match string, added the verify-first step, surfaced the Watchdog/blackhole conflict from the companion `alertmanager-config` skill as an informed deviation, flagged StatefulSet vs Deployment for the RWO strategy.
- [x] **REFACTOR** — no new rationalizations to plug.

## Related

- Companion Phase 1 skill: #78 (`alertmanager-config`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive guide for configuring the Kubernetes Prometheus stack: operator selection patterns, cross-namespace selector notes, Grafana credential handling, recommended deployment strategy for single-replica PVC workloads, migration caveats, guidance for silencing noisy managed-cluster alerts while keeping Watchdog, dual-stack cloud-logging cost controls with verification/apply/revert steps, common mistakes and reference links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->