### PR TITLE
feat(ws): optional shellcheck shell-linting (+ the fixes it found)

### DIFF
--- a/.agent/skills/gdd-branch-workflow/SKILL.md
+++ b/.agent/skills/gdd-branch-workflow/SKILL.md
@@ -157,6 +157,20 @@ git pull siliconsaga main
 git branch -d <type>/<description>
 ```
 
+## Multi-phase work — tracker issues
+
+When a feature spans multiple phases (a design pass plus 3–6 implementation passes), don't try to thread the work through a single CR. Use a **tracker issue** as the canonical "what's left" view, with a phase issue per implementation pass:
+
+- **One tracker issue per multi-phase design.** Label: `tracker`. Body is a markdown task-list with one checkbox per phase. Add a `#N` reference on a checkbox only once that phase's implementation issue exists — so the presence of `#N` doubles as "this phase is ready to claim."
+- **One implementation issue per phase.** Label: `phase`. Linked from the tracker checkbox. GitHub auto-checks the box when the linked issue closes.
+- **The design PR itself** can carry the `rfc` label and link to the tracker in its body so reviewers see the shape of what comes next.
+
+Avoids silent drift between design and implementation, ambiguous "designed but not planned" states, and quiet abandonment of later phases. Live example: `SiliconSaga/knarr#6` (tracker) + `#5` (Phase 1 impl).
+
+## Plan and design docs deserve CR review
+
+Even "docs-only" PRs benefit from full CR (CodeRabbit, Copilot, or the equivalent) when the doc surface is substantial — design docs, implementation plans, or any markdown carrying copy-pastable code blocks. Plan-doc code samples drift from reality during authoring and are easy to introduce real correctness bugs into; reviewers catch them. For a meaty plan, budget 3–4 review rounds, not 1, and use the round-by-round fix-bodyfile commit pattern so each rebuttal is auditable.
+
 ## Key Notes
 
 - Always use `ws push` rather than plain `git push` — it handles remote

--- a/scripts/setup-branch-protection.sh
+++ b/scripts/setup-branch-protection.sh
@@ -26,9 +26,6 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-ENV_FILE="$SCRIPT_DIR/../.env"
-
 if [[ -z "${GH_TOKEN:-}" ]]; then
   echo "ERROR: GH_TOKEN not set." >&2
   echo "  This script requires an admin-scoped token, not the agent PAT." >&2

--- a/scripts/ws
+++ b/scripts/ws
@@ -564,7 +564,11 @@ HELP
     echo "  Token coverage:"
     while IFS= read -r remote; do
         local url
-        url=$(git -C "$comp_dir" remote get-url "$remote" 2>/dev/null || continue)
+        # `continue` must be outside the $() — inside it only exits the subshell,
+        # leaving url='' and printing a bogus empty-URL row instead of skipping.
+        if ! url=$(git -C "$comp_dir" remote get-url "$remote" 2>/dev/null); then
+            continue
+        fi
 
         local provider
         provider=$(gp_detect "$url" "$eco" 2>/dev/null) || provider="unknown"

--- a/scripts/ws-hoard-upgrade.sh
+++ b/scripts/ws-hoard-upgrade.sh
@@ -118,14 +118,14 @@ _ws_hoard_upgrade_plan() {
     # `rm -f` (which skips directories), so the plan only flags what apply can
     # actually remove — a directory entry would otherwise show in the plan but
     # be silently skipped on apply.
-    local fn fi rel
+    local fn fidx rel
     fn="$(yq '.files_remove // [] | length' "$upgrade_yaml")"
-    fi=0
-    while [[ $fi -lt $fn ]]; do
-        rel="$(yq ".files_remove[$fi]" "$upgrade_yaml")"
+    fidx=0
+    while [[ $fidx -lt $fn ]]; do
+        rel="$(yq ".files_remove[$fidx]" "$upgrade_yaml")"
         [[ -e "$hoard_dir/$rel" && ! -d "$hoard_dir/$rel" ]] \
             && printf 'destructive\tremove %s\n' "$rel"
-        fi=$((fi+1))
+        fidx=$((fidx+1))
     done
 
     # core_plugins_disable: destructive when currently enabled.
@@ -474,8 +474,8 @@ _ws_hoard_apply_manifest() {
             local _migrate_tmp
             _migrate_tmp="$(mktemp)"
             sed \
-                -e "s|<!-- BEGIN upgrade:$marker_id -->|$begin_marker|g" \
-                -e "s|<!-- END upgrade:$marker_id -->|$end_marker|g" \
+                -e "s|$legacy_begin|$begin_marker|g" \
+                -e "s|$legacy_end|$end_marker|g" \
                 "$_migrate_target" > "$_migrate_tmp" 2>/dev/null \
                 && mv "$_migrate_tmp" "$_migrate_target" \
                 || rm -f "$_migrate_tmp"

--- a/scripts/ws-lint.sh
+++ b/scripts/ws-lint.sh
@@ -35,6 +35,10 @@ lint_help() {
         echo "what's configured). Extra args pass through to the linter:"
         echo "  ws lint knarr"
         echo "  ws lint knarr --fix"
+        echo ""
+        echo "Shell linting (shellcheck — optional, skipped if not installed):"
+        echo "  ws lint                  shellcheck the ws CLI (scripts/)"
+        echo "  ws lint --shell <path>   shellcheck given files/dirs"
     } >&"$stream"
 }
 
@@ -45,9 +49,16 @@ if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
     exit 0
 fi
 
-if [[ $# -lt 1 ]]; then
-    lint_help 2
-    exit 1
+# No component → lint the workspace's own shell scripts (the ws CLI itself).
+# `ws lint --shell [paths...]` → shellcheck arbitrary shell paths (realm/component
+# tooling). Both delegate to the optional shellcheck helper (a no-op + nag if the
+# tool isn't installed), keeping shell lint orthogonal to the adapter path below.
+if [[ $# -eq 0 ]]; then
+    exec bash "$SCRIPT_DIR/ws-shellcheck.sh"
+fi
+if [[ "$1" == "--shell" ]]; then
+    shift
+    exec bash "$SCRIPT_DIR/ws-shellcheck.sh" "$@"
 fi
 
 comp="$1"

--- a/scripts/ws-preflight.sh
+++ b/scripts/ws-preflight.sh
@@ -31,7 +31,8 @@ install hints for your OS.
 Required: bash, git, yq (v4+, mikefarah/yq specifically), jq.
 Provider: at least one of gh (GitHub) or glab (GitLab).
 Recommended (optional): uv (for MCP servers and Python components),
-realpath (path canonicalization on macOS — usually present).
+realpath (path canonicalization on macOS — usually present),
+shellcheck (optional shell linting for the ws CLI and tooling scripts).
 HELP
     exit 0
 fi

--- a/scripts/ws-preflight.sh
+++ b/scripts/ws-preflight.sh
@@ -80,6 +80,7 @@ hint_for() {
         mac:glab)         echo "'brew install glab'." ;;
         mac:uv)           echo "'brew install uv' or 'curl -LsSf https://astral.sh/uv/install.sh | sh'." ;;
         mac:realpath)     echo 'Usually present via coreutils. If missing: "brew install coreutils" (then use "grealpath", or add the gnubin to PATH: PATH="$(brew --prefix coreutils)/libexec/gnubin:$PATH").' ;;
+        mac:shellcheck)   echo "'brew install shellcheck'." ;;
 
         linux:bash)       echo "Should be present. Most distros ship bash by default." ;;
         linux:git)        echo "'sudo apt install git' (Debian/Ubuntu) or 'sudo dnf install git' (Fedora)." ;;
@@ -89,6 +90,7 @@ hint_for() {
         linux:glab)       echo "Download from https://gitlab.com/gitlab-org/cli/-/releases — distro packages are spotty." ;;
         linux:uv)         echo "'curl -LsSf https://astral.sh/uv/install.sh | sh'." ;;
         linux:realpath)   echo "Usually present via coreutils. 'sudo apt install coreutils' if missing." ;;
+        linux:shellcheck) echo "'sudo apt install shellcheck' (Debian/Ubuntu) or 'sudo dnf install ShellCheck' (Fedora)." ;;
 
         windows:bash)     echo "Use Git Bash (bundled with Git for Windows). Run all 'ws' commands from a Git Bash shell, not cmd.exe or PowerShell." ;;
         windows:git)      echo "'winget install Git.Git' (includes Git Bash). https://git-scm.com/download/win is the manual installer." ;;
@@ -98,6 +100,7 @@ hint_for() {
         windows:glab)     echo "'winget install GLab.GLab'. Fallback: download from https://gitlab.com/gitlab-org/cli/-/releases." ;;
         windows:uv)       echo "'winget install astral-sh.uv'. Fallback: 'powershell -c \"irm https://astral.sh/uv/install.ps1 | iex\"'." ;;
         windows:realpath) echo "Comes with Git Bash; if missing, reinstall Git for Windows." ;;
+        windows:shellcheck) echo "'winget install koalaman.shellcheck'. Fallback: 'choco install shellcheck' from elevated PowerShell." ;;
 
         *) echo "See https://github.com/mikefarah/yq, https://cli.github.com, etc., for install instructions on your platform." ;;
     esac
@@ -166,8 +169,9 @@ check_tool glab provider
 
 echo ""
 echo "Optional (only needed for specific component types):"
-check_tool uv       optional
-check_tool realpath optional
+check_tool uv         optional
+check_tool realpath   optional
+check_tool shellcheck optional
 
 echo ""
 

--- a/scripts/ws-shellcheck.sh
+++ b/scripts/ws-shellcheck.sh
@@ -21,17 +21,21 @@ set -euo pipefail
 SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 strict=0
-sc_args=(-x --severity=warning)
+severity="warning"
+sc_args=(-x)
 paths=()
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --strict)   strict=1; shift ;;
-        --pedantic) sc_args=(-x --severity=style); shift ;;
-        --help|-h)  sed -n '2,21p' "${BASH_SOURCE[0]}"; exit 0 ;;
+        --pedantic) severity="style"; shift ;;
+        --help|-h)  sed -n '2,18p' "${BASH_SOURCE[0]}"; exit 0 ;;
         --*)        sc_args+=("$1"); shift ;;   # passthrough other shellcheck flags
         *)          paths+=("$1"); shift ;;
     esac
 done
+# Append severity last so --pedantic stays order-independent and doesn't clobber
+# any passthrough --* flags collected above.
+sc_args+=(--severity="$severity")
 [[ ${#paths[@]} -eq 0 ]] && paths=("$SELF_DIR")
 
 if ! command -v shellcheck >/dev/null 2>&1; then

--- a/scripts/ws-shellcheck.sh
+++ b/scripts/ws-shellcheck.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# ws-shellcheck.sh — Optional static lint of shell scripts via shellcheck.
+# ws:use-when statically linting bash (the ws CLI itself, realm/component tooling)
+#
+# Detect-and-run: if shellcheck is installed, lint the given paths; if not, print a
+# one-line setup recommendation and skip (exit 0) so a machine without it is never
+# blocked. Runs with `-x` (follow `source`d files) and `--severity=warning` so the
+# signal is real bugs, not style/info noise — pass --pedantic to widen to everything.
+# Opt into hard failure when shellcheck is absent with --strict (for CI).
+#
+# Env:
+#   WS_SHELLCHECK_QUIET=1   silence the "not installed" recommendation
+#
+# Usage:
+#   ws-shellcheck.sh [--strict] [--pedantic] [shellcheck-flags...] [path ...]
+#     path: a file (checked directly) or a dir (searched for *.sh plus extensionless
+#     files with a sh/bash shebang — so the `ws` dispatcher is covered). Default: the
+#     workspace 'scripts/' dir (the ws CLI).
+
+set -euo pipefail
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+strict=0
+sc_args=(-x --severity=warning)
+paths=()
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --strict)   strict=1; shift ;;
+        --pedantic) sc_args=(-x --severity=style); shift ;;
+        --help|-h)  sed -n '2,21p' "${BASH_SOURCE[0]}"; exit 0 ;;
+        --*)        sc_args+=("$1"); shift ;;   # passthrough other shellcheck flags
+        *)          paths+=("$1"); shift ;;
+    esac
+done
+[[ ${#paths[@]} -eq 0 ]] && paths=("$SELF_DIR")
+
+if ! command -v shellcheck >/dev/null 2>&1; then
+    if [[ "${WS_SHELLCHECK_QUIET:-0}" != 1 ]]; then
+        echo "note: shellcheck not installed — skipping shell lint (optional)." >&2
+        echo "      add it for an extra layer of bash checks: 'brew install shellcheck'" >&2
+        echo "      (Linux/Windows hints: 'ws preflight'). Silence: WS_SHELLCHECK_QUIET=1." >&2
+    fi
+    [[ "$strict" == 1 ]] && exit 1
+    exit 0
+fi
+
+# Resolve paths -> concrete files. The two finds are disjoint (has-.sh vs extensionless),
+# so no de-dup is needed. The shebang match catches the extensionless `ws` dispatcher.
+files=()
+for p in "${paths[@]}"; do
+    if [[ -f "$p" ]]; then
+        files+=("$p")
+    elif [[ -d "$p" ]]; then
+        while IFS= read -r f; do files+=("$f"); done < <(
+            find "$p" -type f -name '*.sh'
+            find "$p" -type f ! -name '*.*' -exec sh -c 'head -n1 "$1" | grep -qE "^#!.*[ /](ba)?sh($| )" && printf "%s\n" "$1"' _ {} \;
+        )
+    else
+        echo "warning: '$p' not found — skipping." >&2
+    fi
+done
+
+if [[ ${#files[@]} -eq 0 ]]; then
+    echo "ws-shellcheck: no shell scripts found in: ${paths[*]}"
+    exit 0
+fi
+
+echo "ws-shellcheck: linting ${#files[@]} script(s) [${sc_args[*]}]…"
+shellcheck "${sc_args[@]}" "${files[@]}"


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @Cervator via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## What

Adopt **shellcheck** as an optional, defense-in-depth lint layer for our bash — the
ws CLI itself and realm/component shell tooling — and fix the issues it immediately
surfaced. No single linter catches everything; this stacks shellcheck onto review.

## Commits

1. **Tooling** — `scripts/ws-shellcheck.sh` (detect-and-run helper) wired into:
   - `ws lint` (no component) → shellchecks the CLI (`scripts/`); `ws lint --shell <paths>` → arbitrary files/dirs.
   - `ws preflight` → lists shellcheck as optional with per-OS install hints.
   - Optional by design: if shellcheck isn't installed it prints a one-line setup
     recommendation and skips (exit 0) — never blocks. `--strict` opts into hard
     failure for CI; `WS_SHELLCHECK_QUIET=1` silences the note. Default gate is
     `-x --severity=warning` (real bugs, not style/info noise).
2. **Fixes** the four warnings `ws lint` found — all real:
   - `ws` **SC2106**: `url=$(… || continue)` ran `continue` inside the `$()` subshell,
     so a URL-less remote produced an empty bogus token-coverage row instead of being
     skipped. Moved the skip outside the subshell.
   - `setup-branch-protection.sh` **SC2034**: removed a vestigial `ENV_FILE`/`SCRIPT_DIR`
     pair (never used; the script reads `GH_TOKEN` from the env).
   - `ws-hoard-upgrade.sh` **SC1010**: `local fn fi rel` declared a var named `fi`; renamed to `fidx`.
   - `ws-hoard-upgrade.sh` **SC2034**: wired the unused `legacy_end` into the migration `sed` it belonged to.
3. **Docs** — folds in two previously-uncommitted `gdd-branch-workflow` skill sections
   (tracker issues for multi-phase work; plan-docs deserve CR review). Verified not duplicated elsewhere.

## Verification

- `ws lint` is clean after the fixes (30 CLI scripts, warning severity).
- Helper paths exercised: happy run, clean run, not-installed nag, `WS_SHELLCHECK_QUIET`, `--strict` (exit 1), `--help`.
- `ws preflight` shows `✓ shellcheck`. `bash -n` passes on all edited scripts.

## Follow-ups (not in this PR)

- A CI step (`ws lint --strict`) on the ws scripts.
- Optionally a pre-commit hook for changed `*.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional shell script linting via `ws lint`, including a default run when no component is provided.
  * Introduced `--shell` to lint specific paths, backed by a new shellcheck wrapper.
  * Updated preflight checks and hints to include shellcheck as an optional prerequisite.
* **Bug Fixes**
  * Improved diagnostics to reliably skip remotes when remote URL lookups fail.
* **Documentation**
  * Expanded guidance for multi-phase work tracking and clarified documentation drift/CR review expectations.
* **Chores**
  * Simplified branch protection setup and refined upgrade/migration marker handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->