### PR TITLE
ws orient: scaffold + dispatch + header (Task 4a)

### DIFF
--- a/scripts/ws
+++ b/scripts/ws
@@ -713,6 +713,9 @@ case "$COMMAND" in
     list)
         bash "$SCRIPT_DIR/ws-list.sh" "$@"
         ;;
+    orient)
+        bash "$SCRIPT_DIR/ws-orient.sh" "$@"
+        ;;
     status)
         bash "$SCRIPT_DIR/ws-status.sh" "$@"
         ;;

--- a/scripts/ws-orient.sh
+++ b/scripts/ws-orient.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# ws-orient.sh — deterministic "what can I do here?" menu.
+#
+# `ws orient` is the L1 layer of the progressive-disclosure buffet
+# documented in `docs/plans/2026-06-02-gdd-orientation-and-attribution-design.md`:
+#
+#   L0  slim AGENTS.md + reflex contract       — always-loaded reminder
+#   L1  ws orient                              — this command
+#   L2  ws <cmd> --help                        — per-subcommand depth
+#
+# The goal is one deterministic place an agent (or a human) can run
+# to see: the workspace toolset + the active realm + per-component
+# adapter wiring (with the resolved command surfaced) + the skill
+# index. Phase 1 Task 4 of the gdd-orientation-capability-index arc.
+#
+# This file is the Task 4a scaffold: header only. Sub-steps 4b-4e
+# layer additional sections on top (subcommand survey, active realm,
+# adapters, skill index) — see the plan for the per-step interface
+# contracts.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# shellcheck source=ws-realm.sh
+source "$SCRIPT_DIR/ws-realm.sh"
+
+orient_help() {
+    cat <<'HELP'
+Usage: ws orient
+
+Deterministic "what can I do here?" menu — workspace toolset, active
+realm, per-component adapters (with resolved commands), and the
+skill index. Run after compaction, on a fresh dispatch, or when
+switching tasks. Pairs with the per-command `ws orient` footer
+nudge that fires after every subcommand.
+
+Read-only. No flags yet — Phase 1 Task 4 sub-steps fill in
+sections incrementally.
+HELP
+    exit 0
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" || "${1:-}" == "help" ]]; then
+    orient_help
+fi
+
+# Header. The backticked literal is asserted by tests/ws-orient/orient.bats
+# so a future rename surfaces the doc/help drift here first.
+echo "Workspace toolset (\`ws orient\`)"
+echo ""
+echo "(Phase 1 Task 4 scaffold — subcommand survey, active realm,"
+echo "adapter enumeration, and skill index land in sub-steps 4b-4e.)"

--- a/tests/ws-orient/orient.bats
+++ b/tests/ws-orient/orient.bats
@@ -1,0 +1,46 @@
+#!/usr/bin/env bats
+
+# Tests for `ws orient` — the deterministic discovery menu (Phase 1,
+# Task 4 of the GDD orientation + capability index arc).
+#
+# Task 4a scope (this file initially): scaffold + dispatch + header.
+# Sub-steps 4b-4e bolt on additional assertions as those sections
+# land:
+#   4b — subcommand survey rows
+#   4c — active realm detection
+#   4d — per-component adapter enumeration with resolved-command surfacing
+#   4e — skill index
+#
+# Reuses the ws-smoke test_helper so the dispatcher and timeout
+# behavior match the rest of the smoke suite — `ws orient` is a
+# read-only discovery command, same shape as `ws status` / `ws list`.
+
+load ../ws-smoke/test_helper
+
+setup() {
+    init_workspace
+}
+
+# ─── 4a — scaffold + dispatch + header ─────────────────────────────
+
+@test "ws orient: runs and prints a titled header" {
+    run_ws orient
+    [ "$status" -eq 0 ]
+    # Header pins the literal command name in backticks so a future
+    # rename surfaces here and forces the doc/help update alongside.
+    [[ "$output" == *"Workspace toolset (\`ws orient\`)"* ]]
+}
+
+@test "ws orient: dispatcher routes the subcommand (no 'unknown command' error)" {
+    run_ws orient
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"Unknown command"* ]]
+    [[ "$output" != *"unknown command"* ]]
+}
+
+@test "ws orient: completes well under the smoke timeout (read-only)" {
+    run_ws orient
+    # 124 = `timeout` killed the process. Catches a future regression
+    # where orient grows expensive (e.g. tree-walks every component).
+    [ "$status" -ne 124 ]
+}


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @Cervator via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

First slice of the `gdd-orientation-capability-index` arc's Phase 1 — Task 4a per `docs/plans/2026-06-02-gdd-orientation-and-attribution-plan.md` (lines 346-352).

Wires `ws orient` into the dispatcher and lands the smallest passing shape — a titled header. Sub-steps 4b-4e layer additional sections in subsequent PRs (subcommand survey, active realm, per-component adapter enumeration with the resolved command surfaced, skill index).

## Why this PR is small

The plan recommends `superpowers:subagent-driven-development` with each Task its own PR or stacked PRs. Task 4 has five sub-steps (4a-4e), each its own TDD cycle per the plan. This PR is the scaffold — establishes the dispatch wiring, the help convention, the test-file location, and the header literal that all subsequent sub-steps build on. Reviewing the scaffold standalone keeps the surface area small.

## What this PR does

- `scripts/ws-orient.sh` — new file. Sources `ws-realm.sh` (so the merged-ecosystem + active-realm helpers are available when 4c lands), exposes a `--help` / `-h` / `help` short-circuit matching the rest of the `ws` subcommand convention, prints the titled `Workspace toolset (\`ws orient\`)` header plus a placeholder note pointing at the remaining sub-steps.
- `scripts/ws` — one new `orient)` case in the dispatch block, placed between `list` and `status` (both are read-only inspection commands of the same shape).
- `tests/ws-orient/orient.bats` — new file. Reuses `tests/ws-smoke/test_helper` via a relative `load` so the assertions match the rest of the read-only smoke pattern (same `init_workspace` + `run_ws` 10s-timeout wrapper).

## TDD evidence

- **RED:** 2 of 3 tests failed before the script + dispatch wiring existed (dispatcher returned non-zero for the unknown subcommand; the timeout assertion passed vacuously since failing fast doesn't trip the 10s limit).
- **GREEN:** 3/3 pass after wiring; full bats suite **248/248** confirms no regressions elsewhere.

## Header literal pinned in test

The assertion matches the backticked `` `ws orient` `` literal so a future rename of the subcommand surfaces this test alongside the `--help`, plan, and docs drift that would need fixing in the same pass.

## Test plan

- [x] `bash scripts/ws test yggdrasil "ws orient"` → 3/3 pass.
- [x] `bash scripts/ws test yggdrasil` (full suite) → 248/248 pass.
- [ ] Manual smoke: `bash scripts/ws orient` → prints the titled header and the Task 4a scaffold note.
- [ ] Manual smoke: `bash scripts/ws orient --help` → prints the usage block.

## Related

- **Arc:** `gdd-orientation-capability-index` (Loki-thalamus), Phase 1, Task 4 sub-step 4a.
- **Plan:** `docs/plans/2026-06-02-gdd-orientation-and-attribution-plan.md`.
- **Design:** `docs/plans/2026-06-02-gdd-orientation-and-attribution-design.md`.
- **Phase 0 (already merged):** PR #84.

## Next slices in the arc

- **4b** — subcommand survey (`name — use when …` per `ws` verb).
- **4c** — active realm detection + pointer.
- **4d** — per-component adapter enumeration with the resolved command surfaced (the adapter-trust counterpart — `knarr → ws test [runs: python3 -m pytest --ignore=tests/features]`).
- **4e** — skill index (frontmatter only, no bodies).
- Then Tasks 5-8 + D1 — command-output footer, adapter-aware hook redirects, AGENTS.md L0 cut, `gdd-orientation` skill rework via `superpowers:writing-skills`, docs sweep across 8 GDD docs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `ws orient` command to provide workspace orientation guidance and discovery features.

* **Tests**
  * Added comprehensive test coverage for the new orientation command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->