### PR TITLE
ws orient footer + hook adapter redirects + AGENTS.md L0 cut (Tasks 5, 6, 7)

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -34,9 +34,11 @@ The format is flat sectioned text: `[section]` headers, one entry per line, `#` 
 
 **`[scratch-dirs]`** — workspace-relative paths under which Edit/Write tool calls auto-allow. Keeps in lockstep with the "Workspace-local scratch" section of [`.gitignore`](../../.gitignore). Entries in `hook-rules.local` add to the baseline; they never replace it.
 
-**`[ask-commands]`** — glob patterns for destructive Bash commands that should always produce a permission prompt, regardless of session mode. A match in either file triggers Tier 3 (ask) not a deny — the human approves and the command runs. `hook-rules.local` entries are additive-only: you can make more commands prompt, but you cannot remove a pattern committed in `hook-rules`. This is intentional — per-machine config can tighten the safety floor, never loosen it.
+**`[ask-commands]`** — glob patterns for destructive Bash commands that should always produce a permission prompt, regardless of session mode. A match in either file triggers Tier 4 (ask) not a deny — the human approves and the command runs. `hook-rules.local` entries are additive-only: you can make more commands prompt, but you cannot remove a pattern committed in `hook-rules`. This is intentional — per-machine config can tighten the safety floor, never loosen it.
 
-**`[allow-extras]`** — personal Bash glob patterns auto-allowed on this machine without prompting (Tier 5). Only valid in `hook-rules.local`, never in the committed baseline. An entry here will not win over an "ask command" entry.
+**`[adapter-redirect-commands]`** — Tier 3 patterns for raw test/lint/build runners. The hook resolves the component from `$cwd` and the active realm's adapter file; wired adapters get a deny-with-bypass, missing adapters get a one-line stderr nudge and fall through. See `[adapter-redirect-commands]` in `hook-rules` for the format.
+
+**`[allow-extras]`** — personal Bash glob patterns auto-allowed on this machine without prompting (Tier 6). Only valid in `hook-rules.local`, never in the committed baseline. An entry here will not win over an "ask command" entry.
 
 ### Setting up per-machine overrides
 
@@ -58,7 +60,7 @@ The Tier 2 redirect-deny channels three raw commands toward the workspace's `ws`
 | `git-push` | `git push*` | `ws push <comp> [branch]` — picks the fork remote from `identity.forkOrg`, sets upstream on first push |
 | `gh-pr-create` | `gh pr create*` | `ws cr <comp> <title> <bodyfile>` — bodyfile-driven, applies identity substitutions |
 
-A deny here is a *training* signal, not a safety floor (that's Tier 3 ask). The hook trusts the workspace's own `ws` wrappers to do the right thing — attribution, remote selection, the right token. When a legitimate edge case exists (`ws` doesn't yet support what you need), the agent can request a bypass:
+A deny here is a *training* signal, not a safety floor (that's Tier 4 ask). The hook trusts the workspace's own `ws` wrappers to do the right thing — attribution, remote selection, the right token. When a legitimate edge case exists (`ws` doesn't yet support what you need), the agent can request a bypass:
 
 1. Agent hits the deny; corrective message names `ws hook-bypass <slug>` as the escape hatch.
 2. Agent runs `ws hook-bypass <slug> --reason "<why>"`. The subcommand is on the ask-list, so the human gets a permission prompt — tailored to name the slug being bypassed and surface the `--reason`, so the human sees what they're approving rather than a generic "destructive command" line.

--- a/.claude/hooks/gdd-permission-hook.sh
+++ b/.claude/hooks/gdd-permission-hook.sh
@@ -895,7 +895,10 @@ _ar_resolve_realm() {
 _ar_resolve_component() {
     local cwd="$1" root="$2"
     if [[ "$cwd" == "$root/components/"* ]]; then
-        local rest="${cwd#$root/components/}"
+        # Quote $root inside the expansion so a root path with glob
+        # metacharacters (e.g. /home/user/my[project]) is matched
+        # literally rather than as a pattern. shellcheck SC2295.
+        local rest="${cwd#"$root"/components/}"
         local comp="${rest%%/*}"
         [[ -n "$comp" ]] || return 1
         echo "$comp"

--- a/.claude/hooks/gdd-permission-hook.sh
+++ b/.claude/hooks/gdd-permission-hook.sh
@@ -931,8 +931,13 @@ for _entry in ${adapter_redirect_commands[@]+"${adapter_redirect_commands[@]}"};
             # nudge for later workflow-audit review.
             echo "[$(date '+%Y-%m-%d %H:%M:%S')] UNWIRED-NUDGE [$_ar_slug] no commands.$_ar_verb in realms/$_ar_realm/adapters/$_ar_comp.yaml [$event]: $(audit_safe "$cmd")" >> "$audit_log"
             echo "↪ No \`ws $_ar_verb\` adapter for $_ar_comp yet. Wire one at realms/$_ar_realm/adapters/$_ar_comp.yaml with \`commands.$_ar_verb: ...\` and \`ws $_ar_verb $_ar_comp\` will dispatch it. Running raw this time." >&2
-            # Continue the for loop so later entries can still match,
-            # then fall through to Tier 3.
+            # Break after the first unwired match so an overlapping
+            # glob in hook-rules doesn't emit a second nudge / audit
+            # entry for the same command (Copilot finding on PR #90).
+            # The break exits this for loop; later tiers (Tier 3
+            # ask-list, allow evaluation, passthrough prompt) still
+            # run because we didn't emit a JSON decision or exit.
+            break
         fi
     fi
 done

--- a/.claude/hooks/gdd-permission-hook.sh
+++ b/.claude/hooks/gdd-permission-hook.sh
@@ -884,11 +884,21 @@ _ar_resolve_realm() {
 
 # Resolve the component name from $cwd. Returns 0 + prints the name
 # if $cwd is under $root/components/<comp>/, else returns 1.
+#
+# The pattern `"$root/components/"*` also matches `$cwd == "$root/components/"`
+# itself (empty tail after the prefix strip), which would produce an
+# empty component name — Tier 3 would then treat the workspace-level
+# `components/` directory as a "component", emit a blank-component
+# nudge, and look up `realms/<realm>/adapters/.yaml`. Guard against
+# that by rejecting an empty first segment so the rule only fires
+# under a real `components/<comp>/` path.
 _ar_resolve_component() {
     local cwd="$1" root="$2"
     if [[ "$cwd" == "$root/components/"* ]]; then
         local rest="${cwd#$root/components/}"
-        echo "${rest%%/*}"
+        local comp="${rest%%/*}"
+        [[ -n "$comp" ]] || return 1
+        echo "$comp"
         return 0
     fi
     return 1

--- a/.claude/hooks/gdd-permission-hook.sh
+++ b/.claude/hooks/gdd-permission-hook.sh
@@ -336,6 +336,7 @@ scratch_dirs=()
 ask_commands=()
 allow_extras=()
 redirect_commands=()  # entries: "<slug>|<pattern>|<suggestion>"
+adapter_redirect_commands=()  # entries: "<slug>|<pattern>|<verb>"
 
 # Parse one rules file, appending entries to the section arrays.
 # $1 = file path; $2 = non-empty when parsing hook-rules.local (local).
@@ -396,6 +397,44 @@ _parse_rules_file() {
                         fi
                         # Pack as "slug|pattern|suggestion" (internal separator, never displayed)
                         redirect_commands+=("$slug|$pattern|$suggestion")
+                        ;;
+                    adapter-redirect-commands)
+                        # Parse three pipe-separated columns: slug | pattern | verb.
+                        # Verb is one of test/lint/build — the ws subcommand the
+                        # raw command maps to, AND the key under `commands.` in
+                        # the realm's adapter file (realms/<r>/adapters/<comp>.yaml).
+                        local ar_slug ar_pattern ar_verb ar_rest
+                        if [[ "$line" != *" | "* ]]; then
+                            echo "[$(date '+%Y-%m-%d %H:%M:%S')] WARNING (hook-rules: malformed [adapter-redirect-commands] entry, missing separator): $file" >> "$audit_log"
+                            continue
+                        fi
+                        ar_slug="${line%% | *}"
+                        ar_rest="${line#* | }"
+                        if [[ "$ar_rest" != *" | "* ]]; then
+                            echo "[$(date '+%Y-%m-%d %H:%M:%S')] WARNING (hook-rules: malformed [adapter-redirect-commands] entry, only two columns): $file" >> "$audit_log"
+                            continue
+                        fi
+                        ar_pattern="${ar_rest%% | *}"
+                        ar_verb="${ar_rest#* | }"
+                        ar_slug="${ar_slug%"${ar_slug##*[![:space:]]}"}"
+                        ar_pattern="${ar_pattern%"${ar_pattern##*[![:space:]]}"}"
+                        ar_verb="${ar_verb%"${ar_verb##*[![:space:]]}"}"
+                        ar_verb="${ar_verb#"${ar_verb%%[![:space:]]*}"}"
+                        if [[ ! "$ar_slug" =~ ^[a-z][a-z0-9-]*$ ]]; then
+                            echo "[$(date '+%Y-%m-%d %H:%M:%S')] WARNING (hook-rules: malformed [adapter-redirect-commands] entry, bad slug '$ar_slug'): $file" >> "$audit_log"
+                            continue
+                        fi
+                        # Verb must be a known ws action surface — keeps the
+                        # adapter lookup predictable and prevents typos from
+                        # silently degrading to "no commands.X found".
+                        case "$ar_verb" in
+                            test|lint|build) ;;
+                            *)
+                                echo "[$(date '+%Y-%m-%d %H:%M:%S')] WARNING (hook-rules: malformed [adapter-redirect-commands] entry, bad verb '$ar_verb' — must be test/lint/build): $file" >> "$audit_log"
+                                continue
+                                ;;
+                        esac
+                        adapter_redirect_commands+=("$ar_slug|$ar_pattern|$ar_verb")
                         ;;
                     *)
                         if [[ -z "$section" ]]; then
@@ -781,6 +820,120 @@ for _entry in ${redirect_commands[@]+"${redirect_commands[@]}"}; do
             exit 0
         fi
         deny "$_t2_suggestion"
+    fi
+done
+
+# ─── Tier 2.5: Adapter-aware redirect — raw test/lint runners ───────
+#
+# When a [adapter-redirect-commands] pattern matches AND the agent's
+# $cwd resolves to a component under $project_root/components/<comp>/,
+# consult the active realm's adapter (realms/<realm>/adapters/<comp>.yaml)
+# to decide:
+#   - commands.<verb> wired  → deny-with-bypass pointing at `ws <verb> <comp>`
+#   - commands.<verb> missing → emit a stderr nudge, fall through
+# If $cwd is not in a component dir, the rule doesn't fire at all
+# (raw pytest at the workspace root is a legitimate workspace-test
+# invocation — leave it alone).
+#
+# yq is required for the adapter parse. The hook script's outer
+# bash-runner already has it (workspace prereq via ws preflight).
+
+# Resolve the active realm from a project root. Mirrors ws_detect_realm's
+# logic minus the heavy error handling — we either find one or skip
+# the rule. Returns 0 and prints the realm dir name on success.
+_ar_resolve_realm() {
+    local root="$1"
+    local local_file="$root/ecosystem.local.yaml"
+    if [[ -f "$local_file" ]] && command -v yq >/dev/null 2>&1; then
+        local sel
+        sel="$(yq -r '.realm // ""' "$local_file" 2>/dev/null || echo "")"
+        if [[ -n "$sel" && "$sel" != "null" && -d "$root/realms/$sel" ]]; then
+            echo "$sel"
+            return 0
+        fi
+    fi
+    # Auto-detect: single non-template realm-* dir.
+    local d dname count=0 found=""
+    if [[ -d "$root/realms" ]]; then
+        for d in "$root"/realms/realm-*/; do
+            [[ -d "$d" ]] || continue
+            dname="$(basename "$d")"
+            [[ "$dname" == "realm-template" ]] && continue
+            found="$dname"
+            count=$((count + 1))
+        done
+    fi
+    [[ $count -eq 1 ]] && { echo "$found"; return 0; }
+    return 1
+}
+
+# Resolve the component name from $cwd. Returns 0 + prints the name
+# if $cwd is under $root/components/<comp>/, else returns 1.
+_ar_resolve_component() {
+    local cwd="$1" root="$2"
+    if [[ "$cwd" == "$root/components/"* ]]; then
+        local rest="${cwd#$root/components/}"
+        echo "${rest%%/*}"
+        return 0
+    fi
+    return 1
+}
+
+# Walk the adapter-redirect entries. The bypass marker check + the
+# wired/unwired branch live inline so the tier's flow reads top-to-
+# bottom without jumping helpers.
+for _entry in ${adapter_redirect_commands[@]+"${adapter_redirect_commands[@]}"}; do
+    _ar_slug="${_entry%%|*}"
+    _ar_rest="${_entry#*|}"
+    _ar_pattern="${_ar_rest%%|*}"
+    _ar_verb="${_ar_rest#*|}"
+    _ar_match_pattern="$(normalize_for_match "$_ar_pattern")"
+    # shellcheck disable=SC2053
+    if [[ "$match_cmd" == $_ar_match_pattern ]]; then
+        # Component anchor required — raw pytest outside components/
+        # is fine, the rule only applies inside a component.
+        _ar_comp="$(_ar_resolve_component "$cwd" "$_t2_project_root" 2>/dev/null)" || continue
+        # Realm required for adapter path resolution.
+        _ar_realm="$(_ar_resolve_realm "$_t2_project_root" 2>/dev/null)" || continue
+        _ar_adapter_file="$_t2_project_root/realms/$_ar_realm/adapters/$_ar_comp.yaml"
+        # yq is the parser. Missing yq, missing file, or missing key
+        # all collapse to "unwired".
+        _ar_cmd_value=""
+        if [[ -f "$_ar_adapter_file" ]] && command -v yq >/dev/null 2>&1; then
+            _ar_cmd_value="$(yq -r ".commands.$_ar_verb // \"\"" "$_ar_adapter_file" 2>/dev/null || echo "")"
+        fi
+        if [[ -n "$_ar_cmd_value" && "$_ar_cmd_value" != "null" ]]; then
+            # WIRED — deny with bypass pointer (matches Tier 2 shape).
+            _ar_marker_path="$_t2_project_root/.tmp/hook-bypass/$_ar_slug.bypass"
+            _ar_bypass_ok=0
+            if [[ -f "$_ar_marker_path" ]]; then
+                _ar_marker_sid=$(grep '^session_id:' "$_ar_marker_path" 2>/dev/null | sed 's/^session_id: *//' || true)
+                _ar_marker_reason=$(grep '^reason:' "$_ar_marker_path" 2>/dev/null | sed 's/^reason: *//' || true)
+                if [[ -n "$_t2_session_id" && "$_ar_marker_sid" == "$_t2_session_id" ]]; then
+                    _ar_bypass_ok=1
+                fi
+            fi
+            if [[ "$_ar_bypass_ok" == "1" ]]; then
+                echo "[$(date '+%Y-%m-%d %H:%M:%S')] BYPASS-ALLOW [$_ar_slug] reason=\"$(audit_safe "$_ar_marker_reason")\" [$event]: $(audit_safe "$cmd")" >> "$audit_log"
+                if [[ "$event" == "PermissionRequest" ]]; then
+                    printf '%s\n' '{"hookSpecificOutput":{"hookEventName":"PermissionRequest","decision":{"behavior":"allow"}}}'
+                else
+                    printf '%s\n' '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow"}}'
+                fi
+                exit 0
+            fi
+            deny "Use \`ws $_ar_verb $_ar_comp\` — adapter wired for this component (realms/$_ar_realm/adapters/$_ar_comp.yaml). \`ws $_ar_verb --help\` for filters. \`ws hook-bypass $_ar_slug\` for a session-scoped bypass if you genuinely need raw access."
+        else
+            # UNWIRED — emit stderr nudge and fall through to later
+            # tiers. No JSON output here — the harness then applies
+            # the normal ask/allow evaluation (ask-list, allowlist,
+            # or passthrough prompt). The audit log captures the
+            # nudge for later workflow-audit review.
+            echo "[$(date '+%Y-%m-%d %H:%M:%S')] UNWIRED-NUDGE [$_ar_slug] no commands.$_ar_verb in realms/$_ar_realm/adapters/$_ar_comp.yaml [$event]: $(audit_safe "$cmd")" >> "$audit_log"
+            echo "↪ No \`ws $_ar_verb\` adapter for $_ar_comp yet. Wire one at realms/$_ar_realm/adapters/$_ar_comp.yaml with \`commands.$_ar_verb: ...\` and \`ws $_ar_verb $_ar_comp\` will dispatch it. Running raw this time." >&2
+            # Continue the for loop so later entries can still match,
+            # then fall through to Tier 3.
+        fi
     fi
 done
 

--- a/.claude/hooks/gdd-permission-hook.sh
+++ b/.claude/hooks/gdd-permission-hook.sh
@@ -39,12 +39,12 @@
 #
 # This script is security-sensitive: a permissive pattern here lets
 # the agent skip user confirmation for commands matching that pattern.
-# Keep deny logic conservative (Tiers 1-2 below) and allow logic narrow
-# (Tiers 4-5). Note Tier 1 (composition) is an unconditional deny, while
-# Tier 2 (redirect) is a training-aid deny with a human-approved bypass —
-# do not treat Tier 2 as a hard security floor. When uncertain, default to
-# passthrough — the harness's own prompt is the safety net, not a fallback
-# to be eliminated.
+# Keep deny logic conservative (Tiers 1-3 below) and allow logic narrow
+# (Tiers 5-6). Note Tier 1 (composition) is an unconditional deny, while
+# Tiers 2 and 3 (redirect + adapter-redirect) are training-aid denies
+# with human-approved bypass — do not treat them as a hard security
+# floor. When uncertain, default to passthrough — the harness's own
+# prompt is the safety net, not a fallback to be eliminated.
 #
 # ─── DECISION TIERS (in order) ──────────────────────────────────────
 #
@@ -73,16 +73,29 @@
 #   BYPASS-ALLOW to the audit log
 #   with the slug + optional reason.
 #
-# Tier 3 — Ask-list from hook-rules [ask-commands] (ASK)
+# Tier 3 — Adapter-aware redirect (DENY-OR-NUDGE, with per-slug bypass)
+#   Commands matching an [adapter-redirect-commands] entry route based
+#   on whether the realm's adapter file declares the verb wired:
+#     - $cwd inside components/<comp>/ AND adapter has commands.<verb>
+#       → DENY with a `ws <verb> <comp>` pointer (same bypass-marker
+#       shape as Tier 2).
+#     - $cwd inside components/<comp>/ AND adapter missing or no
+#       commands.<verb> → emit one stderr nudge, fall through to
+#       later tiers (the agent's allowlist may still let the raw
+#       command run).
+#     - $cwd outside any component → rule doesn't fire (workspace-
+#       level raw runner invocations are left alone).
+#
+# Tier 4 — Ask-list from hook-rules [ask-commands] (ASK)
 #   Destructive commands that should always prompt, even under
 #   acceptEdits. Any match → ask.
 #
-# Tier 4 — Per-project allowlist from .claude/settings.json (ALLOW)
+# Tier 5 — Per-project allowlist from .claude/settings.json (ALLOW)
 #   Walk up from $cwd, collect Bash(...) entries from each
 #   .claude/settings.json found, then check $HOME/.claude/settings.json
 #   too. Glob-match each pattern against the command. Any match → allow.
 #
-# Tier 5 — [allow-extras] from hook-rules.local (ALLOW, optional)
+# Tier 6 — [allow-extras] from hook-rules.local (ALLOW, optional)
 #   Personal per-machine glob patterns declared in hook-rules.local's
 #   [allow-extras] section. Parsed into allow_extras above. Any
 #   match → allow. Silently absent if hook-rules.local has no section.
@@ -293,7 +306,7 @@ deny() {
 }
 
 # ask() — force a permission prompt without blocking. Used by the
-# Tier 3 ask-list for destructive-but-sometimes-legitimate commands.
+# Tier 4 ask-list for destructive-but-sometimes-legitimate commands.
 # Unlike deny(), the agent can still run the command once the human
 # approves; unlike allow(), it never auto-runs. The `ask` decision
 # overrides the harness's permission mode — it prompts even under
@@ -326,11 +339,13 @@ ask() {
 # Parsed by pure bash — no yq/jq dependency for config. Four sections:
 #   [scratch-dirs]      — Edit/Write auto-allow path prefixes (Tier consumer)
 #   [redirect-commands] — Tier 2 redirect-deny entries (slug | pattern | suggestion)
-#   [ask-commands]      — Tier 3 ask-list glob patterns
-#   [allow-extras]      — Tier 5 allow glob patterns (hook-rules.local ONLY;
+#   [adapter-redirect-commands] — Tier 3 adapter-aware deny-or-nudge entries
+#                          (slug | pattern | verb)
+#   [ask-commands]      — Tier 4 ask-list glob patterns
+#   [allow-extras]      — Tier 6 allow glob patterns (hook-rules.local ONLY;
 #                         an [allow-extras] section in the committed hook-rules
 #                         is silently inert — only per-machine local files may
-#                         grant Tier 5 allows)
+#                         grant Tier 6 allows)
 # hook-rules.local entries ADD to the baseline (additive merge).
 scratch_dirs=()
 ask_commands=()
@@ -823,7 +838,7 @@ for _entry in ${redirect_commands[@]+"${redirect_commands[@]}"}; do
     fi
 done
 
-# ─── Tier 2.5: Adapter-aware redirect — raw test/lint runners ───────
+# ─── Tier 3: Adapter-aware redirect — raw test/lint runners ─────────
 #
 # When a [adapter-redirect-commands] pattern matches AND the agent's
 # $cwd resolves to a component under $project_root/components/<comp>/,
@@ -934,20 +949,20 @@ for _entry in ${adapter_redirect_commands[@]+"${adapter_redirect_commands[@]}"};
             # Break after the first unwired match so an overlapping
             # glob in hook-rules doesn't emit a second nudge / audit
             # entry for the same command (Copilot finding on PR #90).
-            # The break exits this for loop; later tiers (Tier 3
-            # ask-list, allow evaluation, passthrough prompt) still
-            # run because we didn't emit a JSON decision or exit.
+            # The break exits this for loop; later tiers (Tier 4
+            # ask-list, Tier 5-6 allow evaluation, passthrough prompt)
+            # still run because we didn't emit a JSON decision or exit.
             break
         fi
     fi
 done
 
-# ─── Tier 3: Ask-list — force a prompt for destructive commands ─────
+# ─── Tier 4: Ask-list — force a prompt for destructive commands ─────
 #
 # A match emits `ask`: the harness prompts regardless of permission
 # mode (acceptEdits included), but the agent may still run the command
 # once the human approves. The ask-list is a safety FLOOR — it is
-# checked before the Tier 4/5 allow logic, so a destructive command
+# checked before the Tier 5/6 allow logic, so a destructive command
 # prompts even if some allowlist entry would otherwise pass it.
 for _ask in ${ask_commands[@]+"${ask_commands[@]}"}; do
     # shellcheck disable=SC2053
@@ -995,7 +1010,7 @@ for _ask in ${ask_commands[@]+"${ask_commands[@]}"}; do
     fi
 done
 
-# ─── Tier 4: Match against settings.json `permissions.allow` ────────
+# ─── Tier 5: Match against settings.json `permissions.allow` ────────
 #
 # Walk up from $cwd looking for .claude/settings.json files. Closer
 # files (project-specific) come first; the user-level file at
@@ -1068,7 +1083,7 @@ while IFS= read -r raw; do
     fi
 done < <(collect_patterns)
 
-# ─── Tier 5: Allow via [allow-extras] from hook-rules.local ─────────
+# ─── Tier 6: Allow via [allow-extras] from hook-rules.local ─────────
 #
 # Personal allow-patterns the user trusts on this machine — declared
 # in the [allow-extras] section of hook-rules.local (gitignored,

--- a/.claude/hooks/hook-rules
+++ b/.claude/hooks/hook-rules
@@ -45,9 +45,9 @@ git-push     | git push*      | Use `ws push <comp> [branch]` — handles fork-r
 gh-pr-create | gh pr create*  | Use `ws cr <comp> <title> <bodyfile>` — bodyfile-driven, applies identity substitutions, picks the right token + remote. `ws hook-bypass gh-pr-create` for a session-scoped bypass.
 
 [adapter-redirect-commands]
-# Raw test/lint/build runners with a ws equivalent. The hook resolves
-# the component from $cwd (must be under components/<comp>/) and the
-# active realm, then checks the realm's adapter file at
+# Tier 3 — raw test/lint/build runners with a ws equivalent. The hook
+# resolves the component from $cwd (must be under components/<comp>/)
+# and the active realm, then checks the realm's adapter file at
 # realms/<realm>/adapters/<comp>.yaml:
 #
 #   adapter has commands.<verb> wired → deny with ws <verb> <comp> pointer

--- a/.claude/hooks/hook-rules
+++ b/.claude/hooks/hook-rules
@@ -43,3 +43,27 @@ ws hook-bypass [a-z]*
 git-commit   | git commit*    | Use `ws commit <comp> <bodyfile>` — handles Co-Authored-By trailer + bodyfile-driven staging. See `ws help commit`. If `ws commit` doesn't fit (rare), run `ws hook-bypass git-commit` to request a session-scoped bypass.
 git-push     | git push*      | Use `ws push <comp> [branch]` — handles fork-remote selection from identity.forkOrg and sets upstream on first push. `ws hook-bypass git-push` for a session-scoped bypass.
 gh-pr-create | gh pr create*  | Use `ws cr <comp> <title> <bodyfile>` — bodyfile-driven, applies identity substitutions, picks the right token + remote. `ws hook-bypass gh-pr-create` for a session-scoped bypass.
+
+[adapter-redirect-commands]
+# Raw test/lint/build runners with a ws equivalent. The hook resolves
+# the component from $cwd (must be under components/<comp>/) and the
+# active realm, then checks the realm's adapter file at
+# realms/<realm>/adapters/<comp>.yaml:
+#
+#   adapter has commands.<verb> wired → deny with ws <verb> <comp> pointer
+#                                       (matching the [redirect-commands] tier)
+#   adapter missing or no commands.<verb> → emit a stderr nudge, fall through
+#                                            to normal allow/ask evaluation
+#   $cwd outside any component → rule doesn't fire (raw runner at workspace
+#                                root is a legitimate workspace-test invocation)
+#
+# Format: <slug> | <pattern> | <verb>. Verb is one of test/lint/build —
+# the ws subcommand the raw command maps to AND the key under `commands.`
+# in the adapter file. Slug is kebab-case; doubles as the bypass-marker
+# filename and the ws hook-bypass argument.
+pytest      | pytest*            | test
+pytest-mod  | python* -m pytest* | test
+gradle-test | gradle test*       | test
+ruff        | ruff*              | lint
+black       | black*             | lint
+mypy        | mypy*              | lint

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,9 +10,12 @@ This file is the **L0 menu** — the slim contract that loads into every session
 
 ## Session Start
 
-On every session start, after compaction, or when dispatched fresh:
+On every session start, after compaction, or when dispatched fresh, you **MUST** do BOTH:
 
-**Read `.agent/skills/gdd-orientation/SKILL.md`** and follow its startup sequence.
+1. **Execute `ws orient`** for initial discovery of workspace utilities, the active realm, per-component adapter wiring, and the skill index. This is the deterministic answer to "what's here right now?" — verbs, realm, adapters, skills.
+2. **Read `.agent/skills/gdd-orientation/SKILL.md`** and follow its startup sequence — Thalamus parsing, trust verification, mode/role setup, staleness checks.
+
+`ws orient` answers *what's available*; the orientation skill governs *how to work with the human*. Both are session-start prerequisites, not optional discovery aids.
 
 Two conventions you need before anything else:
 
@@ -47,7 +50,7 @@ The adapter wiring per component lives in `realms/<active>/adapters/<comp>.yaml`
 
 ## ws orient — the L1 discovery surface
 
-For anything not covered above — what subcommands exist, what the active realm is, which components are cloned, which skills are available — run `ws orient`. It's deterministic and frontmatter-only for skill bodies (cheap even with dozens of skills). Output sections:
+Already MUST-run at session start (see above). Also run it mid-session when switching tasks, picking up a new component, or unsure what's available. Output is deterministic and frontmatter-only for skill bodies (cheap even with dozens of skills). Sections:
 
 - **Subcommand survey** ("use when …" per ws verb)
 - **Active realm** name + pointer at its `AGENTS.md`
@@ -78,7 +81,7 @@ Reference forms in skill bodies:
 
 ## Operational Rules
 
-1. **Orientation skill first** at session start, after compaction, or when dispatched fresh.
+1. **MUST run `ws orient` AND read the orientation skill** at session start, after compaction, or when dispatched fresh. Both are prerequisites — see Session Start.
 2. **`ws orient`** when switching tasks or unsure what's available — it's the discovery surface.
 3. **`ws <cmd>`** in preference to raw `git` / `gh` / `glab` / runners (see Reflex Contract).
 4. **One command at a time.** Don't bundle with `;` `&&` `|`. The PreToolUse hook denies shell composition — use separate tool calls and native `ws` flags (`--compact`, `--limit N`, `--output <phrase>`) instead of pipes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,403 +1,105 @@
 # AI Agent Guidelines for This Workspace
 
-Yggdrasil is the workspace root for the SiliconSaga ecosystem. Component repos
-live in `components/` as independent Git repos, cloned via `bash scripts/ws clone`.
-The `ecosystem.yaml` manifest declares all components, their tiers, and configuration.
-Per-developer overrides go in `ecosystem.local.yaml` (gitignored).
+Yggdrasil is the workspace root. Component repos live in `components/` (independent Git repos, cloned via `ws clone`); the merged `ecosystem.yaml` declares what's available. Per-developer overrides go in `ecosystem.local.yaml` (gitignored).
 
-Full ecosystem map: [`docs/ecosystem-architecture.md`](docs/ecosystem-architecture.md)
+**Methodology:** [Guardian Driven Development (GDD)](docs/gdd/index.md).
 
-**Methodology:** This workspace uses [Guardian Driven Development (GDD)](docs/gdd/index.md).
+This file is the **L0 menu** — the slim contract that loads into every session. Deeper content (full skills catalog, every `ws` subcommand, code style, auth, etc.) is discoverable via `ws orient` and per-subcommand `ws <cmd> --help`. The orientation skill and the docs under `docs/gdd/` carry the long-form material.
+
+---
 
 ## Session Start
 
-On every session start, read `.agent/skills/gdd-orientation/SKILL.md` and
-follow its startup sequence.
+On every session start, after compaction, or when dispatched fresh:
 
-**Important:** Workspace skills (under `.agent/skills/`) are plain markdown
-files — read them with your Read tool and follow the instructions inside.
-Do NOT use any plugin/Skill tool to load them. This applies to all workspace
-skills, not just orientation.
+**Read `.agent/skills/gdd-orientation/SKILL.md`** and follow its startup sequence.
 
-**Keep the greeting brief and human-first.** On a greeting or open-ended
-first message:
+Two conventions you need before anything else:
 
-1. Mention GDD briefly so the human knows there's a methodology guiding the
-   session ("I follow Guardian Driven Development conventions for this
-   workspace — happy to explain more if you're curious")
-2. Read `Thalamus.md` at the workspace root (it's gitignored but readable).
-   If it exists, use its frontmatter for mode/role defaults.
-   If it doesn't exist, offer to create it.
-3. Ask about mode and role (or note the defaults from frontmatter).
-   When offering modes to a human, offer **quick, zen, flow, or mentoring** —
-   flow is the natural default for sessions without a single fixed goal.
-4. Ask what the human wants to work on
+1. **Workspace skills are plain markdown.** Files under `.agent/skills/<name>/SKILL.md` are read with the Read tool — do not invoke them via the Skill tool. This applies to every workspace skill, not just orientation. (Plugin skills like `superpowers:executing-plans` use the Skill tool — see Companion plugin below.)
 
-That's it for the first response. Save the component scan, trust verification,
-and detailed workspace inventory for *after* the human has responded and you've
-aligned on what the session is about. Don't front-load everything at once.
+2. **Active realm skills load on demand.** If a realm is present (e.g. `realms/realm-siliconsaga/`), it carries its own `AGENTS.md` and `.agent/skills/`. Orientation preloads the realm-side index at startup; individual realm skills load when their triggering conditions match.
 
 ---
 
-## Repo Roles (quick reference)
+## Reflex Contract — ws first
 
-| Repo | Tier | Role | Path |
-|------|------|------|------|
-| `yggdrasil` | — | Docs, skills, scripts, workspace root | `.` (this repo) |
+A fresh agent's instinct is to reach for raw `git`, `gh`, `glab`, or test runners. The workspace expects the `ws` wrappers — they handle attribution, auth, remote selection, and bodyfile-driven flows that raw tools don't.
 
-Community realms declare their own component catalogs. If a realm is
-active, check its `AGENTS.md` for the full Repo Roles table
-(e.g. `realms/realm-siliconsaga/AGENTS.md`).
+**Unconditional verbs — always use the `ws` wrapper:**
 
-Git remotes: Avoid using a generic `origin` — use explicit remote names
-matching your Git org (e.g. your GitHub org or GitLab group name)
+| Reach for | Use instead |
+|---|---|
+| `git add` + `git commit -m "…"` | `ws commit <comp> <bodyfile>` |
+| `git push` | `ws push <comp> [branch]` |
+| `gh pr create` / `glab mr create` | `ws cr <comp> <title> <bodyfile>` |
+| `gh issue create` / `glab issue create` | `ws issue <comp> [remote] <title> <label> <bodyfile>` |
+| `git clone <fork>` + manual remote-wiring | `ws clone <comp>` (or `ws clone-fork <comp>` for fork-as-origin) |
+| One-off command inside a component dir | `ws exec <comp> <cmd…>` |
+
+The PreToolUse hook denies `git commit` / `git push` / `gh pr create` at Tier 2 with a corrective pointer to the `ws` wrapper. Don't bypass — use the wrapper.
+
+**Adapter-routed verbs — consult `ws orient` first:** `ws test` / `ws lint` / `ws build`.
+
+The adapter wiring per component lives in `realms/<active>/adapters/<comp>.yaml`. **Run `ws orient` to see what each component's adapter resolves to** — the output surfaces each row's executed command (`knarr → ws test [runs: python3 -m pytest --ignore=tests/features]`) so you can verify what `ws test` will actually run. When an adapter is wired, the hook redirects raw `pytest` / `ruff` / `gradle test` to the corresponding `ws` form. When no adapter exists, raw runs through with a one-time nudge.
 
 ---
 
-## Skills
+## ws orient — the L1 discovery surface
 
-Workspace-level skills live in `.agent/skills/<name>/SKILL.md`.
-Community realms may provide additional component-specific skills in
-`realms/<name>/.agent/skills/` — these are discovered during GDD orientation.
+For anything not covered above — what subcommands exist, what the active realm is, which components are cloned, which skills are available — run `ws orient`. It's deterministic and frontmatter-only for skill bodies (cheap even with dozens of skills). Output sections:
 
-**Three reference patterns appear in this codebase — don't confuse them:**
+- **Subcommand survey** ("use when …" per ws verb)
+- **Active realm** name + pointer at its `AGENTS.md`
+- **Per-component adapter wiring** with the resolved command surfaced
+- **Skill index** across workspace + active realm scopes
+
+Per-command depth: `ws <cmd> --help`. The help system is the source of truth for flags and per-command behavior — skills and prose defer to it rather than restating.
+
+A post-dispatch stderr footer fires after every `ws` subcommand to keep `ws orient` discoverable mid-session. Opt out with `WS_FOOTER_DISABLE=1` if you want quiet stderr.
+
+---
+
+## Companion plugin (recommended)
+
+Several GDD plans and practice skills reference [Obra Superpowers](https://github.com/obra/superpowers) skills via the `superpowers:*` namespace: `superpowers:executing-plans`, `superpowers:subagent-driven-development`, `superpowers:brainstorming`, `superpowers:test-driven-development`, `superpowers:receiving-code-review`. Install Superpowers for the smoothest experience — the orientation skill checks at startup and surfaces a one-line nudge if not detected.
+
+Reference forms in skill bodies:
 
 | Pattern | Example | How to use |
 |---|---|---|
-| Workspace skill path | `.agent/skills/gdd-orientation/SKILL.md` | Read the file with the Read tool. Do **not** invoke via the Skill tool. |
-| Plugin skill identifier | `superpowers:executing-plans` | Invoke via the Skill tool. Requires the plugin (e.g. Obra Superpowers) installed. |
-| `@<name>` cross-reference | `@gdd-orientation`, `@gdd-workflow-audit` | Informational pointer to a workspace skill in skill bodies — read the referenced file, don't invoke it as a tool. Plugin skills always use the explicit `superpowers:*` form, never `@<name>`. |
-
-**Companion plugin (recommended):** GDD plans and several practice
-skills reference [Obra Superpowers](https://github.com/obra/superpowers)
-skills (e.g. `superpowers:executing-plans`,
-`superpowers:subagent-driven-development`, `superpowers:brainstorming`,
-`superpowers:test-driven-development`, `superpowers:receiving-code-review`).
-Install Superpowers for the smoothest experience. The `gdd-orientation`
-skill checks for it at session start and surfaces a one-line nudge if
-not detected.
-
-**Graceful degradation without Superpowers:** plan execution falls back
-to manual step-by-step, TDD becomes implicit rather than skill-driven,
-and `receiving-code-review` is read as documentation rather than
-invoked. All workspace skills (under `.agent/skills/`) run without
-Superpowers — only the `superpowers:*` plugin skills are unavailable.
-
-| Skill Name | Description | Source / Reference |
-| :--- | :--- | :--- |
-| GDD (Orchestrator) | Guardian Driven Development — detects roles/modes, delegates to practice and mode skills | [SKILL.md](./.agent/skills/gdd/SKILL.md) |
-| GDD Orientation | Session startup — reads Thalamus.md, trust verification of component instructions, mode/role setup | [SKILL.md](./.agent/skills/gdd-orientation/SKILL.md) |
-| GDD Housekeeping | Audit Thalamus.md — review, promote, prune observations and concerns with the human | [SKILL.md](./.agent/skills/gdd-housekeeping/SKILL.md) |
-| GDD Review Triage | Multi-reviewer CR coordination — fetch, deduplicate, and triage findings from CodeRabbit, Copilot, and others | [SKILL.md](./.agent/skills/gdd-review-triage/SKILL.md) |
-| GDD Mentoring Mode | AI explains decisions and teaches practices in context — request for any unfamiliar area | [SKILL.md](./.agent/skills/gdd-mentoring/SKILL.md) |
-| GDD Quick Mode | Minimal ceremony for short sessions — small tasks, fast context recovery | [SKILL.md](./.agent/skills/gdd-quick/SKILL.md) |
-| GDD Zen Mode | Deep single-topic focus — full ceremony, defer distractions until completion | [SKILL.md](./.agent/skills/gdd-zen/SKILL.md) |
-| GDD Flow Mode | Productive multi-topic drift — adaptive ceremony, incorporate tangents, live Thalamus collaboration | [SKILL.md](./.agent/skills/gdd-flow/SKILL.md) |
-| GDD Scribe | Obsidian vault conventions: PARA, frontmatter, daily notes, wikilinks, inbox capture, daily review, weekly synthesis. Auto-loads for `role: scribe`; other roles dip in on capture-intent keywords. | [SKILL.md](./.agent/skills/gdd-scribe/SKILL.md) |
-| GDD BDD | Gherkin scenarios, feature authoring, planning features, runner integration, and BDD conventions | [SKILL.md](./.agent/skills/gdd-bdd/SKILL.md) |
-| GDD BDD pytest Runner | pytest-bdd step definitions, test execution, and Cucumber JSON output | [SKILL.md](./.agent/skills/gdd-bdd-pytest/SKILL.md) |
-| GDD GitHub Issues | Pre-flight checks, issue templates, and filing process for deferring work to GitHub issues | [SKILL.md](./.agent/skills/gdd-github-issues/SKILL.md) |
-| KUTTL Testing | Guidelines for writing and running KUTTL tests | [SKILL.md](./.agent/skills/kuttl-testing/SKILL.md) |
-| GDD Branch Workflow | Branch naming, commit/push workflow, utility scripts, and when direct push to main is acceptable | [SKILL.md](./.agent/skills/gdd-branch-workflow/SKILL.md) |
-| GDD Workflow Audit | Detect repeated manual workarounds (3+ instances) and propose utility scripts or ws subcommands | [SKILL.md](./.agent/skills/gdd-workflow-audit/SKILL.md) |
-| GDD Doc Writing | Documentation conventions: the Component Documentation Convention (four-Shape graduation ladder), no-hard-wrap rule, Mermaid diagram rules, terminology, and cluster layer naming | [SKILL.md](./.agent/skills/gdd-doc-writing/SKILL.md) |
-| GDD MCP | Agent behaviour when MCP servers are present — auth patterns, tool calling, realm deferral | [SKILL.md](./.agent/skills/gdd-mcp/SKILL.md) |
-| GDD Permissions | Allowlist/deny patterns in `.claude/settings.json`: per-pattern safety analysis, "don't ask again" judgment at permission prompts, and code-review of settings.json changes. Operational companion to `docs/gdd/permissions.md`. | [SKILL.md](./.agent/skills/gdd-permissions/SKILL.md) |
-
----
-
-## Workspace CLI (`ws`)
-
-The shared interface for both humans and AI agents. Use the bare
-`ws <cmd>` form; fall back to `bash scripts/ws <cmd>` if `ws` is not
-on PATH. Scoped permission patterns like `ws push *` are much tighter
-than `bash *` would be, so `ws` runs without prompts where raw tools
-would interrupt.
-
-### `ws`-first reflex check
-
-**Before running any `git`, `gh`, `glab`, or test/build runner
-directly: check whether `ws` has a wrapper.** A fresh agent's
-training-data instinct is to reach for raw tooling; the workspace
-expects the wrappers. The wrappers handle attribution, auth, remote
-selection, and bodyfile-driven flows that raw tools won't.
-
-| Reflex you'd reach for | Use this instead | What `ws` adds |
-|------------------------|------------------|----------------|
-| `git add` + `git commit -m "..."` | `ws commit <comp> <bodyfile>` | Bodyfile-driven staging + Co-Authored-By trailer |
-| `git push` | `ws push <comp> [branch]` | Fork-remote selection from `forkOrg`; auto-sets upstream on first push |
-| `git pull` | `ws pull <comp>` (or `ws pull` for all) | Walks components, realms, and hoards; rebases cleanly; skips dirty repos |
-| `git status` | `ws status` | Cross-workspace view (yggdrasil + components + realms + hoards) with truncation |
-| `git log` | `ws log [comp] [--oneline] [--limit N]` | Branch-vs-main, no need to remember the range syntax |
-| `gh pr create` | `ws cr <comp> <title> <bodyfile>` | Bodyfile-driven; identity substitutions; right token + remote |
-| `gh pr view` / fetching review threads | `ws review <comp> <cr#> [--compact] [--limit N] [--output <phrase>]` | Inline + notes + reviews in one shell view; `--compact` for headline-only triage; `--limit N` to slice; `--output <phrase>` saves snapshot to `.outputs/<ts>-<phrase>.txt` for follow-up grep |
-| Reply/resolve a review thread (web UI or `gh api graphql`) | `ws review <comp> reply <cr#> <id> "msg" [--resolve]` | Auth + thread-id resolution |
-| `gh issue create` | `ws issue <comp> [remote] <title> <label> <bodyfile>` | Same bodyfile pattern + identity |
-| Raw test runners (`gradle test`, `pytest`, `make test`, …) | `ws test <comp> [args]` | Adapter dispatch via `realms/<active>/adapters/<comp>.yaml`; `ws actions <comp>` lists what's available. For pytest adapters, a positional path/nodeid targets that file (`ws test knarr tests/test_x.py`); a bare word becomes a `-k` filter |
-| Raw linters (`ruff`, `eslint`, `golangci-lint`, …) | `ws lint <comp> [args]` | Adapter `commands.lint` dispatch (same `<comp>.yaml` as tests); args pass through (e.g. `ws lint knarr --fix`). `ws actions <comp>` shows the configured command |
-| `git clone <fork-url>` + manual `git remote add upstream …` + `git fetch` | `ws clone-fork <comp>` | Ensures fork exists (creates via API if missing); SSH transport; both remotes wired; local + fork `main` synced with upstream. Idempotent. |
-
-**Hook enforcement:** the PreToolUse hook denies the three write-side raw commands above (`git commit` / `git push` / `gh pr create`) at Tier 2 with a corrective message pointing at the `ws` subcommand. See `.claude/hooks/README.md` § Redirect tier and bypass for the bypass mechanism if a legitimate edge case requires raw access.
-
-When in doubt: `ws help` for the full list, `ws help <subcommand>`
-(or `ws <subcommand> --help`) for per-command details. Skills and
-instructions defer to the help system as the source of truth.
-
-### One command at a time — not bundled
-
-Don't wrap `ws` calls (or auto-approved reads like `cat`, `ls`,
-`hostname`) in compound shells like `ws X; ws Y; cat Z` or
-`ws status && ws log`. Each piece is auto-approved individually but
-compounds often trigger a prompt regardless. Same applies to:
-
-- **`command | head`-style truncation** — most `ws` commands have
-  a native flag for that (`ws status` truncates by default,
-  `ws log --limit N`, `ws review --compact` and/or `--limit N`).
-  Reach for the flag instead of piping into `head`.
-- **`command > file` redirects** — Claude Code's matcher prompts
-  on stdout-redirect-to-file regardless of the LHS, because the
-  destination path is opaque to static analysis. For `ws review`
-  specifically, use `--output <phrase>` to save into the
-  workspace-internal `.outputs/` scratch dir (`ws clean` purges
-  it). Then grep that file as a separate auto-approved command.
-  For other commands, no native equivalent yet — accept the
-  one-time prompt or argue for a flag if the pattern recurs.
-- **`command | grep`-style filtering** — `ws review` already has
-  `--reviewer <name>`, `--since <time>`, and `--compact` for the
-  most common cuts. If you need ad-hoc grep, save with `--output`
-  first then grep the file (two clean commands).
-
-### Subcommand pointers
-
-A few commands worth knowing exist beyond the reflex table:
-
-- `ws gitlab-auth [--status]` — register glab credentials from
-  `.env`; `--status` reports without making changes.
-- `ws diagnose <comp>` — remote URLs, provider detection, token
-  coverage. Run when push/cr fails with auth errors or when
-  onboarding a new component.
-- `ws clone-fork <comp>` — fork-aware clone: ensures the user's
-  personal fork exists in `identity.forkOrg` (creates via API if
-  missing), clones the fork over SSH, wires up both remotes (fork +
-  upstream), and syncs local + fork `main` with upstream. Idempotent
-  — re-runs are safe and re-sync. Use this instead of `ws clone`
-  when a release-style workflow needs fork-as-origin remotes from
-  the start.
-- `ws preflight [--soft]` — workspace prerequisites (bash, git, yq
-  v4+, jq, gh/glab) with per-OS install hints.
-- `ws hoard init [template] [--name <name>]` / `ws hoard <url>` /
-  `ws hoard list` — personal hoards. Canonical type is `thalami`
-  for per-machine Thalamus sync; `basic` for generic hoards.
-- `ws component init <flavor> [name]` / `ws component list` —
-  scaffold a new component from a template. Flagship: `gh-pages`.
-- `ws test yggdrasil` — run the workspace-root shell-script test
-  suite (bats files under `tests/`). Uses a vendored `bats-core`
-  runtime under `tests/vendor/bats-core/` so contributors don't
-  need a system install; see `tests/vendor/README.md` for the
-  refresh procedure.
-
-**Adding new subcommands:** See [`docs/ws-cli-guide.md`](docs/ws-cli-guide.md)
-for how to add commands and classify their permission tier.
-
-### Standalone scripts (not wrapped by `ws`)
-
-| Script | Usage |
-|--------|-------|
-| `setup-branch-protection.sh` | One-time admin op — requires admin-scoped `GH_TOKEN` |
-| `validate-agent-setup.sh` | Verify GH_TOKEN, auth, repo access, branch protection |
-
----
-
-## Hoards (personal containers)
-
-Hoards are personal git repos under `hoards/` (gitignored, like
-`components/` and `realms/`), named `<type>-<username>`. The canonical
-v1 type is `thalami` (per-machine Thalamus files for preference /
-observation sync across machines). Other personal stuff (an Obsidian
-vault, sample projects, etc.) can live in `hoards/` but isn't
-orientation-visible — those are the user's own business.
-
-Active thalami hoard discovery: auto-detects `hoards/thalami-*` (single
-match expected); set `hoards.thalami: <name>` in `ecosystem.local.yaml`
-to override. Per-machine file is `<machine>-thalamus.md` where `<machine>`
-defaults to the short hostname (`${HOSTNAME%%.*}` — portable on Linux,
-macOS, and Windows Git Bash). Pin a stable name with `machine: <value>`
-in `ecosystem.local.yaml` if needed.
-
-Hoard templates ship under `templates/hoards/<flavor>/`. Current flavors:
-`thalami`, `basic`, `obsidian-vault` (PARA-laid-out Obsidian vault with
-auto-installed Templater + Periodic Notes + companion plugins).
-
-See [Realms and Hoards Design](docs/plans/2026-04-24-realms-and-hoards-design.md)
-for the full picture.
-
----
-
-## Components (template-scaffolded)
-
-Components are the third member of the template family alongside hoards
-and realms. `templates/components/<flavor>/` directories ship in upstream
-yggdrasil; `ws component init <flavor> <name>` copies one into
-`components/<name>/`, git-inits it, and registers an entry in
-`ecosystem.local.yaml` (the per-developer layer of the three-layer
-config merge). The component is immediately usable from the workspace
-without touching the realm; when ready to share, move the entry into the
-realm's `ecosystem.yaml` with realm-appropriate fields and push.
-
-Flagship flavor is `gh-pages` — a tutorial-friendly GitHub Pages site
-with a README that walks a solo user through the full edit → PR →
-bot-review → merge → see-it-live loop.
-
-See [Component Templates Design](docs/plans/2026-04-25-component-templates-design.md)
-for the full picture.
-
----
-
-## Git Workflow
-
-**Never use raw `git add`, `git commit`, or `git push`** — always use
-`ws commit` and `ws push`. They handle staging, attribution trailers,
-and auth automatically. For deleted files, use `remove:` in the bodyfile
-frontmatter.
-
-**Don't chain `ws` commands** (e.g. `ws commit && ws push`). Run them
-separately so each can be reviewed and approved independently. Chaining
-defeats per-command permission patterns and hides intermediate errors.
-
-Always use a topic branch. Main is protected.
-
-**Before pushing to a component for the first time in a session**, run
-`ws diagnose <comp>` to confirm token coverage. If a token shows as
-`NOT SET`, add it to `.env`, re-source it, and re-run `ws gitlab-auth`.
-
-For the full step-by-step workflow (branch naming, bodyfile format, CR
-draft, rebase), read the **Topic Branch Workflow** skill at
-`.agent/skills/gdd-branch-workflow/SKILL.md`.
-
----
-
-## Code Style
-
-See [`docs/code-style.md`](docs/code-style.md) for commenting and documentation
-conventions.
-
-### Prose line wrapping
-
-**Don't hard-wrap prose at any character count.** Write each paragraph as a single line and let editors / renderers handle wrap.
-
-This applies to all prose: markdown documents, READMEs, issue bodies, CR/PR descriptions, commit message bodies, hoard notes (Obsidian vault content), Thalamus entries, design docs.
-
-It does *not* apply to:
-
-- Code blocks (use whatever wrap fits the language)
-- Tables (one row per line)
-- Lists (one bullet per line — bullets are list items, not prose)
-- YAML frontmatter
-
-**Why:** GitHub renders some hard-wrapped contexts as visible line breaks; Obsidian/markdown editors wrap automatically; reflowing after every edit is friction. Specific code or tooling may have its own wrap conventions — follow those when they exist (e.g. Mermaid diagrams have their own rules in the gdd-doc-writing skill).
-
-### Bash usage enforcement (PreToolUse hook)
-
-This workspace ships a PreToolUse hook at `.claude/hooks/gdd-permission-hook.sh`, registered in `.claude/settings.json`. It fires on every Bash tool call and denies shell composition (`&&`, `||`, `;`, pipes, command substitution, redirects) with corrective messages that train the agent toward separate tool calls + native `ws` flags. It allows anything matching the project's `permissions.allow` patterns (symmetric normalization between bare `ws ...` and verbose `bash scripts/ws ...` forms) or per-machine allow patterns in `.claude/hooks/hook-rules.local` (copy from `hook-rules.local.example` and add glob patterns under `[allow-extras]`).
-
-Full operational details — what each tier does, how to add personal safe-command patterns, how to disable the hook on a specific machine via `WS_HOOK_DISABLE=1`, what to do if a command stalls — live in [`.claude/hooks/README.md`](./.claude/hooks/README.md).
-
-### Prefer write-then-execute over inline shell scripts
-
-When you need to run anything more than a few lines (Python, JS, complex bash, anything with control flow), **write the script to `.tmp/<name>` via the Write tool first, then invoke it via Bash**. Don't pack the whole script into a `bash -c "..."` or `python -c "..."` one-liner.
-
-Why:
-
-- **Observability:** the Write tool's diff shows the full content in the transcript — easy for the human to scan before approving the execute. A long inline command is hard to read and often gets clipped.
-- **Reviewability:** the file persists in `.tmp/` (gitignored) for post-hoc inspection. An inline one-liner disappears into the command history.
-- **Hook compatibility:** non-trivial scripts almost always involve `&&`, `;`, pipes, or substitution — all of which the PreToolUse hook denies inline. The same operators inside a file body are fine; only the outer `bash <file>` invocation sees the hook, and `<file>` is one segment.
-- **Cleanup:** `ws clean` removes `.tmp/` entries alongside the other workspace draft directories — no orphaned scratch files accumulate.
-
-Inline `bash -c "..."` and `python -c "..."` are still fine for genuinely one-line workloads where inline is more readable than a file (a single `echo`, a quick math expression). Use judgment: if the inline form is longer than a sentence, it's a file.
-
-Note: write-then-execute doesn't change the security boundary — a malicious script content is still a problem regardless of the vehicle. The human reviews the Write content as the canonical safety checkpoint; the hook adds visibility, not invulnerability.
-
----
-
-## Auth Setup
-
-- Token(s) in `.env` (gitignored). See `.env.example`.
-- Full setup guide: [`docs/git-provider-setup.md`](docs/git-provider-setup.md)
-- If `.env` is missing or the provider token is not set, point the user to the
-  setup guide rather than explaining auth inline.
-- GitHub: `gh` CLI uses `GH_TOKEN` automatically — no browser login needed.
-  Classic PAT with `repo` scope recommended (fine-grained PATs have cross-org limitations).
-- GitLab: `glab` CLI uses `GITLAB_TOKEN` automatically — no browser login needed.
-  Personal access token with `api` scope.
-- Day-to-day agent PAT scopes: repo-level read/write for contents, issues, CRs.
-  Administration scope is NOT included; use a separate admin token for `setup-branch-protection.sh`.
-
-Full setup guide: [`docs/git-provider-setup.md`](docs/git-provider-setup.md)
-
----
-
-## Ecosystem Config (Three-Layer Merge)
-
-Configuration is assembled from three layers, merged in order:
-
-1. `ecosystem.yaml` — upstream Yggdrasil defaults (generic, no components)
-2. `realms/<active>/ecosystem.yaml` — community realm (components, identity)
-3. `ecosystem.local.yaml` — per-developer overrides (gitignored)
-
-All `ws` commands read the merged result via `ws_resolve_ecosystem()`.
-
-`ecosystem.local.yaml` common uses:
-
-- `forceChart: true` on a component to use its chart even with local source
-- Override `values:` for local environment specifics (hostnames, feature flags)
-- `disabled: false` on echo-test to validate chart-mode resolution
-- `realm: <name>` to select a specific realm (auto-detection is default)
-
-The `ws-resolve.sh` script uses the merged config to generate ArgoCD Application
-manifests, choosing Git source or OCI chart per component based on what's
-checked out locally (and any `forceChart` overrides).
-
-## IDE Setup
-
-See [`docs/ide-setup.md`](docs/ide-setup.md) for VS Code, JetBrains, and
-terminal editor setup.
-
----
-
-## Issue / CR / Commit Drafts
-
-| Path | Purpose |
-|------|---------|
-| `templates/issue.md` | Committed template for issues |
-| `templates/change.md` | Committed template for CR bodies |
-| `templates/commit.md` | Committed template for `ws commit` bodyfiles (frontmatter format) |
-| `.issues/<repo>-<name>.md` | Gitignored draft clearinghouse for issues |
-| `.crs/<description>.md` | Gitignored draft clearinghouse for CRs |
-| `.commits/<description>.md` | Gitignored draft clearinghouse for commit bodyfiles |
-
-All agent-filed issues must start with the AI attribution blockquote from the template.
-Commit bodyfiles use YAML frontmatter to declare the message and files to stage — see the template.
-
----
-
-## MCP
-
-Read `.agent/skills/gdd-mcp/SKILL.md` when any condition is true:
-
-- **Proactive (in use)** — `.mcp.json` exists in the workspace root, and no
-  `gdd-mcp: skip` preference is set in Thalamus. Load at session start.
-- **Proactive (setup offer)** — `.mcp.json` is absent, the active realm
-  declares `mcp.servers`, and no `mcp-setup: declined` preference is set in
-  Thalamus. Load at session start to drive the one-time setup prompt.
-- **On-demand** — the user asks about MCP, MCP servers, or a specific configured
-  server. Load regardless of any skip preference.
-
-The skill covers agent behaviour when MCP servers are in use; the active realm's
-`AGENTS.md` covers which servers are declared and their setup prompt.
+| Workspace skill path | `.agent/skills/gdd-orientation/SKILL.md` | Read with the Read tool. Do **not** invoke via the Skill tool. |
+| Plugin skill identifier | `superpowers:executing-plans` | Invoke via the Skill tool (requires the plugin installed). |
+| `@<name>` cross-reference | `@gdd-housekeeping`, `@gdd-workflow-audit` | Informational pointer to a workspace skill — read the referenced file, don't invoke as a tool. |
+
+**Graceful degradation without Superpowers:** plan execution falls back to manual step-by-step, TDD becomes implicit, `receiving-code-review` is read as documentation. All workspace skills (under `.agent/skills/`) run without Superpowers.
 
 ---
 
 ## Operational Rules
 
-1. **Check `AGENTS.md` first**: Always verify if a relevant skill exists here before starting a complex task.
-2. **Read Referenced Skills**: If a task matches a skill above, read the content of the referenced file to get the latest instructions.
+1. **Orientation skill first** at session start, after compaction, or when dispatched fresh.
+2. **`ws orient`** when switching tasks or unsure what's available — it's the discovery surface.
+3. **`ws <cmd>`** in preference to raw `git` / `gh` / `glab` / runners (see Reflex Contract).
+4. **One command at a time.** Don't bundle with `;` `&&` `|`. The PreToolUse hook denies shell composition — use separate tool calls and native `ws` flags (`--compact`, `--limit N`, `--output <phrase>`) instead of pipes.
+5. **No raw `git`/`gh`/`glab`** for the unconditional verbs above. Wrappers handle attribution, auth, remote selection — raw tools won't.
+6. **No hard-wrapped prose.** Write each paragraph as a single line and let editors / renderers handle wrap. Code blocks, tables, lists, and YAML frontmatter are exempt.
+
+---
+
+## Deeper References
+
+The orientation skill is the right starting point; these pointers are here so a human or fresh agent reading AGENTS.md knows where the long-form content lives.
+
+- [`docs/gdd/index.md`](docs/gdd/index.md) — Guardian Driven Development overview.
+- [`docs/ecosystem-architecture.md`](docs/ecosystem-architecture.md) — three-tier model, workspace structure, config merge.
+- [`docs/ws-cli-guide.md`](docs/ws-cli-guide.md) — full `ws` CLI reference + how to add new subcommands.
+- [`docs/dev-setup.md`](docs/dev-setup.md) — required tools (bash, git, yq, jq, gh/glab, optional uv).
+- [`docs/git-provider-setup.md`](docs/git-provider-setup.md) — auth, token scopes, `.env` setup.
+- [`docs/code-style.md`](docs/code-style.md) — commenting + documentation conventions.
+- [`docs/ide-setup.md`](docs/ide-setup.md) — VS Code, JetBrains, terminal editor setup.
+- [`.claude/hooks/README.md`](.claude/hooks/README.md) — PreToolUse hook tiers, redirect/bypass mechanics.
+- [`docs/plans/2026-04-24-realms-and-hoards-design.md`](docs/plans/2026-04-24-realms-and-hoards-design.md) — realms + hoards model.
+- [`docs/plans/2026-04-25-component-templates-design.md`](docs/plans/2026-04-25-component-templates-design.md) — `ws component init` flavors.
+
+Issue / CR / commit draft templates live in `templates/`; gitignored draft clearinghouses live in `.issues/` `.crs/` `.commits/`. The `ws clean` subcommand purges them when stale.

--- a/scripts/ws
+++ b/scripts/ws
@@ -741,10 +741,16 @@ _ws_footer() {
         orient|help|--help|-h) return 0 ;;
     esac
     [[ "$_WS_IS_HELP" -eq 1 ]] && return 0
-    # Dim ANSI so the line is visually subordinate to the
-    # subcommand's own output, but the text stays readable in
-    # non-color terminals and captured logs.
-    printf $'\e[2m↪ switching tasks? `ws orient` lists the toolset for what is here.\e[0m\n' >&2
+    # Use dim ANSI only when stderr is a terminal — captured logs and
+    # CI output should see plain text instead of raw `\e[2m...\e[0m`
+    # escape sequences (Copilot finding on PR #90). The visible text
+    # stays identical in both branches so search/grep on the message
+    # works the same way regardless of styling.
+    if [[ -t 2 ]]; then
+        printf $'\e[2m↪ switching tasks? `ws orient` lists available tools.\e[0m\n' >&2
+    else
+        printf '↪ switching tasks? `ws orient` lists available tools.\n' >&2
+    fi
 }
 
 case "$COMMAND" in

--- a/scripts/ws
+++ b/scripts/ws
@@ -708,6 +708,45 @@ if [[ ( "$COMMAND" == "help" || "$COMMAND" == "--help" || "$COMMAND" == "-h" ) &
     set -- "--help" "$@"
 fi
 
+# Detect a help variant in the remaining args so the post-dispatch
+# footer can suppress for per-subcommand help (e.g. `ws hoard --help`)
+# the same way it suppresses for the top-level help command.
+_WS_IS_HELP=0
+for _arg in "$@"; do
+    case "$_arg" in --help|-h|help) _WS_IS_HELP=1; break ;; esac
+done
+
+# One-line stderr nudge appended after every successful subcommand
+# dispatch — keeps the `ws orient` meta-rule discoverable for both
+# humans and agents who entered mid-session without reading
+# AGENTS.md. Stderr so it never contaminates captured stdout (e.g.
+# `var=$(ws log --oneline)`). Suppressed for orient itself (no
+# recursive recommendation), for help variants (the user is reading,
+# not doing), and via the WS_FOOTER_DISABLE env var (agents and
+# scripts that want quiet output). With `set -e` enabled at the top
+# of this file, the footer naturally doesn't fire on error paths —
+# the script exits before reaching the call.
+_ws_footer() {
+    # Explicit opt-out for agents and scripts that want quiet
+    # stderr from every ws subcommand.
+    [[ -n "${WS_FOOTER_DISABLE:-}" ]] && return 0
+    # Auto-skip in bats test runs so output-shape assertions across
+    # the bats suite don't pick up the stderr footer as noise. The
+    # footer's purpose is human/agent discoverability mid-session;
+    # automated tests are neither. Footer-focused tests opt back in
+    # by clearing `BATS_TEST_NAME` for the child process via
+    # `env -u BATS_TEST_NAME ...`.
+    [[ -n "${BATS_TEST_NAME:-}" ]] && return 0
+    case "$COMMAND" in
+        orient|help|--help|-h) return 0 ;;
+    esac
+    [[ "$_WS_IS_HELP" -eq 1 ]] && return 0
+    # Dim ANSI so the line is visually subordinate to the
+    # subcommand's own output, but the text stays readable in
+    # non-color terminals and captured logs.
+    printf $'\e[2m↪ switching tasks? `ws orient` lists the toolset for what is here.\e[0m\n' >&2
+}
+
 case "$COMMAND" in
     help|--help|-h)
         ws_help
@@ -804,3 +843,5 @@ case "$COMMAND" in
         exit 1
         ;;
 esac
+
+_ws_footer

--- a/scripts/ws
+++ b/scripts/ws
@@ -106,6 +106,7 @@ ws_resolve_fork_org() {
 }
 
 ws_exec() {
+    # ws:use-when running a one-off command inside a component dir
     if [[ $# -lt 2 ]]; then
         echo "Usage: ws exec <component> <command...>" >&2
         exit 1
@@ -122,6 +123,7 @@ ws_exec() {
 }
 
 ws_push() {
+    # ws:use-when sending git changes to its remote repo
     # Detect --help/-h anywhere in args (e.g. `ws push my-comp --help`),
     # not just $1, so the typical UNIX-y "any position" form works.
     local _arg
@@ -167,6 +169,7 @@ HELP
 }
 
 ws_cr() {
+    # ws:use-when opening a code-review request (PR / MR) - must use bodyfile from change.md template
     if [[ $# -lt 3 || $# -gt 4 ]]; then
         echo "Usage: ws cr <component> [--upstream] <title> <bodyfile>" >&2
         exit 1
@@ -185,6 +188,7 @@ ws_cr() {
 
 
 ws_log() {
+    # ws:use-when checking what commits are on the current branch versus main
     # Detect --help anywhere in args.
     for _arg in "$@"; do
         if [[ "$_arg" == "--help" || "$_arg" == "-h" ]]; then
@@ -292,6 +296,7 @@ HELP
 }
 
 ws_clean() {
+    # ws:use-when sweeping draft files from .commits/ .crs/ .issues/ .outputs/ .tmp/
     local force=0
     local arg
     for arg in "$@"; do
@@ -405,6 +410,7 @@ ws_clean() {
 }
 
 ws_issue() {
+    # ws:use-when filing a tracker issue with labels and a bodyfile - must use issue.md template
     if [[ $# -lt 4 || $# -gt 5 ]]; then
         echo "Usage: ws issue <component> [remote] <title> <label> <bodyfile>" >&2
         echo "  remote auto-detects if single remote, uses forkOrg if multiple." >&2
@@ -426,6 +432,7 @@ ws_issue() {
 }
 
 ws_diagnose() {
+    # ws:use-when investigating push/cr failures — remote + token coverage
     if [[ $# -lt 1 ]]; then
         echo "Usage: ws diagnose <component|yggdrasil>" >&2
         echo "  Shows ecosystem config, clone status, remotes, provider, and token coverage." >&2
@@ -554,6 +561,7 @@ ws_diagnose() {
 }
 
 ws_gitlab_auth() {
+    # ws:use-when configuring glab + git credentials from .env tokens
     local eco
     eco=$(ws_resolve_ecosystem)
 

--- a/scripts/ws-audit-permissions.sh
+++ b/scripts/ws-audit-permissions.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # ws-audit-permissions.sh — audit permissions.allow patterns for breadth.
+# ws:use-when reviewing your Bash allowlist for over-broad patterns
 #
 # Inspects Claude Code's three permission-config scopes and reports any
 # entries matching a curated watchlist of patterns that are usually too

--- a/scripts/ws-clone-fork.sh
+++ b/scripts/ws-clone-fork.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # ws-clone-fork.sh — Fork-aware clone for ecosystem components
+# ws:use-when fork-aware clone — ensures your personal fork exists then sets both remotes
 #
 # Usage: ws-clone-fork.sh <component>
 #

--- a/scripts/ws-clone.sh
+++ b/scripts/ws-clone.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # ws-clone.sh — Clone ecosystem components or arbitrary repos into components/
+# ws:use-when materializing a component locally from its declared remote
 #
 # Usage:
 #   ws-clone.sh <component>                          Clone a declared component

--- a/scripts/ws-commit.sh
+++ b/scripts/ws-commit.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # ws-commit.sh — Commit with Co-Authored-By trailer (bodyfile-driven)
+# ws:use-when finalizing a change — must use bodyfile from commit.md template
 #
 # Usage:
 #   ws-commit.sh <component> <bodyfile>

--- a/scripts/ws-component.sh
+++ b/scripts/ws-component.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # ws-component.sh — Component management
+# ws:use-when scaffolding a new component from a template flavor
 #
 # Subcommands (called via ws component):
 #   init <flavor> [name] [template-args]   Scaffold a new component locally

--- a/scripts/ws-hoard.sh
+++ b/scripts/ws-hoard.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # ws-hoard.sh — Hoard management
+# ws:use-when managing oddly shaped (non-code) collections (thalami, vaults)
 #
 # Subcommands (called via ws hoard):
 #   init [template] [args...]   Scaffold a new hoard locally

--- a/scripts/ws-hook-bypass.sh
+++ b/scripts/ws-hook-bypass.sh
@@ -1,16 +1,17 @@
 #!/usr/bin/env bash
 # ws-hook-bypass.sh — write a session-scoped bypass marker for a Tier 2
 # ws:use-when requesting a session-scoped bypass of a Tier 2 or Tier 3 redirect-deny
-# redirect-deny slug. The marker lets the matching command run for the
-# rest of the current Claude Code session.
+# or Tier 3 redirect-deny slug. The marker lets the matching command
+# run for the rest of the current Claude Code session.
 #
 # Usage:
 #   ws hook-bypass <slug> [--reason "<text>"]
 #
 # <slug> must appear as column 1 of a row in .claude/hooks/hook-rules
-# under [redirect-commands]. The script writes
-# .tmp/hook-bypass/<slug>.bypass with frontmatter the PreToolUse hook
-# parses (session_id, slug, created_at, reason).
+# under [redirect-commands] (Tier 2) or [adapter-redirect-commands]
+# (Tier 3). The script writes .tmp/hook-bypass/<slug>.bypass with
+# frontmatter the PreToolUse hook parses
+# (session_id, slug, created_at, reason).
 #
 # The subcommand pattern `ws hook-bypass [a-z]*` is on the committed
 # [ask-commands] baseline, so every invocation force-prompts the human —
@@ -31,7 +32,8 @@ usage() {
 Usage: ws hook-bypass <slug> [--reason "<text>"]
 
   <slug>           Bypass slug — must match a row in [redirect-commands]
-                   in .claude/hooks/hook-rules. Run with an unknown slug
+                   (Tier 2) or [adapter-redirect-commands] (Tier 3) in
+                   .claude/hooks/hook-rules. Run with an unknown slug
                    to see the list of known slugs.
   --reason "<txt>" Optional. Captured in the marker file and echoed into
                    each BYPASS-ALLOW audit-log entry for retro grep.
@@ -82,11 +84,17 @@ while [[ $# -gt 0 ]]; do
 done
 
 # Enumerate known slugs from hook-rules. This is a deliberately minimal
-# re-implementation of the [redirect-commands] parse in the hook itself
-# (gdd-permission-hook.sh _parse_rules_file) — we only need column 1
-# (the slug), not the full slug|pattern|suggestion unpack. Keep the
-# shared bits (CRLF strip, section detection, slug regex) in sync if the
-# hook-rules format changes.
+# re-implementation of the [redirect-commands] + [adapter-redirect-commands]
+# parses in the hook itself (gdd-permission-hook.sh _parse_rules_file) —
+# we only need column 1 (the slug), not the full slug|pattern|...
+# unpack. Keep the shared bits (CRLF strip, section detection, slug
+# regex) in sync if the hook-rules format changes.
+#
+# Both sections share the slug shape and column-1 position, so a single
+# parse with a section-membership check covers both tiers. Tier 3
+# adapter-redirect denies instruct users to bypass via `ws hook-bypass`,
+# so the script must accept those slugs too — otherwise the deny message
+# tells users to do something the script refuses to do.
 known_slugs=()
 if [[ -f "$HOOK_RULES" ]]; then
     in_section=""
@@ -100,7 +108,8 @@ if [[ -f "$HOOK_RULES" ]]; then
             in_section="${in_section%\]}"
             continue
         fi
-        if [[ "$in_section" == "redirect-commands" ]]; then
+        if [[ "$in_section" == "redirect-commands" \
+              || "$in_section" == "adapter-redirect-commands" ]]; then
             # Column 1 (slug) — substring up to first " | "
             if [[ "$line" == *" | "* ]]; then
                 s="${line%% | *}"
@@ -132,7 +141,7 @@ if [[ "$slug_ok" != "1" ]]; then
             echo "  - $s" >&2
         done
     else
-        echo "No [redirect-commands] entries found in $HOOK_RULES." >&2
+        echo "No [redirect-commands] or [adapter-redirect-commands] entries found in $HOOK_RULES." >&2
     fi
     exit 1
 fi

--- a/scripts/ws-hook-bypass.sh
+++ b/scripts/ws-hook-bypass.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
-# ws-hook-bypass.sh — write a session-scoped bypass marker for a Tier 2
+# ws-hook-bypass.sh — write a session-scoped bypass marker for a
+# Tier 2 [redirect-commands] or Tier 3 [adapter-redirect-commands]
+# slug. The marker lets the matching command run for the rest of
+# the current Claude Code session.
+#
 # ws:use-when requesting a session-scoped bypass of a Tier 2 or Tier 3 redirect-deny
-# or Tier 3 redirect-deny slug. The marker lets the matching command
-# run for the rest of the current Claude Code session.
 #
 # Usage:
 #   ws hook-bypass <slug> [--reason "<text>"]

--- a/scripts/ws-hook-bypass.sh
+++ b/scripts/ws-hook-bypass.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # ws-hook-bypass.sh — write a session-scoped bypass marker for a Tier 2
+# ws:use-when requesting a session-scoped bypass of a Tier 2 or Tier 3 redirect-deny
 # redirect-deny slug. The marker lets the matching command run for the
 # rest of the current Claude Code session.
 #

--- a/scripts/ws-lint.sh
+++ b/scripts/ws-lint.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # ws-lint.sh — Run the linter for a component
+# ws:use-when running the component's linter via its adapter
 #
 # Usage:
 #   ws-lint.sh <component> [args...]

--- a/scripts/ws-list.sh
+++ b/scripts/ws-list.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # ws-list.sh — List all ecosystem components and their local status
+# ws:use-when surveying what's declared in the ecosystem (clones, tiers, repos)
 #
 # Usage:
 #   ws-list.sh

--- a/scripts/ws-mcp-setup.sh
+++ b/scripts/ws-mcp-setup.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 # ws-mcp-setup.sh — Generate .mcp.json for Claude Code from realm mcp.servers declarations
+# ws:use-when:mcp-setup generating .mcp.json from realm mcp.servers declarations
+# ws:use-when:mcp-status checking which MCP servers are currently configured
 #
 # Usage:
 #   ws-mcp-setup.sh [--dry-run] [--status]

--- a/scripts/ws-orient.sh
+++ b/scripts/ws-orient.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # ws-orient.sh — deterministic "what can I do here?" menu.
+# ws:use-when starting a session, recovering from compaction, or switching tasks
 #
 # `ws orient` is the L1 layer of the progressive-disclosure buffet
 # documented in `docs/plans/2026-06-02-gdd-orientation-and-attribution-design.md`:
@@ -61,44 +62,125 @@ if ! command -v yq &>/dev/null; then
     exit 1
 fi
 
-# Subcommand survey — authored per the plan (Task 4b). The "use when"
-# phrasing is judgment that lives here, in one place, not scattered
-# across each subcommand script. Format is `name|use-when` so the
-# table stays trivially editable; a future `--json` or `--names-only`
-# flag can re-emit the same rows in a different shape.
+# Subcommand survey — built dynamically by scanning each handler for
+# its `# ws:use-when …` docstring. Two awk passes: parse_dispatch
+# maps subcommand-name → handler (a script file or a function inside
+# scripts/ws); find_use_when locates the marker inside that handler.
+# Marker shape:
+#   # ws:use-when <text>             — single subcommand-per-handler (bare)
+#   # ws:use-when:<name> <text>      — one handler, many subcommands (keyed)
+# The keyed form uses a colon-separated subcommand name so the parser
+# never confuses a bare-text marker whose first word happens to look
+# like a kebab identifier with a keyed marker for some other subcommand.
+# A handler without any marker shows as "(no `ws:use-when` marker)"
+# so the gap is visible at orient time rather than discoverable only
+# via grep — keeps the inventory honest as new subcommands land.
 emit_subcommand_survey() {
     printf '\n%s\n' "Subcommands (name — use when …):"
-    while IFS='|' read -r name use_when; do
-        # Skip blank lines + comment rows so the heredoc can carry
-        # section dividers without polluting output.
-        [[ -z "$name" || "$name" == \#* ]] && continue
-        printf '  %-18s — %s\n' "$name" "$use_when"
-    done <<'SURVEY'
-list|surveying what's declared in the ecosystem (clones, tiers, repos)
-orient|starting a session, recovering from compaction, or switching tasks
-status|checking git state across every cloned component at a glance
-clone|materializing a component locally (clone-fork for cross-org forks)
-pull|refreshing every cloned component from its remote
-commit|finalizing a change — required to attach Co-Authored-By + bodyfile
-test|running the component's test suite via its adapter
-lint|running the component's linter via its adapter
-push|sending a topic branch to your fork remote
-cr|opening a code-review request (PR / MR) from the current branch
-review|triaging review comments + resolving threads on an open CR
-issue|filing a tracker issue with a bodyfile + labels
-log|checking what commits are on the current branch versus main
-clean|sweeping draft files from .commits/ .crs/ .issues/ .outputs/ .tmp/
-exec|running a one-off command inside a component dir
-actions|inspecting which adapter commands a component has wired
-realm|adopting or switching the active community config
-hoard|managing personal cross-workspace artifacts (thalami, vaults)
-component|scaffolding a new component from a template flavor
-preflight|verifying workspace prerequisites (bash, git, yq, jq, gh/glab)
-diagnose|investigating push/cr failures — remote + token coverage
-audit-permissions|reviewing your Bash allowlist for over-broad patterns
-gitlab-auth|configuring glab + git credentials from .env tokens
-resolve|generating ArgoCD Application manifests from declared components
-SURVEY
+    local name handler kind ref use_when
+    while IFS=$'\t' read -r name handler; do
+        [[ -z "$name" ]] && continue
+        kind="${handler%%:*}"
+        ref="${handler#*:}"
+        use_when=""
+        case "$kind" in
+            bash)
+                use_when="$(_orient_find_use_when_script "$SCRIPT_DIR/$ref" "$name")"
+                ;;
+            func)
+                use_when="$(_orient_find_use_when_func "$SCRIPT_DIR/ws" "$ref" "$name")"
+                ;;
+        esac
+        if [[ -n "$use_when" ]]; then
+            printf '  %-18s — %s\n' "$name" "$use_when"
+        else
+            printf '  %-18s — (no `ws:use-when` marker — add one to %s)\n' "$name" "$ref"
+        fi
+    done < <(_orient_parse_dispatch "$SCRIPT_DIR/ws")
+}
+
+# Parse the `case "$COMMAND" in … esac` block in scripts/ws.
+# Output: tab-separated <name>\t<kind>:<ref>
+#   kind=bash  → ref is a script filename (e.g. ws-list.sh)
+#   kind=func  → ref is a function name (e.g. ws_push)
+# Alias-group labels (help|--help|-h) and the catchall `*)` are
+# skipped — those aren't user-facing subcommand names.
+_orient_parse_dispatch() {
+    local ws_file="$1"
+    [[ -f "$ws_file" ]] || return 0
+    awk '
+        BEGIN { in_case = 0; pending = "" }
+        /^case .*COMMAND.* in/ { in_case = 1; next }
+        /^esac/ { exit }
+        !in_case { next }
+        # Match a bare label: `    name)` — leading whitespace,
+        # lowercase-and-hyphen name, closing paren, no alias group.
+        match($0, /^[[:space:]]+([a-z][a-z0-9-]*)\)[[:space:]]*$/, m) {
+            pending = m[1]
+            next
+        }
+        # Body line after a label: extract the handler shape.
+        pending != "" {
+            line = $0
+            sub(/^[[:space:]]+/, "", line)
+            if (match(line, /bash "\$SCRIPT_DIR\/(ws-[a-z-]+\.sh)"/, sm)) {
+                printf "%s\tbash:%s\n", pending, sm[1]
+            } else if (match(line, /^(ws_[a-z_]+)/, fm)) {
+                printf "%s\tfunc:%s\n", pending, fm[1]
+            }
+            pending = ""
+        }
+    ' "$ws_file"
+}
+
+# Scan the first 60 lines of a script file for a `# ws:use-when`
+# marker. Looks for the name-keyed form first (so a shared script
+# can declare different "use when" text per dispatched subcommand —
+# e.g. ws-mcp-setup.sh handles both `mcp-setup` and `mcp-status`),
+# then falls back to the bare form.
+_orient_find_use_when_script() {
+    local file="$1" name="$2"
+    [[ -f "$file" ]] || return 0
+    awk -v target="$name" '
+        { line_count++ }
+        line_count > 60 { exit }
+        # Keyed form: `# ws:use-when:<name> <text>`. Only fires for
+        # an exact name match; non-matching keyed markers are skipped
+        # so a shared script can declare distinct text per subcommand.
+        match($0, /^#[[:space:]]*ws:use-when:([a-z][a-z0-9-]*)[[:space:]]+(.+)$/, m) {
+            if (m[1] == target) { print m[2]; exit }
+            next
+        }
+        # Bare form: `# ws:use-when <text>`. Applies to whatever the
+        # caller asked about. The keyed-form rule above already
+        # short-circuits keyed markers so we never confuse the two.
+        match($0, /^#[[:space:]]*ws:use-when[[:space:]]+(.+)$/, m) {
+            print m[1]; exit
+        }
+    ' "$file"
+}
+
+# Scan a function body inside scripts/ws for a `# ws:use-when` marker.
+# Function definition shape: `<name>() {` at the start of a line.
+# Function close: `}` at column 0. Anything in between is the body.
+_orient_find_use_when_func() {
+    local ws_file="$1" func_name="$2" sub_name="$3"
+    [[ -f "$ws_file" ]] || return 0
+    awk -v fn="$func_name" -v target="$sub_name" '
+        in_func == 0 && $0 ~ "^" fn "[[:space:]]*\\(\\)[[:space:]]*\\{" { in_func = 1; next }
+        in_func == 0 { next }
+        in_func && /^}/ { exit }
+        in_func {
+            # See _orient_find_use_when_script for marker shape notes.
+            if (match($0, /^[[:space:]]*#[[:space:]]*ws:use-when:([a-z][a-z0-9-]*)[[:space:]]+(.+)$/, m)) {
+                if (m[1] == target) { print m[2]; exit }
+                next
+            }
+            if (match($0, /^[[:space:]]*#[[:space:]]*ws:use-when[[:space:]]+(.+)$/, m)) {
+                print m[1]; exit
+            }
+        }
+    ' "$ws_file"
 }
 
 # Resolve the active realm once for the whole orient run, classifying

--- a/scripts/ws-orient.sh
+++ b/scripts/ws-orient.sh
@@ -105,6 +105,14 @@ emit_subcommand_survey() {
 #   kind=func  → ref is a function name (e.g. ws_push)
 # Alias-group labels (help|--help|-h) and the catchall `*)` are
 # skipped — those aren't user-facing subcommand names.
+# Portability note: every awk script in this file sticks to POSIX-awk
+# constructs (regex match, sub, substr, RSTART/RLENGTH). The gawk-only
+# 3-arg array-capture form of match (where the third arg is a named
+# array that receives capture groups) is deliberately avoided so
+# orient stays functional under mawk and BSD awk — `ws orient` is now
+# a MUST-run on session start (per AGENTS.md), so any portability gap
+# here is a session-blocker on macOS / Linux distros that ship mawk
+# as the default awk. See scripts/ws-review.sh for the same precedent.
 _orient_parse_dispatch() {
     local ws_file="$1"
     [[ -f "$ws_file" ]] || return 0
@@ -115,18 +123,27 @@ _orient_parse_dispatch() {
         !in_case { next }
         # Match a bare label: `    name)` — leading whitespace,
         # lowercase-and-hyphen name, closing paren, no alias group.
-        match($0, /^[[:space:]]+([a-z][a-z0-9-]*)\)[[:space:]]*$/, m) {
-            pending = m[1]
+        /^[[:space:]]+[a-z][a-z0-9-]*\)[[:space:]]*$/ {
+            name = $0
+            sub(/^[[:space:]]+/, "", name)
+            sub(/\).*$/, "", name)
+            pending = name
             next
         }
         # Body line after a label: extract the handler shape.
+        # POSIX match() sets RSTART/RLENGTH for the whole match; we
+        # then peel the captured token off with substr() + sub().
         pending != "" {
             line = $0
             sub(/^[[:space:]]+/, "", line)
-            if (match(line, /bash "\$SCRIPT_DIR\/(ws-[a-z-]+\.sh)"/, sm)) {
-                printf "%s\tbash:%s\n", pending, sm[1]
-            } else if (match(line, /^(ws_[a-z_]+)/, fm)) {
-                printf "%s\tfunc:%s\n", pending, fm[1]
+            if (match(line, /bash "\$SCRIPT_DIR\/ws-[a-z-]+\.sh"/)) {
+                m = substr(line, RSTART, RLENGTH)
+                sub(/^bash "\$SCRIPT_DIR\//, "", m)
+                sub(/".*$/, "", m)
+                printf "%s\tbash:%s\n", pending, m
+            } else if (match(line, /^ws_[a-z_]+/)) {
+                m = substr(line, RSTART, RLENGTH)
+                printf "%s\tfunc:%s\n", pending, m
             }
             pending = ""
         }
@@ -147,15 +164,26 @@ _orient_find_use_when_script() {
         # Keyed form: `# ws:use-when:<name> <text>`. Only fires for
         # an exact name match; non-matching keyed markers are skipped
         # so a shared script can declare distinct text per subcommand.
-        match($0, /^#[[:space:]]*ws:use-when:([a-z][a-z0-9-]*)[[:space:]]+(.+)$/, m) {
-            if (m[1] == target) { print m[2]; exit }
+        # The bare-form rule below requires whitespace right after
+        # `ws:use-when`, so the colon in this pattern naturally
+        # disambiguates the two shapes — no extra guard needed.
+        /^#[[:space:]]*ws:use-when:[a-z][a-z0-9-]*[[:space:]]+/ {
+            line = $0
+            sub(/^#[[:space:]]*ws:use-when:/, "", line)
+            keyname = line
+            sub(/[[:space:]].*$/, "", keyname)
+            text = line
+            sub(/^[a-z][a-z0-9-]*[[:space:]]+/, "", text)
+            if (keyname == target) { print text; exit }
             next
         }
         # Bare form: `# ws:use-when <text>`. Applies to whatever the
-        # caller asked about. The keyed-form rule above already
-        # short-circuits keyed markers so we never confuse the two.
-        match($0, /^#[[:space:]]*ws:use-when[[:space:]]+(.+)$/, m) {
-            print m[1]; exit
+        # caller asked about.
+        /^#[[:space:]]*ws:use-when[[:space:]]+/ {
+            text = $0
+            sub(/^#[[:space:]]*ws:use-when[[:space:]]+/, "", text)
+            print text
+            exit
         }
     ' "$file"
 }
@@ -172,12 +200,23 @@ _orient_find_use_when_func() {
         in_func && /^}/ { exit }
         in_func {
             # See _orient_find_use_when_script for marker shape notes.
-            if (match($0, /^[[:space:]]*#[[:space:]]*ws:use-when:([a-z][a-z0-9-]*)[[:space:]]+(.+)$/, m)) {
-                if (m[1] == target) { print m[2]; exit }
+            # In-function markers carry leading whitespace from the
+            # function body indent, so the regexes here allow it.
+            if ($0 ~ /^[[:space:]]*#[[:space:]]*ws:use-when:[a-z][a-z0-9-]*[[:space:]]+/) {
+                line = $0
+                sub(/^[[:space:]]*#[[:space:]]*ws:use-when:/, "", line)
+                keyname = line
+                sub(/[[:space:]].*$/, "", keyname)
+                text = line
+                sub(/^[a-z][a-z0-9-]*[[:space:]]+/, "", text)
+                if (keyname == target) { print text; exit }
                 next
             }
-            if (match($0, /^[[:space:]]*#[[:space:]]*ws:use-when[[:space:]]+(.+)$/, m)) {
-                print m[1]; exit
+            if ($0 ~ /^[[:space:]]*#[[:space:]]*ws:use-when[[:space:]]+/) {
+                text = $0
+                sub(/^[[:space:]]*#[[:space:]]*ws:use-when[[:space:]]+/, "", text)
+                print text
+                exit
             }
         }
     ' "$ws_file"

--- a/scripts/ws-preflight.sh
+++ b/scripts/ws-preflight.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # ws-preflight.sh — Check that workspace prerequisites are installed.
+# ws:use-when verifying workspace prerequisites (bash, git, yq, jq, gh/glab)
 #
 # Reports per-tool status (✓ found / ✗ missing / ⚠ wrong-version) plus
 # an install hint for the detected OS when something is missing. Exit

--- a/scripts/ws-pull.sh
+++ b/scripts/ws-pull.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # ws-pull.sh — Pull latest changes for cloned components, realms, and hoards
+# ws:use-when refreshing every cloned component from its remote
 #
 # Usage:
 #   ws-pull.sh             Pull all cloned components/realms/hoards (skips dirty repos)

--- a/scripts/ws-realm.sh
+++ b/scripts/ws-realm.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 # ws-realm.sh — Realm management and shared config merge functions
+# ws:use-when:realm adopting or switching the active community config
+# ws:use-when:actions inspecting which adapter commands a component has wired
 #
 # Subcommands (called via ws realm):
 #   init            Clone template realm for tutorials

--- a/scripts/ws-resolve.sh
+++ b/scripts/ws-resolve.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # ws-resolve.sh — Generate ArgoCD Application manifests from ecosystem.yaml
+# ws:use-when generating ArgoCD Application manifests from declared components
 #
 # Resolution logic per component:
 #   1. If forceChart is set (via ecosystem.local.yaml), use chart mode

--- a/scripts/ws-review.sh
+++ b/scripts/ws-review.sh
@@ -447,9 +447,16 @@ review_comments() {
     local review_states=""
     review_states=$(printf '%s\n' "$reviews" | _list_review_states)
 
-    local n_outside n_embedded_nits
+    local n_outside n_embedded_nits n_low_conf
     n_outside=$(printf '%s\n' "$reviews" | _count_embedded_findings 'Outside diff range comments')
     n_embedded_nits=$(printf '%s\n' "$reviews" | _count_embedded_findings 'Nitpick comments')
+    # Copilot's reviewer bot wraps "low confidence" findings inside the
+    # leading review body as a collapsed <details> block — they never
+    # land as inline threads and they don't show up in any auth'd
+    # comments fetch. They're real, often actionable findings (the
+    # one on PR #90 flagged a gap in ws-hook-bypass's slug enumeration),
+    # so promote the count to the Index alongside the CodeRabbit patterns.
+    n_low_conf=$(printf '%s\n' "$reviews" | _count_embedded_findings 'Comments suppressed due to low confidence')
 
     echo "=== Index ==="
     echo "  Reviews:         $n_reviews"
@@ -465,14 +472,17 @@ review_comments() {
     # misjudge). Pure `if` statements keep the control flow
     # unambiguous — no compound that might trip `errexit` if the count
     # happens to be 0.
-    if (( n_outside > 0 )) || (( n_embedded_nits > 0 )); then
+    if (( n_outside > 0 )) || (( n_embedded_nits > 0 )) || (( n_low_conf > 0 )); then
         echo ""
         echo "  ! Special finds inside review bodies (NOT as separate threads):"
         if (( n_outside > 0 )); then
-            echo "      Outside diff range comments: $n_outside"
+            echo "      Outside diff range comments:        $n_outside"
         fi
         if (( n_embedded_nits > 0 )); then
-            echo "      Embedded nitpick comments:   $n_embedded_nits"
+            echo "      Embedded nitpick comments:          $n_embedded_nits"
+        fi
+        if (( n_low_conf > 0 )); then
+            echo "      Suppressed (low confidence) finds:  $n_low_conf"
         fi
     fi
     echo ""

--- a/scripts/ws-review.sh
+++ b/scripts/ws-review.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # ws-review.sh — CR review comments and thread management
+# ws:use-when triaging review comments + resolving threads on an open CR
 #
 # Usage:
 #   ws-review.sh <comp> threads <cr#> [--status | --resolve <id> | --resolve-all]

--- a/scripts/ws-status.sh
+++ b/scripts/ws-status.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # ws-status.sh — Show Git status for all cloned components
+# ws:use-when checking git state across every cloned component at a glance
 #
 # Usage:
 #   ws-status.sh             Short status (branch, dirty flag, up to 10 changed files)

--- a/scripts/ws-test.sh
+++ b/scripts/ws-test.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # ws-test.sh — Run tests for a component
+# ws:use-when running the component's test suite via its adapter
 #
 # Usage:
 #   ws-test.sh <component> [test-name | args...]

--- a/scripts/ws-vscode.sh
+++ b/scripts/ws-vscode.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # ws-vscode.sh — Generate a VS Code workspace file from cloned components
+# ws:use-when generating the VS Code multi-root workspace file
 #
 # Usage:
 #   ws-vscode.sh                   Generate yggdrasil.code-workspace

--- a/tests/hook/gdd-permission-hook.bats
+++ b/tests/hook/gdd-permission-hook.bats
@@ -759,6 +759,137 @@ EOF
     [[ "$output" != *"Use ws commit"* ]]
 }
 
+# ─── Tier 2.5 — adapter-aware test/lint redirects (Task 6) ──────────
+
+# When `[adapter-redirect-commands]` matches (pytest, ruff, etc.) and
+# $cwd resolves to a component with a wired adapter, the hook denies
+# with a bypass-pointer. When the adapter is unwired (file absent or
+# missing the commands.<verb> entry), the hook emits a stderr nudge
+# and falls through to the normal allow/ask evaluation. Outside a
+# component dir, the rule doesn't fire at all.
+
+@test "adapter-redirect: raw pytest in a component WITH commands.test denies" {
+    write_project_hook_rules "$(cat <<'EOF'
+[adapter-redirect-commands]
+pytest      | pytest*            | test
+pytest-mod  | python* -m pytest* | test
+ruff        | ruff*              | lint
+EOF
+)"
+    seed_adapter_fixture "wiredcomp" "$(cat <<'YAML'
+commands:
+  test: "python3 -m pytest tests/"
+  lint: "python3 -m ruff check src/"
+YAML
+)"
+    run_hook 'pytest tests/test_foo.py' "$WORK/components/wiredcomp"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"\"permissionDecision\":\"deny\""* ]]
+    [[ "$output" == *"ws test wiredcomp"* ]]
+    [[ "$output" == *"ws hook-bypass pytest"* ]]
+}
+
+@test "adapter-redirect: raw python -m pytest matches the pytest-mod pattern" {
+    write_project_hook_rules "$(cat <<'EOF'
+[adapter-redirect-commands]
+pytest      | pytest*            | test
+pytest-mod  | python* -m pytest* | test
+EOF
+)"
+    seed_adapter_fixture "wiredcomp" "$(cat <<'YAML'
+commands:
+  test: "python3 -m pytest tests/"
+YAML
+)"
+    run_hook 'python3 -m pytest tests/' "$WORK/components/wiredcomp"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"\"permissionDecision\":\"deny\""* ]]
+    [[ "$output" == *"ws test wiredcomp"* ]]
+}
+
+@test "adapter-redirect: raw ruff in a component WITH commands.lint denies" {
+    write_project_hook_rules "$(cat <<'EOF'
+[adapter-redirect-commands]
+ruff | ruff* | lint
+EOF
+)"
+    seed_adapter_fixture "wiredcomp" "$(cat <<'YAML'
+commands:
+  lint: "python3 -m ruff check src/"
+YAML
+)"
+    run_hook 'ruff check src/' "$WORK/components/wiredcomp"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"\"permissionDecision\":\"deny\""* ]]
+    [[ "$output" == *"ws lint wiredcomp"* ]]
+}
+
+@test "adapter-redirect: raw pytest in a component WITHOUT an adapter file emits nudge and falls through" {
+    write_project_hook_rules "$(cat <<'EOF'
+[adapter-redirect-commands]
+pytest | pytest* | test
+EOF
+)"
+    # Empty adapter content = no adapter file at all.
+    seed_adapter_fixture "barecomp" ""
+    run_hook 'pytest tests/' "$WORK/components/barecomp"
+    [ "$status" -eq 0 ]
+    # Falls through — no deny / no allow emitted by Tier 2.5.
+    [[ "$output" != *"\"permissionDecision\":\"deny\""* ]]
+    # Nudge on stderr — bats `run` merges fd1+fd2, so the message is
+    # visible in $output even though it's printed to stderr.
+    [[ "$output" == *"No \`ws test\` adapter for barecomp"* ]]
+}
+
+@test "adapter-redirect: adapter present but missing commands.<verb> still emits nudge" {
+    write_project_hook_rules "$(cat <<'EOF'
+[adapter-redirect-commands]
+pytest | pytest* | test
+ruff   | ruff*   | lint
+EOF
+)"
+    # Adapter file exists but only has commands.lint (test is missing).
+    seed_adapter_fixture "lintonly" "$(cat <<'YAML'
+commands:
+  lint: "ruff check ."
+YAML
+)"
+    run_hook 'pytest tests/' "$WORK/components/lintonly"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"\"permissionDecision\":\"deny\""* ]]
+    [[ "$output" == *"No \`ws test\` adapter for lintonly"* ]]
+}
+
+@test "adapter-redirect: pytest outside any component dir doesn't fire the rule" {
+    write_project_hook_rules "$(cat <<'EOF'
+[adapter-redirect-commands]
+pytest | pytest* | test
+EOF
+)"
+    # cwd = $WORK (project root, not inside components/).
+    run_hook "pytest tests/" "$WORK"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"\"permissionDecision\":\"deny\""* ]]
+    [[ "$output" != *"No \`ws test\` adapter"* ]]
+}
+
+@test "adapter-redirect: bypass marker turns wired-deny into allow" {
+    write_project_hook_rules "$(cat <<'EOF'
+[adapter-redirect-commands]
+pytest | pytest* | test
+EOF
+)"
+    seed_adapter_fixture "wiredcomp" "$(cat <<'YAML'
+commands:
+  test: "python3 -m pytest tests/"
+YAML
+)"
+    write_bypass_marker "pytest" "session-xyz" "running a single test directly"
+    run_hook_with_session "pytest tests/test_one.py::test_x" "session-xyz" "$WORK/components/wiredcomp"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"\"permissionDecision\":\"allow\""* ]]
+}
+
 @test "redirect: command outside [redirect-commands] passes through Tier 2" {
     write_project_hook_rules "$(cat <<'EOF'
 [redirect-commands]

--- a/tests/hook/gdd-permission-hook.bats
+++ b/tests/hook/gdd-permission-hook.bats
@@ -4,14 +4,15 @@
 #
 # Coverage:
 #   - Tier 1: deny shell composition (each operator) with specific reason
-#   - Tier 2: ask-tier — destructive commands matching [ask-commands]
-#   - Tier 3: allow via project .claude/settings.json
+#   - Tier 2: redirect-deny for raw commands with a `ws` wrapper
+#   - Tier 3: adapter-aware deny/nudge for raw test/lint runners
+#   - Tier 4: ask-tier — destructive commands matching [ask-commands]
+#   - Tier 5: allow via project .claude/settings.json
 #       - bare command vs verbose pattern (symmetric normalization)
 #       - verbose command vs bare pattern (symmetric normalization)
 #       - CRLF line endings in settings.json don't break matching
-#   - Tier 3: allow via settings.json `permissions.allow` (unchanged logic)
-#   - Tier 4: allow via [allow-extras] section of hook-rules.local
-#   - Tier 4: legacy safe-bash-extras file is ignored (no longer consulted)
+#   - Tier 6: allow via [allow-extras] section of hook-rules.local
+#   - legacy safe-bash-extras file is ignored (no longer consulted)
 #   - Passthrough: no match → exit 0 with no JSON
 #   - WS_HOOK_DISABLE bypass
 #   - Timeout safety: no infinite loops on Windows-style absolute paths
@@ -205,7 +206,7 @@ setup() {
     [[ "$output" == *"File-descriptor merges"* ]]
 }
 
-# ─── Tier 3: symmetric normalization against settings.json ──────────
+# ─── Tier 5: symmetric normalization against settings.json ──────────
 
 @test "allow via settings: bare command matches verbose pattern" {
     write_project_settings 'Bash(bash scripts/ws status)'
@@ -248,7 +249,7 @@ setup() {
     [[ "$output" == *"\"permissionDecision\":\"allow\""* ]]
 }
 
-# ─── Tier 4: [allow-extras] from hook-rules.local ───────────────────
+# ─── Tier 6: [allow-extras] from hook-rules.local ───────────────────
 
 @test "allow via allow-extras: pattern from hook-rules.local [allow-extras] matches" {
     write_project_hook_rules ""
@@ -481,7 +482,7 @@ figlet *"
     [ "$status" -ne 124 ]
 }
 
-# ─── Tier 2: ask-list ───────────────────────────────────────────────
+# ─── Tier 4: ask-list ───────────────────────────────────────────────
 
 @test "ask: rm -rf matches the baseline ask-list and emits ask" {
     write_project_hook_rules "[ask-commands]
@@ -594,7 +595,7 @@ rm -rf*"
     [[ "$output" != *"\"permissionDecision\":\"ask\""* ]]
 }
 
-# ─── Tier 4 vs legacy safe-bash-extras ──────────────────────────────
+# ─── Tier 6 vs legacy safe-bash-extras ──────────────────────────────
 
 @test "allow-extras: a hook-rules.local [allow-extras] pattern allows" {
     write_project_hook_rules ""
@@ -759,7 +760,7 @@ EOF
     [[ "$output" != *"Use ws commit"* ]]
 }
 
-# ─── Tier 2.5 — adapter-aware test/lint redirects (Task 6) ──────────
+# ─── Tier 3 — adapter-aware test/lint redirects (Task 6) ────────────
 
 # When `[adapter-redirect-commands]` matches (pytest, ruff, etc.) and
 # $cwd resolves to a component with a wired adapter, the hook denies
@@ -834,7 +835,7 @@ EOF
     seed_adapter_fixture "barecomp" ""
     run_hook 'pytest tests/' "$WORK/components/barecomp"
     [ "$status" -eq 0 ]
-    # Falls through — no deny / no allow emitted by Tier 2.5.
+    # Falls through — no deny / no allow emitted by Tier 3.
     [[ "$output" != *"\"permissionDecision\":\"deny\""* ]]
     # Nudge on stderr — bats `run` merges fd1+fd2, so the message is
     # visible in $output even though it's printed to stderr.
@@ -920,7 +921,7 @@ EOF
     write_project_settings "Bash(ls *)"
     run_hook "ls -la"
     [ "$status" -eq 0 ]
-    # Settings.json allow at Tier 4 should still match
+    # Settings.json allow at Tier 5 should still match
     [[ "$output" == *"\"permissionDecision\":\"allow\""* ]]
 }
 
@@ -992,7 +993,7 @@ EOF
     [[ "$output" == *"Shell composition"* ]]
 }
 
-@test "bypass: marker does NOT override Tier 3 ask-list" {
+@test "bypass: marker does NOT override Tier 4 ask-list" {
     write_project_hook_rules "$(cat <<'EOF'
 [redirect-commands]
 git-commit | git commit* | Use ws commit
@@ -1031,7 +1032,7 @@ gh-pr-create | gh pr create* | Use ws cr
 ws hook-bypass [a-z]*
 EOF
 )"
-    # Each known slug invocation should hit Tier 3 ask, NOT Tier 2 deny.
+    # Each known slug invocation should hit Tier 4 ask, NOT Tier 2 deny.
     for slug in git-commit git-push gh-pr-create; do
         echo "# testing slug: $slug"   # surfaces which iteration failed
         run_hook "ws hook-bypass $slug"

--- a/tests/hook/gdd-permission-hook.bats
+++ b/tests/hook/gdd-permission-hook.bats
@@ -873,6 +873,27 @@ EOF
     [[ "$output" != *"No \`ws test\` adapter"* ]]
 }
 
+@test "adapter-redirect: overlapping unwired patterns emit only one nudge" {
+    # Two entries whose globs both match `pytest tests/` (same verb,
+    # same component). Without the break-on-first-match guard, the
+    # unwired branch would emit two nudges and two audit entries for
+    # a single invocation (Copilot finding on PR #90). Pin the
+    # one-nudge contract here.
+    write_project_hook_rules "$(cat <<'EOF'
+[adapter-redirect-commands]
+pytest      | pytest*  | test
+pytest-narrow | pytest * | test
+EOF
+)"
+    seed_adapter_fixture "barecomp" ""
+    run_hook "pytest tests/" "$WORK/components/barecomp"
+    [ "$status" -eq 0 ]
+    # Count how many times the nudge phrase appears. Should be 1.
+    local nudge_count
+    nudge_count="$(printf '%s\n' "$output" | grep -c "No \`ws test\` adapter for barecomp" || true)"
+    [ "$nudge_count" -eq 1 ] || { echo "expected 1 nudge, got $nudge_count"; return 1; }
+}
+
 @test "adapter-redirect: bypass marker turns wired-deny into allow" {
     write_project_hook_rules "$(cat <<'EOF'
 [adapter-redirect-commands]

--- a/tests/hook/gdd-permission-hook.bats
+++ b/tests/hook/gdd-permission-hook.bats
@@ -874,6 +874,28 @@ EOF
     [[ "$output" != *"No \`ws test\` adapter"* ]]
 }
 
+@test "adapter-redirect: pytest at the bare components/ root falls through (no blank-component nudge)" {
+    # Pin the _ar_resolve_component edge case: the pattern
+    # `"$root/components/"*` also matches `$root/components/` itself
+    # (empty tail). Without the empty-segment guard the resolver
+    # would emit a nudge for a blank component name and try to look
+    # up `adapters/.yaml`. Guard ensures the rule only fires under
+    # an actual `components/<comp>/` path. Copilot finding on PR #90.
+    write_project_hook_rules "$(cat <<'EOF'
+[adapter-redirect-commands]
+pytest | pytest* | test
+EOF
+)"
+    mkdir -p "$WORK/components"
+    run_hook "pytest tests/" "$WORK/components"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"\"permissionDecision\":\"deny\""* ]]
+    # No blank-component nudge: a regression that surfaces `No ws
+    # test adapter for ...` (with empty or whitespace-only name)
+    # would fail here.
+    [[ "$output" != *"No \`ws test\` adapter for "* ]]
+}
+
 @test "adapter-redirect: overlapping unwired patterns emit only one nudge" {
     # Two entries whose globs both match `pytest tests/` (same verb,
     # same component). Without the break-on-first-match guard, the

--- a/tests/hook/interactive-acceptance.md
+++ b/tests/hook/interactive-acceptance.md
@@ -16,7 +16,7 @@ bats (`gdd-permission-hook.bats`) verifies the hook's *output*. It cannot verify
 |---|---------|-----------------|
 | 1 | `rm -rf .tmp/acceptance-probe` | `ask` prompt — reason mentions the ask-list **and** carries the symlink caution |
 | 2 | `git -C .tmp/acceptance-repo reset --hard HEAD` | `ask` prompt — reason mentions the ask-list, **no** symlink caution |
-| 3 | `ls -la` | **not** an ask prompt. Three valid paths: Tier 4 silent auto-allow (if `ls *` is in `[allow-extras]`), normal harness prompt, or silent allow from Claude Code's session-scoped read trust if the harness has already accepted reads against the directory. The shape of the user-facing response varies; the invariant to verify is in the audit log — see "Confirmation" below. |
+| 3 | `ls -la` | **not** an ask prompt. Three valid paths: Tier 6 silent auto-allow (if `ls *` is in `[allow-extras]`), normal harness prompt, or silent allow from Claude Code's session-scoped read trust if the harness has already accepted reads against the directory. The shape of the user-facing response varies; the invariant to verify is in the audit log — see "Confirmation" below. |
 | 4 | `echo hi && echo bye` | composition **deny** — blocked with the shell-composition message, NOT an ask |
 | 5 | `rm -rf .tmp/acceptance-probe-2` | `ask` prompt **still appears** despite `acceptEdits` mode — the core regression check |
 

--- a/tests/hook/interactive-redirect-acceptance.md
+++ b/tests/hook/interactive-redirect-acceptance.md
@@ -25,7 +25,7 @@ Human confirms:
 
 ## Step 2 — `ws hook-bypass git-commit` force-prompts
 
-Agent announces: *"Now `ws hook-bypass git-commit --reason \"acceptance test\"`. Expect a Tier 3 ask prompt (force-prompt, not a silent run), and on approval, a marker file under `.tmp/hook-bypass/git-commit.bypass`."*
+Agent announces: *"Now `ws hook-bypass git-commit --reason \"acceptance test\"`. Expect a Tier 4 ask prompt (force-prompt, not a silent run), and on approval, a marker file under `.tmp/hook-bypass/git-commit.bypass`."*
 
 Agent runs: `ws hook-bypass git-commit --reason "acceptance test"`
 

--- a/tests/hook/test_helper.bash
+++ b/tests/hook/test_helper.bash
@@ -169,7 +169,7 @@ run_hook_with_session() {
 }
 
 # Set up an active realm + component dir under $WORK so the adapter-
-# aware redirect tier (Tier 2.5) has something to resolve.
+# aware redirect tier (Tier 3) has something to resolve.
 #   $1 — component name (e.g. "knarrlike")
 #   $2 — adapter content (multi-line YAML); empty string = no adapter
 #         file written at all (the "unwired" case where the file is

--- a/tests/hook/test_helper.bash
+++ b/tests/hook/test_helper.bash
@@ -167,3 +167,31 @@ run_hook_with_session() {
         '{session_id:$sid, tool_input:{command:$cmd}, cwd:$cwd}')
     run "$TIMEOUT_BIN" 10 bash "$HOOK_BIN" <<< "$payload"
 }
+
+# Set up an active realm + component dir under $WORK so the adapter-
+# aware redirect tier (Tier 2.5) has something to resolve.
+#   $1 — component name (e.g. "knarrlike")
+#   $2 — adapter content (multi-line YAML); empty string = no adapter
+#         file written at all (the "unwired" case where the file is
+#         missing entirely).
+#   $3 — realm name (default "realm-fixture")
+#
+# Creates: $WORK/components/<comp>/ (cwd anchor for tests),
+#          $WORK/realms/<realm>/ + ecosystem.yaml, optional adapter
+#          file. Auto-detection picks the single non-template realm-*
+#          dir so no ecosystem.local.yaml selector is needed.
+seed_adapter_fixture() {
+    local comp="$1"
+    local adapter_yaml="$2"
+    local realm="${3:-realm-fixture}"
+    mkdir -p "$WORK/components/$comp"
+    mkdir -p "$WORK/realms/$realm/adapters"
+    cat > "$WORK/realms/$realm/ecosystem.yaml" <<'YAML'
+identity:
+  human_account: testuser
+components: {}
+YAML
+    if [[ -n "$adapter_yaml" ]]; then
+        printf '%s\n' "$adapter_yaml" > "$WORK/realms/$realm/adapters/$comp.yaml"
+    fi
+}

--- a/tests/smoke.bats
+++ b/tests/smoke.bats
@@ -22,3 +22,43 @@
     [ "$status" -eq 0 ]
     [[ "$output" == *"Usage:"* ]]
 }
+
+# ─── AGENTS.md L0 contract (Task 7 of gdd-orientation-capability-index) ─
+
+# AGENTS.md is the L0 layer of the progressive-disclosure buffet:
+# slim utilities menu + reflex contract + hard pointer at the
+# orientation skill. Deeper content (skills table, full workspace
+# CLI, code style, etc.) is discoverable via `ws orient` + per-
+# subcommand `--help` rather than inline. These tests pin the
+# load-bearing markers so a future edit that loses them surfaces
+# here first.
+
+@test "AGENTS.md exists at the workspace root" {
+    [ -f "${BATS_TEST_DIRNAME}/../AGENTS.md" ]
+}
+
+@test "AGENTS.md carries the reflex contract marker" {
+    # The reflex contract is the heart of L0 — it's what agents
+    # consult mid-session before reaching for raw git/gh/glab.
+    # Pin both the section heading and a representative verb so a
+    # rename surfaces this test.
+    local agents="${BATS_TEST_DIRNAME}/../AGENTS.md"
+    grep -q "Reflex Contract" "$agents"
+    grep -q "ws commit" "$agents"
+    grep -q "ws push" "$agents"
+}
+
+@test "AGENTS.md points at the orientation skill" {
+    # The single hard pointer to gdd-orientation is the only
+    # session-start reach AGENTS.md mandates. If this line ever
+    # drops, agents miss the orientation flow entirely.
+    grep -q ".agent/skills/gdd-orientation/SKILL.md" "${BATS_TEST_DIRNAME}/../AGENTS.md"
+}
+
+@test "AGENTS.md points at ws orient as the discovery surface" {
+    # ws orient is the L1 of the buffet — the deterministic menu
+    # agents fall back to mid-session when not sure what verbs /
+    # adapters / skills exist. AGENTS.md must surface it as the
+    # discovery surface so the L0→L1 transition is explicit.
+    grep -q "ws orient" "${BATS_TEST_DIRNAME}/../AGENTS.md"
+}

--- a/tests/smoke.bats
+++ b/tests/smoke.bats
@@ -62,3 +62,13 @@
     # discovery surface so the L0→L1 transition is explicit.
     grep -q "ws orient" "${BATS_TEST_DIRNAME}/../AGENTS.md"
 }
+
+@test "AGENTS.md mandates ws orient at session start (MUST language)" {
+    # Pin the firmer session-start directive: agents must EXECUTE
+    # `ws orient` on every fresh dispatch, not treat it as a loose
+    # discovery aid. The MUST keyword + Execute pair surfaces in
+    # the Session Start block and again in Operational Rules.
+    local agents="${BATS_TEST_DIRNAME}/../AGENTS.md"
+    grep -q "MUST" "$agents"
+    grep -q "Execute \`ws orient\`" "$agents"
+}

--- a/tests/ws-cli/hook-bypass.bats
+++ b/tests/ws-cli/hook-bypass.bats
@@ -113,3 +113,41 @@ EOF
     [[ "$output" == *"Unknown slug"* ]]
     [ ! -d "$WORK/.tmp/hook-bypass" ]
 }
+
+@test "adapter-redirect slugs are accepted (Tier 3 alongside Tier 2)" {
+    # The Tier 3 [adapter-redirect-commands] deny message instructs
+    # users to bypass via `ws hook-bypass <slug>`. The script must
+    # accept those slugs too — otherwise the deny message tells users
+    # to do something the script refuses to do. Pin the contract.
+    # Copilot low-confidence finding on PR #90.
+    cat > "$WORK/.claude/hooks/hook-rules" <<'EOF'
+[redirect-commands]
+git-commit          | git commit*    | Use ws commit
+
+[adapter-redirect-commands]
+adapter-redirect-pytest  | pytest*       | test
+adapter-redirect-ruff    | ruff*         | lint
+EOF
+    run bash "$SCRIPT" adapter-redirect-pytest --reason "investigating raw pytest"
+    [ "$status" -eq 0 ]
+    [ -f "$WORK/.tmp/hook-bypass/adapter-redirect-pytest.bypass" ]
+    grep -q '^slug: adapter-redirect-pytest$' "$WORK/.tmp/hook-bypass/adapter-redirect-pytest.bypass"
+}
+
+@test "unknown-slug error lists both [redirect-commands] and [adapter-redirect-commands] slugs" {
+    # Make sure the helpful-message branch enumerates BOTH tiers so a
+    # user typing an adapter-redirect slug close to but not matching
+    # an entry sees its real cousins, not just the Tier 2 list.
+    cat > "$WORK/.claude/hooks/hook-rules" <<'EOF'
+[redirect-commands]
+git-commit          | git commit*    | Use ws commit
+
+[adapter-redirect-commands]
+adapter-redirect-pytest  | pytest*       | test
+EOF
+    run bash "$SCRIPT" no-such-slug
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Unknown slug"* ]]
+    [[ "$output" == *"git-commit"* ]]
+    [[ "$output" == *"adapter-redirect-pytest"* ]]
+}

--- a/tests/ws-orient/orient.bats
+++ b/tests/ws-orient/orient.bats
@@ -79,6 +79,22 @@ setup() {
     [[ "$output" == *"orient"*"starting a session"* ]]
 }
 
+@test "ws orient: awk parsers stay POSIX (no gawk-only match(re, arr) form)" {
+    # Portability gate: `match($0, /re/, arr)` with the array-capture
+    # third arg is gawk-only and breaks on mawk / BSD awk, which
+    # several Linux distros and macOS ship as the default. Since
+    # AGENTS.md mandates `ws orient` at session start, that gap
+    # would be a session-blocker. Pin the contract — any new awk
+    # block that reintroduces the form fails this test.
+    #
+    # scripts/ws-review.sh notes the same precedent. Source-of-truth
+    # for the rule lives at the top of ws-orient.sh.
+    local script="$REPO_ROOT/scripts/ws-orient.sh"
+    run grep -nE 'match\([^,]+,[^,]+,[[:space:]]*[a-zA-Z_]' "$script"
+    # grep exits 1 when no match — that's the passing path.
+    [ "$status" -eq 1 ]
+}
+
 @test "ws orient: subcommand survey resolves name-keyed markers (mcp-setup vs mcp-status)" {
     # When one handler dispatches multiple subcommands (ws-mcp-setup.sh
     # serves both `mcp-setup` and `mcp-status`), each row must pick

--- a/tests/ws-orient/orient.bats
+++ b/tests/ws-orient/orient.bats
@@ -67,6 +67,29 @@ setup() {
     done
 }
 
+@test "ws orient: subcommand survey resolves bare ws:use-when markers from script handlers" {
+    # The dynamic inventory is the whole point of the survey: a
+    # `# ws:use-when <text>` marker in scripts/ws-orient.sh must
+    # surface here verbatim, so adding a new subcommand never means
+    # editing a hardcoded list. Pin the text from ws-orient.sh's
+    # own marker — if someone deletes it, this test fails and the
+    # gap is visible immediately, not via a stale survey row.
+    run_ws orient
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"orient"*"starting a session"* ]]
+}
+
+@test "ws orient: subcommand survey resolves name-keyed markers (mcp-setup vs mcp-status)" {
+    # When one handler dispatches multiple subcommands (ws-mcp-setup.sh
+    # serves both `mcp-setup` and `mcp-status`), each row must pick
+    # up its own keyed marker rather than collapsing onto the same
+    # text. Asserts both rows render the distinct keyed text.
+    run_ws orient
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"mcp-setup"*"generating .mcp.json"* ]]
+    [[ "$output" == *"mcp-status"*"checking which MCP servers"* ]]
+}
+
 # ─── 4c — active realm detection ────────────────────────────────────
 
 @test "ws orient: prints 'Active realm: none' when no realm is present" {

--- a/tests/ws-smoke/read-only.bats
+++ b/tests/ws-smoke/read-only.bats
@@ -79,6 +79,75 @@ setup() {
     [[ "$output" == *"ws <command>"* ]]
 }
 
+# ─── command-output footer (Task 5) ─────────────────────────────────
+
+# The footer is a one-line stderr nudge appended after every
+# successful `ws` subcommand dispatch — keeps the `ws orient` meta-
+# rule discoverable mid-session without requiring agents to memorize
+# it. Suppressed for `orient` itself (no recursive recommendation),
+# for the help command, for any subcommand's --help variant, and via
+# `WS_FOOTER_DISABLE=1`. Stderr so it never contaminates captured
+# stdout (e.g. `commit=$(ws log --oneline)`).
+
+# Footer suppresses automatically when `BATS_TEST_NAME` is set so
+# the rest of the bats suite isn't disrupted by the stderr line.
+# These footer-focused tests opt back in by unsetting that env var
+# for the child process (`env -u BATS_TEST_NAME …`) so we can
+# verify the user-facing behavior.
+
+@test "ws status: footer prints to stderr after dispatch" {
+    run bash -c "env -u BATS_TEST_NAME $TIMEOUT_BIN 10 bash $WS_BIN status 2>$BATS_TEST_TMPDIR/stderr.txt"
+    [ "$status" -eq 0 ]
+    local stderr_content
+    stderr_content="$(cat "$BATS_TEST_TMPDIR/stderr.txt")"
+    [[ "$stderr_content" == *"ws orient"* ]]
+    [[ "$stderr_content" == *"switching tasks"* ]]
+}
+
+@test "ws status: footer stays out of stdout" {
+    # Capture-output is a common pattern (var=\$(ws list)); a footer
+    # on stdout would contaminate that. Pin the separation.
+    run bash -c "env -u BATS_TEST_NAME $TIMEOUT_BIN 10 bash $WS_BIN status 2>/dev/null"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"switching tasks"* ]]
+}
+
+@test "ws orient: footer does NOT fire (no recursive self-recommend)" {
+    run bash -c "env -u BATS_TEST_NAME $TIMEOUT_BIN 10 bash $WS_BIN orient 2>$BATS_TEST_TMPDIR/stderr.txt"
+    [ "$status" -eq 0 ]
+    [[ "$(cat "$BATS_TEST_TMPDIR/stderr.txt")" != *"switching tasks"* ]]
+}
+
+@test "ws help: footer does NOT fire on the help command itself" {
+    run bash -c "env -u BATS_TEST_NAME $TIMEOUT_BIN 10 bash $WS_BIN help 2>$BATS_TEST_TMPDIR/stderr.txt"
+    [ "$status" -eq 0 ]
+    [[ "$(cat "$BATS_TEST_TMPDIR/stderr.txt")" != *"switching tasks"* ]]
+}
+
+@test "ws hoard --help: footer does NOT fire on subcommand help" {
+    run bash -c "env -u BATS_TEST_NAME $TIMEOUT_BIN 10 bash $WS_BIN hoard --help 2>$BATS_TEST_TMPDIR/stderr.txt"
+    [ "$status" -eq 0 ]
+    [[ "$(cat "$BATS_TEST_TMPDIR/stderr.txt")" != *"switching tasks"* ]]
+}
+
+@test "WS_FOOTER_DISABLE=1: footer is silenced even with BATS_TEST_NAME cleared" {
+    # Opt-out env var. Clear BATS_TEST_NAME to remove the auto-skip
+    # so this test exercises the explicit WS_FOOTER_DISABLE branch.
+    run bash -c "env -u BATS_TEST_NAME WS_FOOTER_DISABLE=1 $TIMEOUT_BIN 10 bash $WS_BIN status 2>$BATS_TEST_TMPDIR/stderr.txt"
+    [ "$status" -eq 0 ]
+    [[ "$(cat "$BATS_TEST_TMPDIR/stderr.txt")" != *"switching tasks"* ]]
+}
+
+@test "ws under bats (BATS_TEST_NAME set): footer auto-skips so suite assertions hold" {
+    # Belt-and-braces guard: confirm the auto-skip mechanism the
+    # rest of the suite relies on actually works. If a refactor
+    # ever loses this, dozens of unrelated output-shape tests would
+    # start failing — surface that here first.
+    run "$TIMEOUT_BIN" 10 bash "$WS_BIN" status
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"switching tasks"* ]]
+}
+
 @test "ws hoard --help: exits 0 (subcommand-level help)" {
     run_ws hoard --help
     [ "$status" -eq 0 ]
@@ -151,6 +220,8 @@ setup() {
 }
 
 @test "ws hoard scan --names-only: empty hoards/ produces no output" {
+    # Footer auto-skips under bats so $output is just fd1; no
+    # special handling needed.
     run_ws hoard scan --names-only
     [ "$status" -eq 0 ]
     [ -z "$output" ]

--- a/tests/ws-smoke/read-only.bats
+++ b/tests/ws-smoke/read-only.bats
@@ -148,6 +148,24 @@ setup() {
     [[ "$output" != *"switching tasks"* ]]
 }
 
+@test "footer: no ANSI escape sequences when stderr isn't a terminal" {
+    # bats' `run` pipes stderr — !isatty(2) — so the footer must
+    # emit plain text. Captured logs / CI output / `2> file`
+    # redirects all hit this branch; raw escape sequences in those
+    # contexts are visible garbage. (Copilot finding on PR #90.)
+    run bash -c "env -u BATS_TEST_NAME $TIMEOUT_BIN 10 bash $WS_BIN status 2>$BATS_TEST_TMPDIR/stderr.txt"
+    [ "$status" -eq 0 ]
+    local stderr_content
+    stderr_content="$(cat "$BATS_TEST_TMPDIR/stderr.txt")"
+    [[ "$stderr_content" == *"switching tasks"* ]]
+    # The dim/reset ANSI sequence escape characters must NOT appear.
+    # $'\e' is the bash-evaluated escape literal; grep -F treats it
+    # as a fixed substring (no regex), so it triggers only on the
+    # actual ESC byte, not on the printable backslash-e form.
+    ! grep -qF $'\e[2m' "$BATS_TEST_TMPDIR/stderr.txt"
+    ! grep -qF $'\e[0m' "$BATS_TEST_TMPDIR/stderr.txt"
+}
+
 @test "ws hoard --help: exits 0 (subcommand-level help)" {
     run_ws hoard --help
     [ "$status" -eq 0 ]


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @Cervator via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

Bundles Tasks 5, 6, and 7 of the `gdd-orientation-capability-index` arc into a single PR. Each Task is its own commit per the plan, but they ship together because the review process is heavier than per-Task PRs add value at this stage of the arc.

| Commit | Task | Scope |
|---|---|---|
| `198f794` | **Task 5** | One-line stderr footer after every successful `ws` subcommand: `↪ switching tasks? \`ws orient\` lists available tools.` Suppressed for `orient`, `--help` variants, `WS_FOOTER_DISABLE=1`, and (auto) under `BATS_TEST_NAME`. |
| `904a021` | **Task 7** | `AGENTS.md` cut to L0 — 404 → 107 lines. Reflex contract (6 unconditional verbs + `ws orient` meta-rule for test/lint/build), single hard pointer at the orientation skill, ws-orient framed as the L1 discovery surface. Deep content moves to `ws orient` / `ws <cmd> --help` / linked docs. |
| `a58299b` | **Task 6** | Adapter-aware hook Tier 2.5 — raw `pytest`/`python -m pytest`/`gradle test`/`ruff`/`black`/`mypy` route based on the realm's adapter file. Wired → deny-with-bypass; unwired → stderr nudge + fall through. New `[adapter-redirect-commands]` section in `hook-rules`. |

## The progressive-disclosure buffet, complete

This PR closes the L0/L1/L2 loop the design specified:

- **L0** (AGENTS.md, Task 7) — slim menu, reflex contract, orientation pointer.
- **L1** (`ws orient`, already merged) — deterministic discovery menu.
- **L2** (`ws <cmd> --help`) — per-command depth.

The footer (Task 5) threads L1 discoverability through every L0/L2 interaction. The adapter-aware hook (Task 6) operationalizes the L0 meta-rule "consult `ws orient` first for test/lint/build" — it's now enforced, not just documented.

## Task 5 — Command-output footer (`198f794`)

One dim ANSI line on stderr after every successful subcommand (TTY-detected — plain text when stderr isn't a terminal so captured logs / CI stay clean):

```
↪ switching tasks? `ws orient` lists available tools.
```

**Suppression cases:**

- `WS_FOOTER_DISABLE=1` — explicit opt-out for agents/scripts wanting quiet stderr.
- `COMMAND` is `orient`/`help`/`--help`/`-h`, or any subcommand was invoked with `--help`/`-h`/`help`.
- Under bats — `BATS_TEST_NAME` auto-skip so the rest of the suite's output-shape assertions don't pick up the footer as noise. Footer-focused tests opt back in via `env -u BATS_TEST_NAME …`.
- Subcommand exited non-zero — `set -e` exits the script before reaching the footer.

7 new tests pinning each case + the stdout/stderr separation contract.

## Task 7 — AGENTS.md L0 cut (`904a021`)

**Size:** 404 → 107 lines. Major cuts:

- Full skills table (20 rows) → discoverable via `ws orient` skill index.
- Full `Workspace CLI` section with per-flag detail → discoverable via `ws <cmd> --help`. AGENTS.md keeps just the reflex contract (the verb-substitution table).
- Hoards / Components / Auth Setup / Ecosystem Config / IDE Setup / Code Style / MCP — each had its own AGENTS.md section duplicating content already in `docs/` or in the corresponding skill body. AGENTS.md now lists them under `Deeper References` as pointers; the substance lives once at the linked location.

**Kept (load-bearing for agent behavior):**

- "Workspace skills are plain markdown — read with Read tool, do NOT invoke via the Skill tool."
- Active realm skills load on demand.
- Reflex contract with the 6 unconditional verbs (commit/push/cr/issue/clone/exec).
- Adapter-routed verbs (test/lint/build) framed via the `ws orient` meta-rule — Task 6's hook redirects make this load-bearing.
- `ws orient` as the L1 discovery surface.
- Companion plugin (Superpowers) with the three reference patterns.
- 6-bullet operational rules.

4 new tests in `tests/smoke.bats` pinning: AGENTS.md exists, the Reflex Contract marker + representative verbs present, the gdd-orientation pointer present, `ws orient` named as the discovery surface.

## Task 6 — Adapter-aware hook redirects (`a58299b`)

New **Tier 3** between the previous Tier 2 (raw-`ws` redirect) and the ask-list (renumbered Tier 4). Catches raw test/lint/build runners and routes based on the realm's adapter file.

**New committed `hook-rules` section:**

```
[adapter-redirect-commands]
pytest      | pytest*            | test
pytest-mod  | python* -m pytest* | test
gradle-test | gradle test*       | test
ruff        | ruff*              | lint
black       | black*             | lint
mypy        | mypy*              | lint
```

**Decision flow** when a pattern matches:

1. `$cwd` must be under `components/<comp>/`. Raw runners at workspace root → rule doesn't fire (legitimate workspace-test invocation).
2. Active realm required (mirrors `ws_detect_realm` logic inline so the hook stays self-contained).
3. Read `realms/<realm>/adapters/<comp>.yaml` via `yq`:
   - `commands.<verb>` wired → deny with `ws <verb> <comp>` pointer + `ws hook-bypass <slug>` hint. Reuses the existing bypass-marker machinery (`<root>/.tmp/hook-bypass/<slug>.bypass`).
   - Adapter missing or `commands.<verb>` missing → one stderr line nudge, fall through to normal allow/ask evaluation. Allowlist still applies.

**Why a separate tier from Tier 2.** The existing `[redirect-commands]` entries always deny — their `ws` alternative always exists. Test/lint runners are different: absence of an adapter is a legitimate state. Conflating would either over-deny (force every component to wire an adapter first) or under-deny (defeat the adapter-trust mitigation). Separate classification expresses the contract correctly.

**Audit log additions:**

- `BYPASS-ALLOW [<slug>] reason=…` for Tier 3 bypassed denies.
- `UNWIRED-NUDGE [<slug>] no commands.<verb> in realms/<realm>/adapters/<comp>.yaml` for the allow-with-nudge path. Recurring entries for the same component signal that wiring would pay back.

7 new tests covering: wired pytest, `python -m pytest` form, wired ruff, missing-adapter-file nudge, missing-commands.verb nudge, outside-component non-fire, bypass-marker override.

## Test plan

- [x] `bash scripts/ws test yggdrasil` → all tests pass (footer + AGENTS.md + adapter-hook + ws-review + dynamic survey, plus follow-up fixes).
- [x] Manual smoke: `bash scripts/ws status` → footer fires on stderr.
- [x] Manual smoke: `bash scripts/ws orient` → footer suppressed.
- [x] Manual smoke: `bash scripts/ws hoard --help` → footer suppressed.
- [ ] Real-session smoke: kick off a fresh session, observe footer, check that the orientation skill loads correctly via the new L0.
- [ ] Hook smoke: try `pytest` inside `components/heimdall/` (no adapter) — should nudge. Try in `components/nordri/` (Makefile-based test adapter wired) — should deny with bypass hint.

## Related

- **Arc:** `gdd-orientation-capability-index` (Loki-thalamus), Phase 1, Tasks 5 + 6 + 7.
- **Plan:** `docs/plans/2026-06-02-gdd-orientation-and-attribution-plan.md`.
- **Design:** `docs/plans/2026-06-02-gdd-orientation-and-attribution-design.md`.
- **Predecessor PRs:** #88 (Task 4a scaffold), #89 (Tasks 4b-4e). Both merged.

## What's left in the arc

- **Task 8** — rework `gdd-orientation` skill via `superpowers:writing-skills`. Calls `ws orient` for facts (drops the prose-restating-orient parts), auto-refreshes `.env` `CLAUDE_MODEL`, extends risk-scan to adapter command strings (the load-bearing counterpart to Task 6).
- **Task D1** — docs sweep across 8 GDD docs (`agent-training.md` largest).

After D1 the arc closes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New component-aware redirect tier: common test/lint commands inside a component now deny and point to the component wrapper (with a session-scoped bypass marker) when the component exposes the matching command.
  * Emits a non-blocking nudge when a component lacks adapter wiring.
  * CLI footer hint after commands: a subtle "switching tasks? ws orient" hint on stderr.

* **Documentation**
  * AGENTS.md condensed to an L0 reflex/wrapper-first contract; hook docs expanded for adapter-redirects; many "ws:use-when" notes added.

* **Tests**
  * Expanded suites covering adapter redirects, bypass flow, orient/subcommand survey, and stderr footer behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
