### PR TITLE
ws orient: fill out subcommand survey + realm + adapters + skills (Task 4b-4e)

### DIFF
--- a/scripts/ws
+++ b/scripts/ws
@@ -7,6 +7,8 @@
 #
 # Commands:
 #   list              List ecosystem components (tier, repo, clone status)
+#   orient            Deterministic "what can I do here?" menu — workspace
+#                     toolset + active realm + adapters + skill index
 #   status [--verbose] Git status across workspace
 #   clone [comp|--all|--url <url> [--name N] [--add-eco]] Clone components
 #   clone-fork <comp>  Fork-aware clone: ensure fork exists, clone fork, wire

--- a/scripts/ws-orient.sh
+++ b/scripts/ws-orient.sh
@@ -86,12 +86,34 @@ resolve|generating ArgoCD Application manifests from declared components
 SURVEY
 }
 
+# Active realm — same detection logic gdd-orientation Step 0c uses
+# (ecosystem.local.yaml `realm:` selector, else a single realm-*).
+# Prints a status line + pointer to the realm's AGENTS.md guide; the
+# realm's skill enumeration lands separately in 4e so the index
+# duties stay in one place.
+emit_active_realm() {
+    printf '\n'
+    local active_realm
+    active_realm="$(ws_detect_realm)"
+    if [[ -z "$active_realm" ]]; then
+        echo "Active realm: none"
+        echo "  Adopt one with \`ws realm <git-url>\` or scaffold the tutorial via \`ws realm init\`."
+        return
+    fi
+    echo "Active realm: $active_realm"
+    local realm_agents="$REALMS_DIR/$active_realm/AGENTS.md"
+    if [[ -f "$realm_agents" ]]; then
+        echo "  Guide: $realm_agents"
+    fi
+}
+
 # Header. The backticked literal is asserted by tests/ws-orient/orient.bats
 # so a future rename surfaces the doc/help drift here first.
 echo "Workspace toolset (\`ws orient\`)"
 
 emit_subcommand_survey
+emit_active_realm
 
 echo ""
-echo "(Phase 1 Task 4 in progress — active realm, adapter enumeration,"
-echo "and skill index land in sub-steps 4c-4e.)"
+echo "(Phase 1 Task 4 in progress — adapter enumeration + skill index"
+echo "land in sub-steps 4d-4e.)"

--- a/scripts/ws-orient.sh
+++ b/scripts/ws-orient.sh
@@ -26,16 +26,6 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # the script clobbering the test's exported override.
 : "${ROOT_DIR:="$(cd "$SCRIPT_DIR/.." && pwd)"}"
 
-# Explicit yq presence check matching ws-list / ws-test / ws-lint —
-# under `set -euo pipefail` a missing yq would otherwise surface as
-# a cryptic 127 from inside `_emit_one_adapter` rather than as a
-# helpful diagnostic at startup.
-if ! command -v yq &>/dev/null; then
-    echo "ERROR: yq (v4+) is required." >&2
-    echo "  Install: see docs/dev-setup.md or 'ws preflight' for the platform-specific hint." >&2
-    exit 1
-fi
-
 # shellcheck source=ws-realm.sh
 source "$SCRIPT_DIR/ws-realm.sh"
 
@@ -57,6 +47,18 @@ HELP
 
 if [[ "${1:-}" == "--help" || "${1:-}" == "-h" || "${1:-}" == "help" ]]; then
     orient_help
+fi
+
+# Explicit yq presence check matching ws-list / ws-test / ws-lint —
+# under `set -euo pipefail` a missing yq would otherwise surface as
+# a cryptic 127 from inside `_emit_one_adapter` rather than as a
+# helpful diagnostic at startup. Deliberately AFTER the --help
+# short-circuit so a fresh-machine user can still discover `ws orient`
+# before installing every prerequisite (Copilot finding on PR #89).
+if ! command -v yq &>/dev/null; then
+    echo "ERROR: yq (v4+) is required." >&2
+    echo "  Install: see docs/dev-setup.md or 'ws preflight' for the platform-specific hint." >&2
+    exit 1
 fi
 
 # Subcommand survey — authored per the plan (Task 4b). The "use when"
@@ -104,15 +106,39 @@ SURVEY
 # than re-invoking ws_detect_realm (which exits 1 on multi-realm —
 # without this catch, the rest of orient never renders).
 #
-# Status values: ok | none | ambiguous
+# Status values: ok | none | ambiguous | error
+#   ok        — exactly one realm-* directory or selector picked one
+#   none      — no realms present (and no selector pointing at one)
+#   ambiguous — multiple realm-* dirs and no selector to disambiguate
+#   error     — any OTHER detection failure (YAML parse, file I/O, …)
+#
+# `ambiguous` and `error` are split deliberately: ws_detect_realm
+# exits 1 on both multi-realm AND on a malformed ecosystem.local.yaml.
+# Conflating them would point the user at the wrong fix path
+# (Copilot finding on PR #89). The split keys off the canonical
+# "Multiple non-template realms" stderr message from
+# ws_detect_realm; anything else is classified as a generic error
+# and the actual stderr first line surfaces to the user.
 _ORIENT_REALM=""
 _ORIENT_REALM_STATUS="none"
+_ORIENT_REALM_ERROR=""
 _resolve_orient_realm() {
-    local rc=0
-    _ORIENT_REALM="$(ws_detect_realm 2>/dev/null)" || rc=$?
+    local rc=0 stderr_file
+    stderr_file="$(mktemp 2>/dev/null || echo "/tmp/orient.stderr.$$")"
+    _ORIENT_REALM="$(ws_detect_realm 2>"$stderr_file")" || rc=$?
+    local first_err=""
+    if [[ -f "$stderr_file" ]]; then
+        first_err="$(head -n1 "$stderr_file" 2>/dev/null || true)"
+        rm -f "$stderr_file"
+    fi
     if [[ $rc -ne 0 ]]; then
         _ORIENT_REALM=""
-        _ORIENT_REALM_STATUS="ambiguous"
+        if [[ "$first_err" == *"Multiple non-template realms"* ]]; then
+            _ORIENT_REALM_STATUS="ambiguous"
+        else
+            _ORIENT_REALM_STATUS="error"
+            _ORIENT_REALM_ERROR="$first_err"
+        fi
         return
     fi
     if [[ -n "$_ORIENT_REALM" ]]; then
@@ -250,6 +276,13 @@ _emit_skills_in() {
 emit_active_realm() {
     printf '\n'
     case "$_ORIENT_REALM_STATUS" in
+        error)
+            echo "Active realm: error (detection failed)"
+            if [[ -n "$_ORIENT_REALM_ERROR" ]]; then
+                echo "  $_ORIENT_REALM_ERROR"
+            fi
+            return
+            ;;
         ambiguous)
             echo "Active realm: ambiguous (multiple non-template realms found)"
             echo "  Set \`realm: <name>\` in ecosystem.local.yaml to pick one."

--- a/scripts/ws-orient.sh
+++ b/scripts/ws-orient.sh
@@ -21,7 +21,10 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+# Honor a pre-set ROOT_DIR (matches scripts/ws + ws-commit.sh) so the
+# bats smoke suite can point ws-orient at an isolated $WORK without
+# the script clobbering the test's exported override.
+: "${ROOT_DIR:="$(cd "$SCRIPT_DIR/.." && pwd)"}"
 
 # shellcheck source=ws-realm.sh
 source "$SCRIPT_DIR/ws-realm.sh"
@@ -145,6 +148,58 @@ _emit_one_adapter() {
     fi
 }
 
+# Skill index — workspace + active-realm scopes only. Component
+# skills are surfaced indirectly via the component's adapter rows
+# above (the ai_context paths); listing them here would explode the
+# section into noise. Frontmatter-only parsing — the SKILL.md body
+# stays unread, so the index is cheap even on a workspace with
+# dozens of skills.
+emit_skill_index() {
+    printf '\nSkills (workspace + active realm):\n'
+    local active_realm
+    active_realm="$(ws_detect_realm)"
+
+    local any=0
+    if [[ -d "$ROOT_DIR/.agent/skills" ]]; then
+        _emit_skills_in "$ROOT_DIR/.agent/skills" "workspace" && any=1
+    fi
+    if [[ -n "$active_realm" && -d "$REALMS_DIR/$active_realm/.agent/skills" ]]; then
+        _emit_skills_in "$REALMS_DIR/$active_realm/.agent/skills" "realm:$active_realm" && any=1
+    fi
+    if [[ $any -eq 0 ]]; then
+        echo "  (no skills found in workspace or active realm)"
+    fi
+}
+
+# Render every SKILL.md under the given dir. Returns 0 if at least
+# one skill rendered, 1 if the dir was empty — lets the caller
+# decide whether to surface the "no skills" fallback.
+_emit_skills_in() {
+    local skills_dir="$1" scope="$2"
+    local skill_file rendered=0
+    for skill_file in "$skills_dir"/*/SKILL.md; do
+        [[ -f "$skill_file" ]] || continue
+        local name description
+        # Parse the frontmatter only — `yq` reads the first YAML
+        # document in a multi-doc stream by default, which on
+        # SKILL.md files (front-matter only at the top) yields the
+        # frontmatter map directly without a body read.
+        name="$(yq -r '.name // ""' "$skill_file" 2>/dev/null)"
+        description="$(yq -r '.description // ""' "$skill_file" 2>/dev/null)"
+        # Fallback to the dir name if the frontmatter is missing /
+        # malformed so the row still surfaces something useful.
+        [[ -z "$name" || "$name" == "null" ]] && name="$(basename "$(dirname "$skill_file")")"
+        [[ "$description" == "null" ]] && description=""
+        if [[ -n "$description" ]]; then
+            printf '  [%s] %s — %s\n' "$scope" "$name" "$description"
+        else
+            printf '  [%s] %s\n' "$scope" "$name"
+        fi
+        rendered=1
+    done
+    [[ $rendered -eq 1 ]]
+}
+
 # Active realm — same detection logic gdd-orientation Step 0c uses
 # (ecosystem.local.yaml `realm:` selector, else a single realm-*).
 # Prints a status line + pointer to the realm's AGENTS.md guide; the
@@ -173,6 +228,4 @@ echo "Workspace toolset (\`ws orient\`)"
 emit_subcommand_survey
 emit_active_realm
 emit_component_adapters
-
-echo ""
-echo "(Phase 1 Task 4 in progress — skill index lands in sub-step 4e.)"
+emit_skill_index

--- a/scripts/ws-orient.sh
+++ b/scripts/ws-orient.sh
@@ -86,6 +86,65 @@ resolve|generating ArgoCD Application manifests from declared components
 SURVEY
 }
 
+# Per-component adapter enumeration with the resolved command
+# surfaced. The "runs:" form is the adapter-trust mitigation from
+# the design (§ Adapter trust): when `ws test` runs, the actual
+# command the wrapper dispatches must be auditable from `ws orient`
+# output. Otherwise the wrapper hides the executable-config surface.
+#
+# Discovery: iterate $COMPONENTS_DIR/*/ that look cloned (any .git
+# entry — handles both real .git dirs and worktree-pointer .git
+# files). For each, look up the realm-side adapter at
+# realms/<active>/adapters/<comp>.yaml and surface what's wired.
+emit_component_adapters() {
+    printf '\nComponents (cloned) — adapter wiring:\n'
+    local active_realm
+    active_realm="$(ws_detect_realm)"
+
+    local found=0 comp_dir comp
+    if [[ -d "$COMPONENTS_DIR" ]]; then
+        for comp_dir in "$COMPONENTS_DIR"/*/; do
+            [[ -d "$comp_dir" ]] || continue
+            [[ -e "$comp_dir/.git" ]] || continue
+            comp="$(basename "$comp_dir")"
+            _emit_one_adapter "$comp" "$active_realm"
+            found=1
+        done
+    fi
+    if [[ $found -eq 0 ]]; then
+        echo "  (no components cloned)"
+    fi
+}
+
+# Render one component's adapter wiring. Walks the three plan-named
+# verbs explicitly (test/lint/build) so a typo in the YAML doesn't
+# silently swallow a missing slot — the diagnostic message stays
+# loud either way.
+_emit_one_adapter() {
+    local comp="$1" active_realm="$2"
+    echo "  $comp"
+    local adapter_file=""
+    if [[ -n "$active_realm" ]]; then
+        adapter_file="$REALMS_DIR/$active_realm/adapters/$comp.yaml"
+    fi
+    if [[ -z "$adapter_file" || ! -f "$adapter_file" ]]; then
+        local hint="realms/${active_realm:-<active>}/adapters/$comp.yaml"
+        echo "    no test/lint adapter (wire: $hint)"
+        return
+    fi
+    local verb cmd any=0
+    for verb in test lint build; do
+        cmd="$(yq -r ".commands.$verb // \"\"" "$adapter_file" 2>/dev/null)"
+        if [[ -n "$cmd" && "$cmd" != "null" ]]; then
+            printf '    ws %s [runs: %s]\n' "$verb" "$cmd"
+            any=1
+        fi
+    done
+    if [[ $any -eq 0 ]]; then
+        echo "    (adapter present but no commands.{test,lint,build} wired)"
+    fi
+}
+
 # Active realm — same detection logic gdd-orientation Step 0c uses
 # (ecosystem.local.yaml `realm:` selector, else a single realm-*).
 # Prints a status line + pointer to the realm's AGENTS.md guide; the
@@ -113,7 +172,7 @@ echo "Workspace toolset (\`ws orient\`)"
 
 emit_subcommand_survey
 emit_active_realm
+emit_component_adapters
 
 echo ""
-echo "(Phase 1 Task 4 in progress — adapter enumeration + skill index"
-echo "land in sub-steps 4d-4e.)"
+echo "(Phase 1 Task 4 in progress — skill index lands in sub-step 4e.)"

--- a/scripts/ws-orient.sh
+++ b/scripts/ws-orient.sh
@@ -99,6 +99,29 @@ resolve|generating ArgoCD Application manifests from declared components
 SURVEY
 }
 
+# Resolve the active realm once for the whole orient run, classifying
+# the result so each emit_* function consumes a stable state rather
+# than re-invoking ws_detect_realm (which exits 1 on multi-realm —
+# without this catch, the rest of orient never renders).
+#
+# Status values: ok | none | ambiguous
+_ORIENT_REALM=""
+_ORIENT_REALM_STATUS="none"
+_resolve_orient_realm() {
+    local rc=0
+    _ORIENT_REALM="$(ws_detect_realm 2>/dev/null)" || rc=$?
+    if [[ $rc -ne 0 ]]; then
+        _ORIENT_REALM=""
+        _ORIENT_REALM_STATUS="ambiguous"
+        return
+    fi
+    if [[ -n "$_ORIENT_REALM" ]]; then
+        _ORIENT_REALM_STATUS="ok"
+    else
+        _ORIENT_REALM_STATUS="none"
+    fi
+}
+
 # Per-component adapter enumeration with the resolved command
 # surfaced. The "runs:" form is the adapter-trust mitigation from
 # the design (§ Adapter trust): when `ws test` runs, the actual
@@ -111,8 +134,6 @@ SURVEY
 # realms/<active>/adapters/<comp>.yaml and surface what's wired.
 emit_component_adapters() {
     printf '\nComponents (cloned) — adapter wiring:\n'
-    local active_realm
-    active_realm="$(ws_detect_realm)"
 
     local found=0 comp_dir comp
     if [[ -d "$COMPONENTS_DIR" ]]; then
@@ -120,7 +141,7 @@ emit_component_adapters() {
             [[ -d "$comp_dir" ]] || continue
             [[ -e "$comp_dir/.git" ]] || continue
             comp="$(basename "$comp_dir")"
-            _emit_one_adapter "$comp" "$active_realm"
+            _emit_one_adapter "$comp" "$_ORIENT_REALM"
             found=1
         done
     fi
@@ -145,15 +166,24 @@ _emit_one_adapter() {
         echo "    no test/lint adapter (wire: $hint)"
         return
     fi
-    local verb cmd any=0
+    local verb cmd rc=0 any=0 parse_failed=0
     for verb in test lint build; do
-        cmd="$(yq -r ".commands.$verb // \"\"" "$adapter_file" 2>/dev/null)"
+        rc=0
+        cmd="$(yq -r ".commands.$verb // \"\"" "$adapter_file" 2>/dev/null)" || rc=$?
+        if [[ $rc -ne 0 ]]; then
+            # Don't let one malformed adapter file abort the whole
+            # orient run — surface a diagnostic, keep walking.
+            parse_failed=1
+            continue
+        fi
         if [[ -n "$cmd" && "$cmd" != "null" ]]; then
             printf '    ws %s [runs: %s]\n' "$verb" "$cmd"
             any=1
         fi
     done
-    if [[ $any -eq 0 ]]; then
+    if [[ $parse_failed -eq 1 ]]; then
+        echo "    (adapter present but YAML parse failed — fix $adapter_file)"
+    elif [[ $any -eq 0 ]]; then
         echo "    (adapter present but no commands.{test,lint,build} wired)"
     fi
 }
@@ -166,15 +196,12 @@ _emit_one_adapter() {
 # dozens of skills.
 emit_skill_index() {
     printf '\nSkills (workspace + active realm):\n'
-    local active_realm
-    active_realm="$(ws_detect_realm)"
-
     local any=0
     if [[ -d "$ROOT_DIR/.agent/skills" ]]; then
         _emit_skills_in "$ROOT_DIR/.agent/skills" "workspace" && any=1
     fi
-    if [[ -n "$active_realm" && -d "$REALMS_DIR/$active_realm/.agent/skills" ]]; then
-        _emit_skills_in "$REALMS_DIR/$active_realm/.agent/skills" "realm:$active_realm" && any=1
+    if [[ -n "$_ORIENT_REALM" && -d "$REALMS_DIR/$_ORIENT_REALM/.agent/skills" ]]; then
+        _emit_skills_in "$REALMS_DIR/$_ORIENT_REALM/.agent/skills" "realm:$_ORIENT_REALM" && any=1
     fi
     if [[ $any -eq 0 ]]; then
         echo "  (no skills found in workspace or active realm)"
@@ -194,8 +221,11 @@ _emit_skills_in() {
         # document in a multi-doc stream by default, which on
         # SKILL.md files (front-matter only at the top) yields the
         # frontmatter map directly without a body read.
-        name="$(yq -r '.name // ""' "$skill_file" 2>/dev/null)"
-        description="$(yq -r '.description // ""' "$skill_file" 2>/dev/null)"
+        # Tolerate malformed frontmatter — fall back to the dir
+        # name and an empty description rather than aborting the
+        # whole walk over one broken SKILL.md.
+        name="$(yq -r '.name // ""' "$skill_file" 2>/dev/null)" || name=""
+        description="$(yq -r '.description // ""' "$skill_file" 2>/dev/null)" || description=""
         # Fallback to the dir name if the frontmatter is missing /
         # malformed so the row still surfaces something useful.
         [[ -z "$name" || "$name" == "null" ]] && name="$(basename "$(dirname "$skill_file")")"
@@ -214,18 +244,25 @@ _emit_skills_in() {
 # (ecosystem.local.yaml `realm:` selector, else a single realm-*).
 # Prints a status line + pointer to the realm's AGENTS.md guide; the
 # realm's skill enumeration lands separately in 4e so the index
-# duties stay in one place.
+# duties stay in one place. Consumes the cached _ORIENT_REALM state
+# resolved by _resolve_orient_realm so the multi-realm exit-1 case
+# is rendered as a clear status, not propagated as a script crash.
 emit_active_realm() {
     printf '\n'
-    local active_realm
-    active_realm="$(ws_detect_realm)"
-    if [[ -z "$active_realm" ]]; then
-        echo "Active realm: none"
-        echo "  Adopt one with \`ws realm <git-url>\` or scaffold the tutorial via \`ws realm init\`."
-        return
-    fi
-    echo "Active realm: $active_realm"
-    local realm_agents="$REALMS_DIR/$active_realm/AGENTS.md"
+    case "$_ORIENT_REALM_STATUS" in
+        ambiguous)
+            echo "Active realm: ambiguous (multiple non-template realms found)"
+            echo "  Set \`realm: <name>\` in ecosystem.local.yaml to pick one."
+            return
+            ;;
+        none)
+            echo "Active realm: none"
+            echo "  Adopt one with \`ws realm <git-url>\` or scaffold the tutorial via \`ws realm init\`."
+            return
+            ;;
+    esac
+    echo "Active realm: $_ORIENT_REALM"
+    local realm_agents="$REALMS_DIR/$_ORIENT_REALM/AGENTS.md"
     if [[ -f "$realm_agents" ]]; then
         echo "  Guide: $realm_agents"
     fi
@@ -234,6 +271,12 @@ emit_active_realm() {
 # Header. The backticked literal is asserted by tests/ws-orient/orient.bats
 # so a future rename surfaces the doc/help drift here first.
 echo "Workspace toolset (\`ws orient\`)"
+
+# Resolve realm state once so emit_active_realm + emit_component_adapters
+# + emit_skill_index can all consume the same answer without re-invoking
+# ws_detect_realm (which exits 1 on multi-realm and would otherwise
+# kill orient mid-render).
+_resolve_orient_realm
 
 emit_subcommand_survey
 emit_active_realm

--- a/scripts/ws-orient.sh
+++ b/scripts/ws-orient.sh
@@ -26,6 +26,16 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # the script clobbering the test's exported override.
 : "${ROOT_DIR:="$(cd "$SCRIPT_DIR/.." && pwd)"}"
 
+# Explicit yq presence check matching ws-list / ws-test / ws-lint —
+# under `set -euo pipefail` a missing yq would otherwise surface as
+# a cryptic 127 from inside `_emit_one_adapter` rather than as a
+# helpful diagnostic at startup.
+if ! command -v yq &>/dev/null; then
+    echo "ERROR: yq (v4+) is required." >&2
+    echo "  Install: see docs/dev-setup.md or 'ws preflight' for the platform-specific hint." >&2
+    exit 1
+fi
+
 # shellcheck source=ws-realm.sh
 source "$SCRIPT_DIR/ws-realm.sh"
 

--- a/scripts/ws-orient.sh
+++ b/scripts/ws-orient.sh
@@ -46,9 +46,52 @@ if [[ "${1:-}" == "--help" || "${1:-}" == "-h" || "${1:-}" == "help" ]]; then
     orient_help
 fi
 
+# Subcommand survey — authored per the plan (Task 4b). The "use when"
+# phrasing is judgment that lives here, in one place, not scattered
+# across each subcommand script. Format is `name|use-when` so the
+# table stays trivially editable; a future `--json` or `--names-only`
+# flag can re-emit the same rows in a different shape.
+emit_subcommand_survey() {
+    printf '\n%s\n' "Subcommands (name — use when …):"
+    while IFS='|' read -r name use_when; do
+        # Skip blank lines + comment rows so the heredoc can carry
+        # section dividers without polluting output.
+        [[ -z "$name" || "$name" == \#* ]] && continue
+        printf '  %-18s — %s\n' "$name" "$use_when"
+    done <<'SURVEY'
+list|surveying what's declared in the ecosystem (clones, tiers, repos)
+orient|starting a session, recovering from compaction, or switching tasks
+status|checking git state across every cloned component at a glance
+clone|materializing a component locally (clone-fork for cross-org forks)
+pull|refreshing every cloned component from its remote
+commit|finalizing a change — required to attach Co-Authored-By + bodyfile
+test|running the component's test suite via its adapter
+lint|running the component's linter via its adapter
+push|sending a topic branch to your fork remote
+cr|opening a code-review request (PR / MR) from the current branch
+review|triaging review comments + resolving threads on an open CR
+issue|filing a tracker issue with a bodyfile + labels
+log|checking what commits are on the current branch versus main
+clean|sweeping draft files from .commits/ .crs/ .issues/ .outputs/ .tmp/
+exec|running a one-off command inside a component dir
+actions|inspecting which adapter commands a component has wired
+realm|adopting or switching the active community config
+hoard|managing personal cross-workspace artifacts (thalami, vaults)
+component|scaffolding a new component from a template flavor
+preflight|verifying workspace prerequisites (bash, git, yq, jq, gh/glab)
+diagnose|investigating push/cr failures — remote + token coverage
+audit-permissions|reviewing your Bash allowlist for over-broad patterns
+gitlab-auth|configuring glab + git credentials from .env tokens
+resolve|generating ArgoCD Application manifests from declared components
+SURVEY
+}
+
 # Header. The backticked literal is asserted by tests/ws-orient/orient.bats
 # so a future rename surfaces the doc/help drift here first.
 echo "Workspace toolset (\`ws orient\`)"
+
+emit_subcommand_survey
+
 echo ""
-echo "(Phase 1 Task 4 scaffold — subcommand survey, active realm,"
-echo "adapter enumeration, and skill index land in sub-steps 4b-4e.)"
+echo "(Phase 1 Task 4 in progress — active realm, adapter enumeration,"
+echo "and skill index land in sub-steps 4c-4e.)"

--- a/tests/ws-orient/orient.bats
+++ b/tests/ws-orient/orient.bats
@@ -97,3 +97,63 @@ MD
     # to the canonical realm guide without further discovery.
     [[ "$output" == *"AGENTS.md"* ]]
 }
+
+# ─── 4d — per-component adapters with resolved command ──────────────
+
+# Helper: drop a fixture realm + a cloned component dir. Used by the
+# adapter tests below so each test can opt into wiring an adapter
+# (or not).
+_seed_realm_and_component() {
+    local comp="$1"
+    mkdir -p "$WORK/realms/realm-fixture/adapters"
+    cat > "$WORK/realms/realm-fixture/ecosystem.yaml" <<'YAML'
+identity:
+  human_account: testuser
+components: {}
+YAML
+    # .git as a real dir marks the component as cloned for orient's
+    # enumeration. No actual git operations happen — orient is
+    # read-only and never invokes git on the component.
+    mkdir -p "$WORK/components/$comp/.git"
+}
+
+@test "ws orient: wired adapter surfaces 'ws test [runs: …]' with the resolved command" {
+    _seed_realm_and_component knarrlike
+    cat > "$WORK/realms/realm-fixture/adapters/knarrlike.yaml" <<'YAML'
+commands:
+  test: "python3 -m pytest --ignore=tests/features"
+  lint: "python3 -m ruff check src/ tests/"
+YAML
+    run_ws orient
+    [ "$status" -eq 0 ]
+    # Adapter-trust mitigation per design § Adapter trust: the
+    # executed command must be visible from `ws orient` output, not
+    # hidden behind the ws wrapper. Pin both the `runs:` token and
+    # the actual command tail so an agent can verify what fires.
+    [[ "$output" == *"ws test"* ]]
+    [[ "$output" == *"runs: python3 -m pytest --ignore=tests/features"* ]]
+    [[ "$output" == *"ws lint"* ]]
+    [[ "$output" == *"runs: python3 -m ruff check"* ]]
+}
+
+@test "ws orient: cloned component without an adapter prints the wire-it hint" {
+    _seed_realm_and_component bareclone
+    # No adapter file. The orient output should call this out
+    # explicitly so the unwired state is discoverable, not silent.
+    run_ws orient
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"bareclone"* ]]
+    [[ "$output" == *"no test/lint adapter"* ]]
+    [[ "$output" == *"realm-fixture/adapters/bareclone.yaml"* ]]
+}
+
+@test "ws orient: components section is present even when no clones exist" {
+    # init_workspace alone — no components cloned. Section must
+    # still be emitted with a clear "(no components cloned)"
+    # status so agents can distinguish "section was rendered but
+    # empty" from "section is missing because of a regression."
+    run_ws orient
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Components"* ]]
+    [[ "$output" == *"no components cloned"* ]]
+}

--- a/tests/ws-orient/orient.bats
+++ b/tests/ws-orient/orient.bats
@@ -44,3 +44,25 @@ setup() {
     # where orient grows expensive (e.g. tree-walks every component).
     [ "$status" -ne 124 ]
 }
+
+# ─── 4b — subcommand survey ─────────────────────────────────────────
+
+@test "ws orient: prints a subcommand survey with the 'use when' phrase" {
+    run_ws orient
+    [ "$status" -eq 0 ]
+    # The plan specifies the 'use when' framing for each row — pin
+    # the literal so a future cosmetic rephrase surfaces here first.
+    [[ "$output" == *"use when"* ]]
+}
+
+@test "ws orient: subcommand survey lists the headline verbs (commit, test, lint, orient)" {
+    # Plan-mandated rows (Task 4b assertions). Other rows live in
+    # the authored survey table and can drift; these four are
+    # pinned because they're the verbs the surrounding plan tasks
+    # (5/6/7/8) revolve around.
+    run_ws orient
+    [ "$status" -eq 0 ]
+    for verb in commit test lint orient; do
+        [[ "$output" == *"$verb"* ]] || { echo "missing survey row: $verb"; return 1; }
+    done
+}

--- a/tests/ws-orient/orient.bats
+++ b/tests/ws-orient/orient.bats
@@ -66,3 +66,34 @@ setup() {
         [[ "$output" == *"$verb"* ]] || { echo "missing survey row: $verb"; return 1; }
     done
 }
+
+# ─── 4c — active realm detection ────────────────────────────────────
+
+@test "ws orient: prints 'Active realm: none' when no realm is present" {
+    # init_workspace creates an empty realms/ directory, so the
+    # detect helper returns empty. The empty case must still
+    # produce a clear status line — silence would be ambiguous.
+    run_ws orient
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Active realm: none"* ]]
+}
+
+@test "ws orient: surfaces the active realm name when one is present" {
+    # Drop a fixture realm; auto-detection picks the single
+    # non-template realm-* directory under realms/.
+    mkdir -p "$WORK/realms/realm-fixture"
+    cat > "$WORK/realms/realm-fixture/ecosystem.yaml" <<'YAML'
+identity:
+  human_account: testuser
+components: {}
+YAML
+    cat > "$WORK/realms/realm-fixture/AGENTS.md" <<'MD'
+# realm-fixture
+MD
+    run_ws orient
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Active realm: realm-fixture"* ]]
+    # Pointer to the realm's AGENTS.md so the agent can navigate
+    # to the canonical realm guide without further discovery.
+    [[ "$output" == *"AGENTS.md"* ]]
+}

--- a/tests/ws-orient/orient.bats
+++ b/tests/ws-orient/orient.bats
@@ -241,6 +241,12 @@ YAML
     run_ws orient
     [ "$status" -eq 0 ]
     [[ "$output" == *"badyaml"* ]]
+    # Pin the diagnostic text so a regression that silently swallows
+    # the parse failure (returning empty commands and rendering "no
+    # commands wired") instead of surfacing the actual problem fails
+    # this test. Per CodeRabbit on PR #89.
+    [[ "$output" == *"adapter present but YAML parse failed"* ]]
+    [[ "$output" == *"badyaml.yaml"* ]]
     [[ "$output" == *"Skills"* ]]
 }
 
@@ -260,6 +266,12 @@ MD
     _seed_skill "$WORK/.agent/skills" sibling-skill "Should still appear despite the sibling's broken frontmatter."
     run_ws orient
     [ "$status" -eq 0 ]
+    # The broken skill must still render via the dir-name fallback —
+    # not just "didn't abort". Per CodeRabbit on PR #89: pin the
+    # fallback path explicitly so a regression that silently drops
+    # broken skills (e.g. via `continue` instead of `name=basename`)
+    # would fail this test.
+    [[ "$output" == *"broken-skill"* ]]
     # The good skill's description must still render — proves orient
     # didn't abort mid-walk over the broken sibling.
     [[ "$output" == *"sibling-skill"* ]]

--- a/tests/ws-orient/orient.bats
+++ b/tests/ws-orient/orient.bats
@@ -250,6 +250,46 @@ YAML
     [[ "$output" == *"Skills"* ]]
 }
 
+@test "ws orient --help works when yq is not on PATH" {
+    # Fresh-machine contract: --help must short-circuit before the
+    # yq dependency check so a newcomer can discover the command
+    # before installing every prerequisite. Per Copilot finding on
+    # PR #89.
+    #
+    # Strip yq from PATH by pointing to system bin dirs only. If
+    # those happen to contain yq on this host (rare — most installs
+    # land in /usr/local/bin or ~/.local/bin), skip rather than
+    # produce a false positive.
+    local minimal_path="/usr/bin:/bin"
+    if PATH="$minimal_path" command -v yq >/dev/null 2>&1; then
+        skip "yq is in /usr/bin or /bin on this host — cannot simulate missing-yq"
+    fi
+    run env "PATH=$minimal_path" "$TIMEOUT_BIN" 10 bash "$WS_BIN" orient --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+}
+
+@test "ws orient: ecosystem.local.yaml parse failure renders 'error' (not 'ambiguous')" {
+    # Per Copilot finding on PR #89: a YAML parse failure in
+    # ecosystem.local.yaml shouldn't be misreported as multi-realm
+    # ambiguity — that sends the user down the wrong fix path.
+    # Distinguish via the stderr content from ws_detect_realm.
+    cat > "$WORK/ecosystem.local.yaml" <<'YAML'
+identity:
+  human_account: "broken
+  unterminated: scalar
+realm: "missing close
+YAML
+    run_ws orient
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Active realm: error"* ]]
+    # No misleading multi-realm guidance — that'd be the
+    # wrong-fix-path Copilot warned about.
+    [[ "$output" != *"Active realm: ambiguous"* ]]
+    # Subsequent sections must still render.
+    [[ "$output" == *"Skills"* ]]
+}
+
 @test "ws orient: malformed skill frontmatter does not abort orient" {
     # SKILL.md with broken frontmatter — yq fails on the parse.
     # Orient should fall back to the dir name (already done) and

--- a/tests/ws-orient/orient.bats
+++ b/tests/ws-orient/orient.bats
@@ -157,3 +157,55 @@ YAML
     [[ "$output" == *"Components"* ]]
     [[ "$output" == *"no components cloned"* ]]
 }
+
+# ─── 4e — skill index ───────────────────────────────────────────────
+
+# Helper: drop a SKILL.md with the given name + description into the
+# target dir. Mirrors the on-disk convention every workspace +
+# realm skill uses (`.agent/skills/<slug>/SKILL.md` with a YAML
+# frontmatter carrying `name:` and `description:`).
+_seed_skill() {
+    local skills_root="$1" slug="$2" description="$3"
+    mkdir -p "$skills_root/$slug"
+    cat > "$skills_root/$slug/SKILL.md" <<MD
+---
+name: $slug
+description: $description
+---
+
+# $slug
+MD
+}
+
+@test "ws orient: surfaces a workspace skill name and its description" {
+    _seed_skill "$WORK/.agent/skills" fixture-skill "Use when running the orient skill-index test."
+    run_ws orient
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"fixture-skill"* ]]
+    [[ "$output" == *"orient skill-index test"* ]]
+}
+
+@test "ws orient: surfaces an active-realm skill alongside workspace skills" {
+    mkdir -p "$WORK/realms/realm-fixture"
+    cat > "$WORK/realms/realm-fixture/ecosystem.yaml" <<'YAML'
+identity:
+  human_account: testuser
+components: {}
+YAML
+    _seed_skill "$WORK/.agent/skills" ws-skill "Workspace-tier skill"
+    _seed_skill "$WORK/realms/realm-fixture/.agent/skills" realm-skill "Realm-tier skill"
+    run_ws orient
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"ws-skill"* ]]
+    [[ "$output" == *"realm-skill"* ]]
+}
+
+@test "ws orient: skills section is present even when no skills exist" {
+    # init_workspace alone has no .agent/skills/ dirs anywhere.
+    # Section header must still render so a future regression that
+    # silently drops the whole index is visible.
+    run_ws orient
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Skills"* ]]
+    [[ "$output" == *"no skills"* ]]
+}

--- a/tests/ws-orient/orient.bats
+++ b/tests/ws-orient/orient.bats
@@ -209,3 +209,59 @@ YAML
     [[ "$output" == *"Skills"* ]]
     [[ "$output" == *"no skills"* ]]
 }
+
+# ─── resilience: ambiguous realm + malformed YAML survive ───────────
+
+@test "ws orient: ambiguous realm renders a clear status, not a hard exit" {
+    # ws_detect_realm exits 1 when multiple non-template realm-*
+    # dirs are present and no ecosystem.local.yaml `realm:` selector
+    # picks one. Orient should catch that, render an "ambiguous"
+    # status with the resolution hint, and continue rendering the
+    # rest of the output — not die mid-section.
+    mkdir -p "$WORK/realms/realm-alpha" "$WORK/realms/realm-beta"
+    run_ws orient
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Active realm: ambiguous"* ]]
+    [[ "$output" == *"ecosystem.local.yaml"* ]]
+    # Subsequent sections must still render — Skills header proves
+    # we didn't bail at the realm step.
+    [[ "$output" == *"Skills"* ]]
+}
+
+@test "ws orient: malformed adapter YAML does not abort orient" {
+    _seed_realm_and_component badyaml
+    # Garbage YAML — yq will fail to parse. With strict mode, an
+    # unguarded yq call would propagate the failure and kill orient
+    # mid-render. The component should still appear with a clear
+    # diagnostic, and following sections must still render.
+    cat > "$WORK/realms/realm-fixture/adapters/badyaml.yaml" <<'YAML'
+commands:
+  test: "missing close quote
+YAML
+    run_ws orient
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"badyaml"* ]]
+    [[ "$output" == *"Skills"* ]]
+}
+
+@test "ws orient: malformed skill frontmatter does not abort orient" {
+    # SKILL.md with broken frontmatter — yq fails on the parse.
+    # Orient should fall back to the dir name (already done) and
+    # keep walking; other skills must still appear.
+    mkdir -p "$WORK/.agent/skills/broken-skill"
+    cat > "$WORK/.agent/skills/broken-skill/SKILL.md" <<'MD'
+---
+name: broken-skill
+description: "unterminated quote
+---
+
+# broken-skill
+MD
+    _seed_skill "$WORK/.agent/skills" sibling-skill "Should still appear despite the sibling's broken frontmatter."
+    run_ws orient
+    [ "$status" -eq 0 ]
+    # The good skill's description must still render — proves orient
+    # didn't abort mid-walk over the broken sibling.
+    [[ "$output" == *"sibling-skill"* ]]
+    [[ "$output" == *"Should still appear"* ]]
+}

--- a/tests/ws-smoke/read-only.bats
+++ b/tests/ws-smoke/read-only.bats
@@ -62,8 +62,14 @@ setup() {
 
     run_ws help
     [ "$status" -eq 0 ]
+    # Match space-delimited so `clone` doesn't false-positive on
+    # `clone-fork` (Copilot finding on PR #89). The help block
+    # format always puts the command between leading indent
+    # whitespace and either an argument hint or an aligned
+    # description — both shapes carry a trailing space after the
+    # command token.
     for cmd in "${dispatched[@]}"; do
-        [[ "$output" == *"$cmd"* ]] || { echo "missing in ws help: $cmd"; return 1; }
+        [[ "$output" == *" $cmd "* ]] || { echo "missing in ws help: $cmd"; return 1; }
     done
 }
 

--- a/tests/ws-smoke/read-only.bats
+++ b/tests/ws-smoke/read-only.bats
@@ -24,15 +24,46 @@ setup() {
     [[ "$output" == *"ws <command>"* ]]
 }
 
-@test "ws help: lists every registered subcommand" {
-    # Regression guard for the omission CodeRabbit caught on PR #88:
-    # `orient` was wired into the dispatcher but absent from the help
-    # text. Pin the headline commands here so a new subcommand can't
-    # land without being announced.
+@test "ws help: lists every dispatched subcommand from scripts/ws" {
+    # Regression guard for the omission CodeRabbit caught on PR #88
+    # (`orient` was wired into the dispatcher but absent from help)
+    # AND the follow-up finding on PR #89 that a hard-pinned list
+    # missed 11 dispatched commands. Derive the expected list from
+    # the dispatcher's `case "$COMMAND" in` block so every new
+    # subcommand auto-enrolls into the regression guard — no
+    # hand-edit needed when adding one.
+    #
+    # Parsing rules: extract each label line (`    <name>)`), strip
+    # whitespace + trailing `)`, split alias groups on `|`, keep
+    # only bare lowercase-and-hyphen names (drops `*)`, `--help`,
+    # `-h`, etc. — those are flag forms or fallbacks, not commands).
+    local dispatched=() line label labels label_group
+    while IFS= read -r line; do
+        # Match "    <label-group>)" where label-group may contain
+        # alias delimiters (`|`), wildcards (`*`), and hyphens.
+        # The captured group strips leading whitespace + trailing
+        # ) and beyond in one step — avoids the bash-${var## } trap
+        # of stripping only a single literal space character.
+        if [[ "$line" =~ ^[[:space:]]+([a-zA-Z*][a-zA-Z0-9_|*-]*)\) ]]; then
+            label_group="${BASH_REMATCH[1]}"
+            IFS='|' read -ra labels <<<"$label_group"
+            for label in "${labels[@]}"; do
+                # Bare lowercase-and-hyphen labels are dispatched
+                # subcommands; everything else (`--help`, `-h`,
+                # `*`) is a flag form / fallback.
+                [[ "$label" =~ ^[a-z][a-z0-9-]*$ ]] && dispatched+=("$label")
+            done
+        fi
+    done < <(awk '/^case .*COMMAND.* in/,/^esac/' "$WS_BIN")
+
+    # Sanity: if the parser pulled nothing, the dispatcher's case
+    # shape changed and this test silently became a no-op. Fail loud.
+    [ "${#dispatched[@]}" -gt 0 ] || { echo "dispatch parser found no commands — case-block shape changed?"; return 1; }
+
     run_ws help
     [ "$status" -eq 0 ]
-    for cmd in list orient status clone pull push cr commit test lint review log clean exec realm hoard component actions preflight; do
-        [[ "$output" == *"$cmd"* ]] || { echo "missing in help: $cmd"; return 1; }
+    for cmd in "${dispatched[@]}"; do
+        [[ "$output" == *"$cmd"* ]] || { echo "missing in ws help: $cmd"; return 1; }
     done
 }
 

--- a/tests/ws-smoke/read-only.bats
+++ b/tests/ws-smoke/read-only.bats
@@ -24,6 +24,18 @@ setup() {
     [[ "$output" == *"ws <command>"* ]]
 }
 
+@test "ws help: lists every registered subcommand" {
+    # Regression guard for the omission CodeRabbit caught on PR #88:
+    # `orient` was wired into the dispatcher but absent from the help
+    # text. Pin the headline commands here so a new subcommand can't
+    # land without being announced.
+    run_ws help
+    [ "$status" -eq 0 ]
+    for cmd in list orient status clone pull push cr commit test lint review log clean exec realm hoard component actions preflight; do
+        [[ "$output" == *"$cmd"* ]] || { echo "missing in help: $cmd"; return 1; }
+    done
+}
+
 @test "ws --help: exits 0 and prints usage" {
     run_ws --help
     [ "$status" -eq 0 ]


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @Cervator via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

Completes **Task 4** of the `gdd-orientation-capability-index` arc's Phase 1 — fills out `ws orient` with the four content sections specified in `docs/plans/2026-06-02-gdd-orientation-and-attribution-plan.md` (lines 346-352). Builds on the Task 4a scaffold that landed in PR #88.

Five incremental commits, one PR for review efficiency. Each commit owns its own TDD cycle (RED → GREEN → no-regression check on the full bats suite).

## Commits in this PR

1. **`ws help`: add `orient` to the command list + regression test for every subcommand** — addresses the CodeRabbit feedback on PR #88 (`orient` was dispatched but missing from `ws help` output). The new test pins a list of headline subcommand names so a future addition can't slip past help discoverability.
2. **Task 4b — subcommand survey with 'use when' framing.** 24 rows authored as a single `name|use-when` table in `ws-orient.sh`. The phrasing is judgment that lives in one place, not scattered across each subcommand script.
3. **Task 4c — surface active realm + AGENTS.md pointer.** Reuses the existing `ws_detect_realm` helper so detection logic stays single-sourced. Handles no-realm / one-realm / multi-realm cases.
4. **Task 4d — per-component adapter enumeration with the resolved command surfaced.** The load-bearing adapter-trust mitigation from the design (§ Adapter trust): when `ws test`/`ws lint`/`ws build` fires, the actual command must be visible from `ws orient` output, not hidden behind the wrapper. Output shape: `comp → ws test [runs: <cmd>]` or `comp → no test/lint adapter (wire: …)`.
5. **Task 4e — skill index (workspace + active realm) + a bug fix.** Frontmatter-only enumeration of `.agent/skills/<name>/SKILL.md` in both scopes. Bug fix folded in: the 4a scaffold unconditionally set `ROOT_DIR`, clobbering the bats helper's exported test workspace — switched to the `:=` defaulting form like `scripts/ws` uses.

## Real-workspace smoke output

Against the live SiliconSaga workspace, `ws orient` now produces a ~60-line digest covering: 24 subcommand rows with "use when" framing, `Active realm: realm-siliconsaga` + AGENTS.md pointer, 12 cloned components with adapter wiring (resolved commands surfaced for `nordri` / `destinationsol` / `terasology` / `ting`; `heimdall` flagged as "adapter present but no commands wired"; unwired components each get their wire-it hint), and 20 skills enumerated across the workspace + realm scopes with descriptions.

## TDD evidence

| Commit | New tests | RED behavior | GREEN result |
|---|---|---|---|
| help-text | 1 (subcommand-list regression guard) | `orient` absent → fail | pass |
| 4b survey | 2 ("use when" phrase + headline-verb rows) | placeholder body → both fail | both pass |
| 4c realm | 2 (no-realm + with-realm fixture) | no realm section → both fail | both pass |
| 4d adapters | 3 (wired / unwired / no-clones) | no adapter section → all 3 fail | all 3 pass |
| 4e skills | 3 (workspace / realm / no-skills) | no skill section → all 3 fail | all 3 pass |

Full bats suite: **259/259** with the new branch (was 248/248 before; +11 new assertions, no regressions).

## Why "incremental commits, single PR"

Per the arc's plan, each Task 4 sub-step is its own TDD cycle. Keeping them as separate commits preserves the bisect-friendly history (the help-text fix is `369313d`; 4b is `622b282`; etc.) while bundling for review so a reviewer can follow the section-by-section growth of the output without context-switching across five PRs.

## Test plan

- [x] `bash scripts/ws test yggdrasil` → 259/259 pass.
- [x] `bash scripts/ws orient` (against the live workspace) → reads cleanly, all four sections render with real data.
- [x] `bash scripts/ws orient --help` → usage block prints.
- [x] `bash scripts/ws help` → `orient` row present.

## Related

- **Arc:** `gdd-orientation-capability-index` (Loki-thalamus), Phase 1, Task 4 sub-steps 4b-4e + the PR #88 follow-up.
- **Plan:** `docs/plans/2026-06-02-gdd-orientation-and-attribution-plan.md`.
- **Design:** `docs/plans/2026-06-02-gdd-orientation-and-attribution-design.md`.
- **Predecessor PR:** [SiliconSaga/yggdrasil#88](https://github.com/SiliconSaga/yggdrasil/pull/88) — Task 4a scaffold (merged).

## Next slices in the arc

- **Task 5** — one-line stderr footer after every `ws` subcommand: `↪ switching tasks? \`ws orient\` lists the toolset for what's here.`
- **Task 6** — adapter-aware hook redirects (`pytest` → `ws test`: deny-with-bypass when adapter wired, allow-with-nudge when unwired).
- **Task 7** — cut `AGENTS.md` to L0 (slim menu + reflex contract + orientation pointer).
- **Task 8** — rework `gdd-orientation` skill via `superpowers:writing-skills` (calls `ws orient` for facts, auto-refreshes `.env` `CLAUDE_MODEL`, scans adapter commands for risk).
- **Task D1** — docs sweep across 8 GDD docs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `ws orient` — a deterministic "what can I do here?" menu showing available subcommands, active realm status (with guidance), per-component adapter wiring (with run hints), and a skills index.
  * `ws help` now includes the new orient entry.

* **Bug Fixes**
  * Continues rendering despite missing/malformed realm, adapter, or skill metadata; shows clear diagnostics and fallbacks.
  * Honors preset workspace root when present and validates required tooling before running.

* **Tests**
  * Added deterministic and smoke tests covering orient discovery, realm detection, adapter enumeration, and skills rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->