### PR TITLE
docs(gdd): B6 — versioning policy, seeded CHANGELOG, tooling decisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog
+
+All notable changes to the yggdrasil workspace and the `ws` CLI are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project adheres to [Semantic Versioning](https://semver.org/) — see [docs/gdd/versioning.md](docs/gdd/versioning.md) for what is versioned (workspace + `ws` CLI together; methodology docs ride along) and how this file is maintained.
+
+This changelog begins at the 1.0.0 GA push. The pre-1.0 history below is a curated reconstruction from the merged-PR record, grouped by theme rather than exhaustively — full detail lives in git history and the design docs under `docs/plans/`.
+
+## [Unreleased]
+
+This section becomes `1.0.0` when every GA blocker in `docs/plans/2026-06-08-gdd-ga-readiness-design.md` is ✅ and the tag is cut.
+
+### Added
+
+- **The `ws` CLI** — unified workspace verbs (`commit`, `push`, `cr`, `issue`, `review`, `test`, `lint`, `log`, `clone`, `clone-fork`, `pull`, `status`, `exec`, `clean`, `diagnose`, `preflight`, `orient`, and friends) with bodyfile-driven commit/CR/issue flows, Co-Authored-By attribution, fork-aware remote selection, and multi-kind target resolution (components, realms, hoards, the workspace itself) via `ws_resolve_target` (#40, #44, #62, #92, #94).
+- **Realms and hoards** — community config layer (`realms/`, three-layer ecosystem merge, per-component adapters) and personal containers (`hoards/`, thalami + Obsidian-vault flavors, `ws hoard init/list/scan/cadence/upgrade`) with provenance-tracked, plan/apply/rollback template upgrades (#43, #59, #63, #74–#76).
+- **The PreToolUse permission hook** — tiered Bash governance: shell-composition deny, raw-command redirect-to-`ws` with session-scoped human-gated bypass, adapter-aware test/lint redirect, destructive-command ask-tier, settings-allow and per-machine allow-extras; PowerShell matcher coverage (#47, #61, #64, #71, #91, #95).
+- **`ws audit-permissions`** — startup allowlist breadth audit with watchlist severities, ws-wrapper normalization scoped to in-repo paths, and per-machine `[audit-acknowledged]` allowances (#94, #96).
+- **Orientation and discovery** — `ws orient` (subcommand survey, active realm, adapter wiring, skill index), the gdd-orientation startup skill, post-dispatch discoverability footer, and the `ws:use-when` marker convention (#84, #88–#91).
+- **Skills catalog** — workspace skills under `.agent/skills/` (orientation, permissions, scribe, housekeeping, review-triage, mentoring, BDD, zen/quick/flow modes, and more) with the skill→script extraction principle codified (#48, #85).
+- **Thalamus system** — per-machine shared thinking files in a thalami hoard, arcs with cross-host stitching, ArcDashboard with filter/sort controls, commit-cadence nudges (#49, #60, #76).
+- **Component templates and tutorial** — `ws component init` flavors including the flagship gh-pages scaffold-to-live tutorial and getting-started docs (#45, plus the gh-pages tutorial lineage).
+- **Docs site** — `docs/gdd/` methodology pages (features tour, trust and safety, permissions, agent training, organization stack, samples) and the ecosystem/CLI/setup reference docs (#53, #55–#57, #66, #70, #86, #93).
+
+### Changed
+
+- Permission allowlist collapsed from per-arg-count ladders to Claude Code's `:*` prefix form (~200 → ~95 entries), with deliberate pins kept for subcommands whose tightness is intentional (#96).
+- `ws review` side-effect forms (`reply`, `threads … --resolve*`) moved behind the hook's ask-tier — outward-facing review actions now always prompt, while read-only triage stays frictionless (#96).
+- Resolver renamed `ws_validate_component` → `ws_resolve_target` with a kind-neutral miss-message; `ws diagnose` accepts realm/hoard targets (#94).
+- Help handling unified: `--help`/`-h` works at every level for every target-taking subcommand (#94).
+
+### Fixed
+
+- `ws audit-permissions` no longer floods a clean config with false positives (~120 → 0); the genuinely-broad `Bash(ws:*)` catch-all is now detected (#94).
+- Audit normalization rejects foreign and traversal paths masquerading as in-repo wrappers (#96).
+
+## Pre-1.0 archaeology
+
+The workspace evolved through roughly five waves, each anchored by design docs in `docs/plans/`: (1) the `ws` CLI extraction and provider abstraction (PRs ≤ #42); (2) realms, hoards, and component templates (#43–#46); (3) permissions, hook tiers, and skill hygiene (#47–#52, #61, #64, #71–#72); (4) the scribe role, vaults, organization stack, and hoard-upgrade machinery (#53–#76); (5) orientation, attribution, and the GA-readiness push (#83–#96).
+
+[Unreleased]: https://github.com/SiliconSaga/yggdrasil/commits/main

--- a/docs/gdd/index.md
+++ b/docs/gdd/index.md
@@ -90,6 +90,7 @@ The last entry relates to the original more amusing "Dad-Driven-Development" nam
 - [Agent Training](agent-training.md) — the PreToolUse hook, the "scary red" deny output new users see early in a session, why one-action-per-call doesn't double API cost
 - [Access](access.md) — identities, tokens, and remote Git operations (the companion to Permissions)
 - [The Self-Improving Loop](self-improving-loop.md) — how the framework evolves through use
+- [Versioning & Releases](versioning.md) — what is versioned (workspace + `ws` CLI together), the changelog workflow, and the change-note tooling decisions
 - [Organization Stack](organization-stack.md) — four-tier capture model (Vault → Thalami → Docs → GitHub), the scribe and GDD ceremonies, and the Intake bridge
 
 **Design archive:**

--- a/docs/gdd/versioning.md
+++ b/docs/gdd/versioning.md
@@ -1,0 +1,53 @@
+# Versioning & Releases
+
+How the GDD reference implementation is versioned, what a release means, and how change notes are produced — including the tooling decisions for the ongoing workflow.
+
+## What is versioned
+
+**The yggdrasil workspace and the `ws` CLI version together under [SemVer](https://semver.org/),** and the methodology docs (`docs/gdd/`) ride along with that version. One number describes the whole reference implementation: a clone of yggdrasil at tag `X.Y.Z` is a complete, coherent snapshot of the CLI, the hook, the skills, and the docs that describe them.
+
+Everything else versions independently:
+
+- **Realm repos** (e.g. `realm-siliconsaga`) — community config evolves on its own cadence.
+- **Component repos** — their own projects, their own versioning.
+- **Hoard templates** — already carry their own monotonic `version` in the upgrade manifest (`.upgrade/upgrade.yaml`), consumed by `ws hoard upgrade`; that mechanism is independent of the workspace version.
+
+SemVer interpretation for a workspace + CLI:
+
+| Bump | Meaning here |
+|---|---|
+| **Major** | Breaking change to the `ws` CLI surface, the ecosystem/realm/hoard config schema, or the hook contract — something a downstream workspace or realm must adapt to |
+| **Minor** | New subcommands, new skills, new template flavors, backwards-compatible behavior additions |
+| **Patch** | Fixes, docs, de-noising — no new surface |
+
+Pre-1.0 the project deliberately favored clean breaks over compat shims; from 1.0.0 on, breaking changes cost a major bump, which is the point of tagging.
+
+## The changelog
+
+`CHANGELOG.md` at the workspace root follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/): an `[Unreleased]` section accumulates entries grouped under Added / Changed / Fixed / Security, and becomes the next version's section at tag time.
+
+**The changelog is curated, not generated.** Generators draft; a human or agent edits for the reader. The raw material is already good because of two existing conventions: `ws commit` bodyfiles carry conventional-commit-shaped subjects (`fix(ws): …`, `docs(gdd): …`, `feat(hook): …`), and PRs land with descriptive titles and bodies. A changelog entry should say what changed *for the user of the workspace*, not restate the commit log.
+
+### Release ceremony
+
+1. Confirm the suite is green (`ws test yggdrasil`) on main.
+2. Curate `[Unreleased]` → rename to `## [X.Y.Z] - YYYY-MM-DD`, add a fresh empty `[Unreleased]` above it, update the link references at the bottom.
+3. Tag (`git tag -a vX.Y.Z`) and push the tag.
+4. Create the GitHub Release from the tag, pasting the changelog section as the body (optionally augmented by GitHub's auto-generated notes — see below).
+
+## Change-note tooling (the ongoing workflow)
+
+Decision record, so the options don't get re-litigated each release:
+
+- **Input convention: conventional commits — already in place.** `ws commit` subjects use `type(scope): summary`. This is the load-bearing choice: every generator below consumes it. A future `ws commit` lint of the subject shape is a cheap polish item if drift appears.
+- **Drafting: [git-cliff](https://git-cliff.org/) when wanted.** Single static binary (no Node toolchain — fits the bash/yq/jq stack), config-in-repo (`cliff.toml`), parses conventional commits into grouped sections, supports `--unreleased` drafts. Use it to draft the `[Unreleased]` section before a release; curate the output rather than committing it raw. Not a required dependency — the changelog can always be maintained by hand (or by an agent reading `git log`).
+- **Per-repo GitHub Releases: auto-generated notes as a complement.** GitHub's built-in release-notes generation (`.github/release.yml` categories driven by PR labels) is zero-tooling and PR-title-based; good as the "what merged" appendix under the curated changelog section in a Release body.
+- **Not adopted: semantic-release / release-please.** Full release automation (CI computes the version from commit types and publishes) is more machinery than a workspace repo needs, pulls in a Node/bot dependency, and takes the version decision away from the human. Revisit only if release cadence ever makes manual tagging a real cost.
+
+## Stack-level aggregation (roadmap, not GA)
+
+The known hard problem — familiar from Terasology, where engine + dozens of module changelogs had to be aggregated into one release announcement — will show up for the **SiliconSaga stack** (yggdrasil + nordri + mimir + other components shipping together) rather than for GDD itself.
+
+GDD has the ingredient Terasology lacked: **the merged ecosystem config is already a machine-readable manifest of the stack.** That makes the future shape a `ws` verb rather than a bespoke pipeline — e.g. `ws changelog <target>|--stack [--since <tag|date>]`, walking the declared components via `ws_resolve_target`, collecting each repo's conventional commits (or CHANGELOG section) since its last tag, and emitting one grouped stack-level draft. Same skill→script extraction principle as every other `ws` verb: the script gathers deterministically, the human/agent curates.
+
+Parked until a stack release actually needs it; recorded here so the Terasology lesson isn't relearned. Tracked alongside the other deferred CLI ideas in the GA readiness doc (`R6`).

--- a/docs/plans/2026-06-08-gdd-ga-readiness-design.md
+++ b/docs/plans/2026-06-08-gdd-ga-readiness-design.md
@@ -149,7 +149,9 @@ The tutorial is the literal front door for a public launch, and the `tutorial-ne
 
 **Approach:** Run the tutorial pass as its own arc (it already is). Prioritize the adoption section (concrete realm bootstrap walkthrough) and the getting-started `ws`-vs-`bash scripts/ws` consistency, since those are what a public reader trips on first.
 
-### B6 — SemVer + CHANGELOG + release notes — ⬜ Not started
+### B6 — SemVer + CHANGELOG + release notes — ✅ Machinery in place (tag pending the gate)
+
+**Status update (2026-06-11):** versioning unit decided per the recommendation below — workspace + `ws` CLI version together under SemVer, methodology docs ride along, realm/component/hoard-template versioning stays independent. Root `CHANGELOG.md` seeded (Keep a Changelog; `[Unreleased]` becomes `1.0.0` at tag time; curated pre-1.0 archaeology grouped by wave). `docs/gdd/versioning.md` carries the policy, the release ceremony, and the change-note tooling decision record: conventional-commit subjects (already the `ws commit` convention) as the input, git-cliff as the optional no-Node drafting tool, GitHub auto-generated release notes as a per-repo complement, semantic-release/release-please explicitly not adopted. The Terasology-style aggregation problem (engine + modules → one release note; here, the SiliconSaga stack) is parked as a future ecosystem-manifest-driven `ws changelog` verb — recorded in the doc and `R6`. Remaining: the `ws version` subcommand stays optional; cut the `1.0.0` tag when all B* are ✅.
 
 "1.0.0" requires the machinery to make a version mean something. None exists today.
 
@@ -252,6 +254,7 @@ Designed-but-deferred, "defer until evidence of need":
 - **`ws rebase`** utility (Dionysus): script the repeatable rebase ceremony (status → fetch → backup branch → conflict preview → rebase or exit-to-agent if conflicts likely → verify no markers → report + offer backup cleanup).
 - **`ws run <comp> <action>`** dispatcher (Loki): `ws actions` shows per-component adapter commands but doesn't execute them; `ws run` would. Needs the `B1` `ws_resolve_target` helper to accept hoard/realm targets (the `sweethome3d` auto-approve dependency).
 - **`git-issue.sh` querying** (Dionysus): handle *reading* issues, not just creating them (agents currently drop to raw `gh` for this).
+- **`ws changelog <target>|--stack`** (B6 follow-on, 2026-06-11): stack-level change-note aggregation — walk the declared ecosystem components, collect each repo's conventional commits (or CHANGELOG section) since its last tag, emit one grouped draft. The Terasology engine+modules aggregation lesson, solved by the manifest GDD already has. Detail in `docs/gdd/versioning.md` § Stack-level aggregation.
 - **Setup wizard** during orientation / `ws overlay init` (Dionysus onboarding): walk token creation, identity config, remote setup. Companion to `P6`.
 - **`ws realm new` wizard** (Dionysus): interactive realm scaffolding mirroring `ws hoard init` (today realm creation is fork-and-edit on GitHub).
 - **Workspace-wide `ws diagnose`** (Dionysus): aggregate one-shot view (no comp arg) + identity/tools check; the per-repo form already exists.


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @Cervator via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

B6 (SemVer + CHANGELOG + release notes) machinery, following the versioning-unit decision: **the yggdrasil workspace and the `ws` CLI version together under SemVer**, methodology docs ride along, and realms/components/hoard-templates keep their own versioning.

- **`CHANGELOG.md`** (Keep a Changelog): `[Unreleased]` carries the GA-push highlights grouped Added/Changed/Fixed and becomes `1.0.0` at tag time; pre-1.0 history is a curated five-wave reconstruction from the merged-PR record with PR references, not an exhaustive dump.
- **`docs/gdd/versioning.md`**: SemVer interpretation for a workspace+CLI (what bumps major/minor/patch), the curated-not-generated changelog stance, the four-step release ceremony, and a tooling decision record for the ongoing workflow — conventional-commit subjects (already the `ws commit` convention) as the generator input, **git-cliff** as the optional single-binary drafting tool (no Node toolchain), GitHub auto-generated release notes as a per-repo Release-body complement, and semantic-release/release-please explicitly not adopted (full release automation is more machinery than a workspace repo needs and takes the version decision away from the human).
- **Stack-level aggregation parked deliberately**: the Terasology engine+modules aggregation pain is anticipated for the SiliconSaga stack rather than GDD itself; the future shape is a `ws changelog <target>|--stack` verb driven by the merged ecosystem config (the machine-readable manifest Terasology lacked). Recorded in the versioning doc's roadmap section and the GA doc's `R6` list so the lesson isn't relearned.
- GA doc marks **B6 ✅** (machinery in place; the `1.0.0` tag itself waits on the remaining B* gate: B2 cross-platform runs and B5 front door).

## Test plan

- [x] Docs-only change — no code paths touched; `ws test yggdrasil` green on the branch point (336+ tests as of PR #96).
- [x] CHANGELOG PR references spot-checked against `git log --first-parent main`.
- [x] `docs/gdd/index.md` links the new page alongside its siblings.

## Related

- Tracks `docs/plans/2026-06-08-gdd-ga-readiness-design.md` item B6.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive changelog documenting major features, changes, and fixes for the yggdrasil workspace
  * New versioning and release documentation explaining semantic versioning approach, changelog structure, and release ceremony process
  * Updated release planning documentation reflecting versioning and release machinery readiness

<!-- end of auto-generated comment: release notes by coderabbit.ai -->