### PR TITLE
fix(ws-review): resolve realm/hoard targets via ws_validate_component

### DIFF
--- a/scripts/ws-review.sh
+++ b/scripts/ws-review.sh
@@ -753,24 +753,15 @@ if [[ "$COMP" == "help" ]]; then
     exit 0
 fi
 
-# Validate component name (same regex as ws_validate_component)
-if [[ ! "$COMP" =~ ^[a-z]([a-z0-9-]*[a-z0-9])?(\.[a-z]([a-z0-9-]*[a-z0-9])?)*$ ]]; then
-    echo "ERROR: Invalid component name '$COMP'. Must be lowercase alphanumeric with hyphens/dots." >&2
-    exit 1
-fi
-
-# Resolve repo slug from component's remotes.
+# Resolve the target directory via the shared helper — accepts components,
+# realms, hoards, and 'yggdrasil' (workspace root), matching ws commit/push.
+# (Previously hardcoded components/<name>, which broke realm/hoard CR review —
+# the ws_resolve_target gap hit on realm-siliconsaga #9.)
 # Unlike push/issue (which target YOUR fork), review reads CRs that may live
 # on any remote (typically upstream). Strategy: extract the CR number from args,
 # try each remote's slug until the CR is found.
-COMP_DIR="$ROOT_DIR/components/$COMP"
-[[ "$COMP" == "yggdrasil" ]] && COMP_DIR="$ROOT_DIR"
-
-if [[ ! -d "$COMP_DIR" ]] || [[ ! -d "$COMP_DIR/.git" ]]; then
-    echo "ERROR: Component '$COMP' is not cloned locally." >&2
-    echo "  Run 'ws clone $COMP' first." >&2
-    exit 1
-fi
+ws_validate_component "$COMP"
+COMP_DIR="$COMPONENT_DIR"
 
 # Build list of candidate slugs from all remotes, grouped by provider
 _CANDIDATE_SLUGS=()

--- a/scripts/ws-review.sh
+++ b/scripts/ws-review.sh
@@ -763,6 +763,15 @@ fi
 ws_validate_component "$COMP"
 COMP_DIR="$COMPONENT_DIR"
 
+# ws_validate_component guarantees the directory exists, not that it's a git
+# repo. Guard before the git-remote probing below so a bare folder fails with
+# a friendly message instead of a raw git fatal under set -e. rev-parse is
+# worktree-safe where a plain `-d .git` check is not.
+if ! git -C "$COMP_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "ERROR: '$COMP' at $COMP_DIR is not a git repository." >&2
+    exit 1
+fi
+
 # Build list of candidate slugs from all remotes, grouped by provider
 _CANDIDATE_SLUGS=()
 _CANDIDATE_PROVIDERS=()


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @Cervator via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

- `ws review` resolved targets by hardcoding `components/<name>`, so reviewing a CR on a realm or hoard repo failed with "not cloned locally" — hit on realm-siliconsaga #9 (one-off GraphQL workaround) and again on realm-siliconsaga #10. This was the known `ws_resolve_target` backlog gap.
- Swaps the manual resolution (and its duplicated name regex) for the shared `ws_validate_component` helper, which `ws-review.sh` already sourced. Realms, hoards, components, and the yggdrasil root now all resolve, matching `ws commit` / `ws push` / `ws cr` behavior.
- Behavior note: components must now be declared in the merged ecosystem config to be reviewable — same rule as every other `ws` verb (previously any directory under `components/` passed).

## Test plan

- [x] `bash scripts/ws review realm-siliconsaga 10` returns the full review set for the realm CR (previously errored).
- [ ] `bash scripts/ws review <component> <cr#>` still works for a regular declared component.
- [ ] `bash scripts/ws review nosuchthing 1` still errors cleanly via the shared helper's messaging.

## Related

- Thalamus 2026-06-05 audit note: "ws subcommand target-kind generalization" backlog item, validated in practice on realm-siliconsaga #9.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved component-targeting flow to use centralized validation and normalization.
  * Now derives component directories from helper-provided metadata instead of manual path computation.
  * Uses a safer repository/worktree verification before probing remotes and lookups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->