### PR TITLE
docs(ecosystem): document the vendor component role

### DIFF
--- a/docs/ecosystem-architecture.md
+++ b/docs/ecosystem-architecture.md
@@ -45,6 +45,8 @@ Arrows read as **"provides the foundation for"** — each tier only knows about 
 | **2** | Platform services | `nidavellir` (platform app-of-apps), plus capability components like observability / data / notifications |
 | **3** | End-user applications | The apps real people actually interact with |
 
+Tiers 1–3 are *deployable* tiers — they describe where a component sits in the stack's dependency chain. A realm's `ecosystem.yaml` may also declare components in two **non-stack roles** that sit outside this chain: `test` (throwaway fixtures that validate the tooling itself, e.g. SiliconSaga's `echo-test`) and `vendor` (third-party mirrors — see below).
+
 For the concrete SiliconSaga stack — what's in each tier, the GitOps model, the alert pipeline, the cluster-identity pattern — see the realm-side narrative at [SiliconSaga/realm-siliconsaga: `docs/stack.md`](https://github.com/SiliconSaga/realm-siliconsaga/blob/main/docs/stack.md) (and the per-tier docs alongside it). If you've cloned the realm via `ws realm`, the same file is at `realms/realm-siliconsaga/docs/stack.md` locally. Other realms describe their own stacks the same way.
 
 ## Workspace Structure
@@ -116,6 +118,23 @@ The `scripts/ws-resolve.sh` script auto-detects which mode applies per component
 - `forceChart: true` — use chart even when local source exists
 - Override `values:` for local environment specifics
 - Toggle `disabled` to include/exclude components
+
+## Vendored Mirrors (`tier: vendor`)
+
+Sometimes a realm needs to deploy manifests it does **not** author — an upstream operator's CRDs + controller, a third-party chart's raw YAML, anything where the bytes are owned elsewhere but a GitOps deploy needs them at a pinned version. The naive options both have real costs:
+
+- **Vendor the files into a component repo you maintain.** A single operator's CRDs can be tens of thousands of lines. They dwarf your own code on contribution/LOC stats, bloat code-review (and review-bot context budgets), and can choke IDE/agent indexers — all for bytes you never edit and review adds nothing to.
+- **Sync ArgoCD straight from the upstream GitHub URL.** Reproducibility now depends on the internet and on an upstream tag staying immutable, and a foundational app reaches outside your trust boundary on every refresh.
+
+The `vendor` role is the third option: a realm declares the upstream repo as its own component (`tier: vendor`), held as an **individual, intact mirror** — full history and tags — under the realm's org. The bytes live in a dedicated repo that *isn't one you maintain*, so they never touch your maintained repos' stats, review surface, or local indexers, while staying first-class in the workspace:
+
+- **`ws clone`** fetches the mirror naturally alongside every other component, so a from-scratch workspace gets it without special steps.
+- **Hydration** (the GitOps source-of-truth push — SiliconSaga's seed-Gitea flow) pushes the mirror's *real history and tags* (not the orphan-commit snapshot used for maintained repos), so an in-cluster ArgoCD app can pin an exact upstream tag (`targetRevision: <tag>`) against the local copy.
+- **Updating** is re-syncing the mirror from upstream and bumping the pin — the same deliberate, auditable upgrade ceremony as vendoring, just relocated out of the maintained tree.
+
+A vendor mirror is **read-only**: never commit local edits to it (that would fork it from upstream). If you need to modify upstream manifests, that's a real component you maintain, not a mirror. Whether mirrors stay manually re-synced or become self-maintaining (e.g. a platform Git host's native pull-mirror feature) is a realm-infrastructure choice, not a GDD-framework concern.
+
+> SiliconSaga worked example: the Keycloak operator ships as the `keycloak-k8s-resources` vendor mirror, pinned to a tag by Nidavellir's `keycloak-operator` ArgoCD app — keeping ~18k lines of operator CRD schema out of the Nidavellir repo entirely. Upstream Yggdrasil declares no vendor components itself; the role exists in the framework for any realm to use.
 
 ## Related Docs
 

--- a/docs/ecosystem-architecture.md
+++ b/docs/ecosystem-architecture.md
@@ -130,6 +130,7 @@ The `vendor` role is the third option: a realm declares the upstream repo as its
 
 - **`ws clone`** fetches the mirror naturally alongside every other component, so a from-scratch workspace gets it without special steps.
 - **Hydration** (the GitOps source-of-truth push — SiliconSaga's seed-Gitea flow) pushes the mirror's *real history and tags* (not the orphan-commit snapshot used for maintained repos), so an in-cluster ArgoCD app can pin an exact upstream tag (`targetRevision: <tag>`) against the local copy.
+- **Not an ArgoCD app itself.** `ws-resolve` skips `tier: vendor` components (alongside `supporting`/`test`) — a mirror is a *source repo*, not a deployable, so no `Application` is generated for it. It reaches a cluster only through a *real* component's app that pins it (e.g. `repoURL: <git-host>/<mirror>.git`, `targetRevision: <tag>`); the pin lives on that consuming app, not in `ecosystem.yaml`.
 - **Updating** is re-syncing the mirror from upstream and bumping the pin — the same deliberate, auditable upgrade ceremony as vendoring, just relocated out of the maintained tree.
 
 A vendor mirror is **read-only**: never commit local edits to it (that would fork it from upstream). If you need to modify upstream manifests, that's a real component you maintain, not a mirror. Whether mirrors stay manually re-synced or become self-maintaining (e.g. a platform Git host's native pull-mirror feature) is a realm-infrastructure choice, not a GDD-framework concern.

--- a/scripts/ws-resolve.sh
+++ b/scripts/ws-resolve.sh
@@ -57,8 +57,11 @@ resolve_component() {
     local tier namespace chart_version chart_name path sync_wave force_chart values_yaml
     tier=$(yq ".components[\"$name\"].tier" "$EFFECTIVE_FILE")
 
-    # Skip non-deployable components (supporting, test, or no tier)
-    if [[ "$tier" == "supporting" || "$tier" == "test" || "$tier" == "null" ]]; then
+    # Skip non-deployable components. `vendor` mirrors are NOT ArgoCD apps —
+    # they're upstream source repos consumed by hydration (their refs land in
+    # the seed Git host) and pinned by a real app's repoURL/targetRevision, so
+    # ws-resolve must not generate an Application for them.
+    if [[ "$tier" == "supporting" || "$tier" == "test" || "$tier" == "vendor" || "$tier" == "null" ]]; then
         echo "SKIP: $name (tier: $tier, not deployable)"
         return 0
     fi


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @Cervator via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

- Document the `vendor` component role in the framework-level ecosystem docs. The realm ecosystem config grew this role during the SiliconSaga Keycloak work (third-party upstream mirrors held at arm's length so their bytes never inflate maintained repos' stats/review/indexers, while staying GitOps-reproducible), but `docs/ecosystem-architecture.md` only described the deployable 1/2/3 tiers.
- Adds: a note that `tier` accepts **non-stack roles** (`test`, `vendor`) beyond the deployable chain, and a **Vendored Mirrors** section covering the why, the how (`ws clone` + hydration pushing history+tags + ArgoCD tag-pin), and the read-only rule. SiliconSaga's `keycloak-k8s-resources` is the worked example; upstream Yggdrasil ships no vendor components itself — the role exists in the framework for any realm.

## Test plan

- [x] Doc-only; renders/links check (the new section references existing concepts already in the doc)

## Related

- Realm-side mechanics: SiliconSaga/realm-siliconsaga (`tier: vendor` ecosystem entry) + SiliconSaga/nordri (hydration support)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the three-tier deployment model, specifying deployable tiers and documenting additional non-stack roles like `test` and `vendor`.
  * Added a new guide for “vendored mirrors,” including a realm-based pattern for deploying byte-identical upstream content and managing updates via version pinning.
* **Bug Fixes**
  * Updated release resolution so components marked as `tier: vendor` are treated as non-deployable and no longer produce deployment application manifests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->