### PR TITLE
feat(ws): push tags and generic agent attribution

### DIFF
--- a/.agent/skills/gdd-orientation/SKILL.md
+++ b/.agent/skills/gdd-orientation/SKILL.md
@@ -149,17 +149,19 @@ You know your own running model. Read `.env` if it exists. Find:
 export GDD_CO_AUTHOR="${GDD_CO_AUTHOR:-Claude Opus 4.8 <noreply@anthropic.com>}"
 ```
 
-If the default identity differs from your running agent/model, rewrite **just that default string**. Preserve the `${GDD_CO_AUTHOR:-…}` shape so inline overrides still win:
+If the default identity differs from your running agent/model, **propose the change and wait for explicit confirmation before writing** — `.env` holds tokens, so never rewrite it silently. Surface the proposed one-line edit (preserving the `${GDD_CO_AUTHOR:-…}` shape so inline overrides still win):
+
+> "Your `.env` `GDD_CO_AUTHOR` default is `Claude Opus 4.8 <…>`, but I'm running as Codex GPT-5. Update just that default to `Codex GPT-5 <noreply@openai.com>`? Only that one line changes."
+
+On a yes, rewrite **only the default token** inside the `${GDD_CO_AUTHOR:-…}` form:
 
 ```bash
-GDD_CO_AUTHOR="Codex GPT-5 <noreply@openai.com>"
+export GDD_CO_AUTHOR="${GDD_CO_AUTHOR:-Codex GPT-5 <noreply@openai.com>}"
 ```
 
-One-line ack to the human:
+If they decline (or don't answer), leave `.env` alone and use the inline override at commit time instead — never block the session on it.
 
-> "Refreshed `.env` GDD_CO_AUTHOR default → `Codex GPT-5 <noreply@openai.com>`."
-
-**Skip this step if you're a sub-agent.** Parallel sub-agents would race on the same file. Sub-agents use the inline override at commit time (per `ws commit --help`).
+**Skip this step entirely if you're a sub-agent.** Parallel sub-agents would race on the same file. Sub-agents use the inline override at commit time (per `ws commit --help`).
 
 ### Trust verification
 

--- a/.agent/skills/gdd-orientation/SKILL.md
+++ b/.agent/skills/gdd-orientation/SKILL.md
@@ -141,23 +141,23 @@ Session-scoped only. Don't update Thalamus frontmatter unless the human asks.
 
 If they decline or don't respond, continue at the current mode without further mention. Ask once.
 
-### CLAUDE_MODEL refresh (main agent only)
+### Commit attribution refresh (main agent only)
 
 You know your own running model. Read `.env` if it exists. Find:
 
 ```bash
-export CLAUDE_MODEL="${CLAUDE_MODEL:-Opus 4.8}"
+export GDD_CO_AUTHOR="${GDD_CO_AUTHOR:-Claude Opus 4.8 <noreply@anthropic.com>}"
 ```
 
-If the default token (`Opus 4.8` above) differs from your running model name, rewrite **just that token**. Preserve the `${CLAUDE_MODEL:-…}` shape so inline overrides still win:
+If the default identity differs from your running agent/model, rewrite **just that default string**. Preserve the `${GDD_CO_AUTHOR:-…}` shape so inline overrides still win:
 
 ```bash
-CLAUDE_MODEL="Sonnet 4.6" ws commit <comp> <bodyfile>
+GDD_CO_AUTHOR="Codex GPT-5 <noreply@openai.com>"
 ```
 
 One-line ack to the human:
 
-> "Refreshed `.env` CLAUDE_MODEL default → `Opus 4.8`."
+> "Refreshed `.env` GDD_CO_AUTHOR default → `Codex GPT-5 <noreply@openai.com>`."
 
 **Skip this step if you're a sub-agent.** Parallel sub-agents would race on the same file. Sub-agents use the inline override at commit time (per `ws commit --help`).
 

--- a/.env.example
+++ b/.env.example
@@ -18,9 +18,13 @@ export GH_TOKEN=ghp_xxxxxxxxxxxx
 export GH_USER=your-github-username
 
 # ── Commit attribution ───────────────────────────────────────
-# Model name used in the ws commit Co-Authored-By trailer (ws-commit.sh).
-# The :- form supplies a default but still lets an inline override pass
-# through, e.g. CLAUDE_MODEL="Sonnet 4.6" ws commit … for a sub-agent.
+# Full identity used in the ws commit Co-Authored-By trailer.
+# This is agent-neutral: Codex/Gemini/Claude sessions can set their own
+# identity without changing ecosystem config.
+export GDD_CO_AUTHOR="${GDD_CO_AUTHOR:-Claude Opus 4.8 <noreply@anthropic.com>}"
+
+# Legacy fallback used when GDD_CO_AUTHOR is unset. Kept for existing Claude
+# workflows and inline sub-agent overrides.
 export CLAUDE_MODEL="${CLAUDE_MODEL:-Opus 4.8}"
 
 # ── GitLab ───────────────────────────────────────────────────

--- a/docs/gdd/permissions.md
+++ b/docs/gdd/permissions.md
@@ -62,7 +62,7 @@ The `ws hook-bypass <slug>` subcommand itself is on the ask-list — every invoc
 
 See `.claude/hooks/README.md` § Redirect tier and bypass for the operator-facing details.
 
-### Bounded `CLAUDE_MODEL=` attribution prefix
+### Bounded legacy `CLAUDE_MODEL=` attribution prefix
 
 `ws commit`, `ws test`, and `ws lint` are allowlisted by default in this workspace's `.claude/settings.json` — they no longer need to be hand-added per machine. The `ws commit` allow patterns come in four forms:
 
@@ -75,7 +75,7 @@ Bash(CLAUDE_MODEL=* bash scripts/ws commit:*)
 
 The `:*` suffix here is Claude Code's *prefix* form — it matches the command plus any argument tail, not a single argument slot (see [Pattern shapes → Colon-prefix](#colon-prefix-cmd) below). Both the `ws commit` and `bash scripts/ws commit` bare forms are listed because that prefix match is anchored at the start of the string, so neither covers the other dispatch form; listing both keeps the command auto-approving under Claude Code's native matcher too — i.e. when this hook is disabled or passes through and only the literal settings patterns apply.
 
-The `CLAUDE_MODEL=*` forms exist because sub-agents attribute commits by prepending the model inline — `CLAUDE_MODEL="Sonnet 4.6" ws commit <comp> <bodyfile>` — rather than rewriting the shared `.env` (which would race across parallel sub-agents). See [`ws commit` attribution in the CLI guide](../ws-cli-guide.md#ws-commit) for the resolution rules.
+The `CLAUDE_MODEL=*` forms are a legacy Claude compatibility path. New cross-agent work should prefer `GDD_CO_AUTHOR` in `.env` as the primary workspace default, with `identity.co_authored_by` reserved for pinned static overrides. See [`ws commit` attribution in the CLI guide](../ws-cli-guide.md#ws-commit) for the resolution rules.
 
 To make the prefixed form auto-approve cleanly, the PreToolUse hook (`strip_claude_model_prefix` in `.claude/hooks/gdd-permission-hook.sh`) strips a **single** leading `CLAUDE_MODEL=<value>` assignment (quoted or unquoted) from the command **before** allow/redirect matching. The strip is applied to the MATCH copy of the command only — never the executed command, never the audit log. Two consequences fall out of this:
 

--- a/docs/ws-cli-guide.md
+++ b/docs/ws-cli-guide.md
@@ -216,7 +216,7 @@ The `Co-Authored-By` trailer name resolves as:
 export GDD_CO_AUTHOR="${GDD_CO_AUTHOR:-Claude Opus 4.8 <noreply@anthropic.com>}"
 ```
 
-Keep `.env` current with the agent/model the workspace primarily commits as, rather than prepending identity variables on every commit. `GDD_CO_AUTHOR` must include an email in angle brackets, for example `Codex GPT-5 <noreply@openai.com>`. If `.env` is absent, `ws-commit.sh` falls back to `Claude Opus 4.8 <noreply@anthropic.com>`. The resolved value only feeds the trailer string and is newline-sanitized — it is never evaluated as a command.
+Keep `.env` current with the agent/model the workspace primarily commits as, rather than prepending identity variables on every commit. `GDD_CO_AUTHOR` must include an email in angle brackets, for example `Codex GPT-5 <noreply@openai.com>`. The fallback is whatever the resolution order above lands on from the *process* environment, not a fixed string: with `.env` absent, a `GDD_CO_AUTHOR` exported in the shell still wins, and failing that the legacy `Claude $CLAUDE_MODEL <noreply@anthropic.com>` form is used (`CLAUDE_MODEL` itself only defaults to `Opus 4.8` when it too is unset). The resolved value only feeds the trailer string and is newline-sanitized — it is never evaluated as a command.
 
 `CLAUDE_MODEL` remains as a legacy fallback for existing Claude-only workspaces when `GDD_CO_AUTHOR` is unset:
 

--- a/docs/ws-cli-guide.md
+++ b/docs/ws-cli-guide.md
@@ -207,25 +207,32 @@ A post-dispatch stderr footer on every other `ws` subcommand keeps `ws orient` d
 The `Co-Authored-By` trailer name resolves as:
 
 1. `identity.co_authored_by` from the merged ecosystem config, **if set** — a realm or local override can pin a fixed attribution string.
-2. Otherwise `"Claude $CLAUDE_MODEL"`.
+2. `GDD_CO_AUTHOR` from the environment or workspace `.env`, **if set** — the generic full trailer identity for the current agent.
+3. Otherwise the legacy Claude fallback, `"Claude $CLAUDE_MODEL <noreply@anthropic.com>"`.
 
-`CLAUDE_MODEL` is auto-sourced from `.env` at the workspace root. The shipped default (see `.env.example`) is:
+`GDD_CO_AUTHOR` is auto-sourced from `.env` at the workspace root. The shipped default (see `.env.example`) is:
+
+```bash
+export GDD_CO_AUTHOR="${GDD_CO_AUTHOR:-Claude Opus 4.8 <noreply@anthropic.com>}"
+```
+
+Keep `.env` current with the agent/model the workspace primarily commits as, rather than prepending identity variables on every commit. `GDD_CO_AUTHOR` must include an email in angle brackets, for example `Codex GPT-5 <noreply@openai.com>`. If `.env` is absent, `ws-commit.sh` falls back to `Claude Opus 4.8 <noreply@anthropic.com>`. The resolved value only feeds the trailer string and is newline-sanitized — it is never evaluated as a command.
+
+`CLAUDE_MODEL` remains as a legacy fallback for existing Claude-only workspaces when `GDD_CO_AUTHOR` is unset:
 
 ```bash
 export CLAUDE_MODEL="${CLAUDE_MODEL:-Opus 4.8}"
 ```
 
-Keep `.env` current with the model the workspace primarily commits as, rather than prepending `CLAUDE_MODEL` on every commit. If `.env` is absent, `ws-commit.sh` falls back to a hardcoded default (also `Opus 4.8`). The resolved value only feeds the trailer string and is newline-sanitized — it is never evaluated as a command.
-
 ### Sub-agent override rule
 
-A sub-agent running on a **non-default** model (e.g. Sonnet while the workspace default is Opus) should prepend the model **inline** for that one commit:
+A sub-agent running on a **non-default** model should prepend the full identity **inline** for that one commit:
 
 ```bash
-CLAUDE_MODEL="Sonnet 4.6" ws commit <comp> <bodyfile>
+GDD_CO_AUTHOR="Claude Sonnet 4.6 <noreply@anthropic.com>" ws commit <comp> <bodyfile>
 ```
 
-Inline is the correct mechanism for sub-agents. Do **not** rewrite the shared `.env` to change attribution for a single commit — parallel sub-agents rewriting the same file would race. The inline prefix is allowlisted (`Bash(CLAUDE_MODEL=* ws commit:*)`); see [the bounded `CLAUDE_MODEL=` prefix in the permissions reference](gdd/permissions.md#bounded-claude_model-attribution-prefix) for why this specific prefix auto-approves while arbitrary env prefixes do not.
+Inline is the correct mechanism for sub-agents. Do **not** rewrite the shared `.env` to change attribution for a single commit — parallel sub-agents rewriting the same file would race. Claude-only legacy sub-agents may still use the bounded `CLAUDE_MODEL=` prefix while that compatibility path remains; see [the bounded `CLAUDE_MODEL=` prefix in the permissions reference](gdd/permissions.md#bounded-claude_model-attribution-prefix).
 
 ## ws component init
 

--- a/scripts/git-push.sh
+++ b/scripts/git-push.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
-# git-push.sh — push a branch to a named remote
+# git-push.sh — push a branch or tag to a named remote
 #
-# Usage: git-push.sh [--force] [branch]
-#   --force — force push (for rebased branches). Refuses to force-push main/master.
-#   branch  — branch to push (default: current branch)
+# Usage: git-push.sh [--force] [branch|tag]
+#   --force    — force push a branch (for rebases). Refuses main/master and tags.
+#   branch|tag — ref to push (default: current branch)
 #
 # Auth is handled by the system credential helper (credential.helper=manager
 # on Windows, osxkeychain on macOS, or gh/glab auth). No token needed here.
@@ -24,7 +24,28 @@ if [[ "${1:-}" == "--force" ]]; then
   shift
 fi
 
-BRANCH="${1:-$(git rev-parse --abbrev-ref HEAD)}"
+TARGET="${1:-}"
+TARGET_KIND="branch"
+if [[ -z "$TARGET" ]]; then
+  TARGET="$(git rev-parse --abbrev-ref HEAD)"
+else
+  HAS_LOCAL_BRANCH=""
+  HAS_LOCAL_TAG=""
+  if git show-ref --verify --quiet "refs/heads/$TARGET"; then
+    HAS_LOCAL_BRANCH="1"
+  fi
+  if git show-ref --verify --quiet "refs/tags/$TARGET"; then
+    HAS_LOCAL_TAG="1"
+  fi
+
+  if [[ -n "$HAS_LOCAL_BRANCH" && -n "$HAS_LOCAL_TAG" ]]; then
+    echo "ERROR: Target '$TARGET' is ambiguous: both refs/heads/$TARGET and refs/tags/$TARGET exist." >&2
+    echo "  Rename one ref, or push the tag manually with an explicit refspec if that is intentional." >&2
+    exit 1
+  elif [[ -n "$HAS_LOCAL_TAG" ]]; then
+    TARGET_KIND="tag"
+  fi
+fi
 
 # Find the push remote.
 mapfile -t REMOTES < <(git remote)
@@ -68,6 +89,22 @@ fi
 
 REMOTE_URL=$(git remote get-url "$REMOTE_NAME" 2>/dev/null || echo "")
 ORG_REPO=$(echo "$REMOTE_URL" | sed 's|^ssh://[^/]*/||; s|^https://[^/]*/||; s|^http://[^/]*/||; s|^git@[^:]*:||; s|\.git$||')
+
+# Tags do not have upstream tracking branches. Use an explicit tag
+# refspec so Git cannot reinterpret an ambiguous short name.
+if [[ "$TARGET_KIND" == "tag" ]]; then
+  if [[ -n "$FORCE" ]]; then
+    echo "ERROR: Refusing to force-push tag $TARGET." >&2
+    echo "  Tags are release markers; delete/recreate intentionally outside ws push if needed." >&2
+    exit 1
+  fi
+
+  echo "Pushing tag $TARGET → $REMOTE_NAME ($ORG_REPO)"
+  git push "$REMOTE_NAME" "refs/tags/$TARGET:refs/tags/$TARGET"
+  exit 0
+fi
+
+BRANCH="$TARGET"
 
 # Safety: refuse to force-push main or master
 if [[ -n "$FORCE" ]] && [[ "$BRANCH" == "main" || "$BRANCH" == "master" ]]; then

--- a/scripts/ws
+++ b/scripts/ws
@@ -16,7 +16,7 @@
 #   pull [comp]       Pull all or one component
 #   resolve           Generate ArgoCD Applications
 #   vscode            Generate VS Code workspace file
-#   push [comp] [branch] [--force] Push branch (remote from identity.forkOrg)
+#   push [comp] [branch|tag] [--force] Push branch or tag (remote from identity.forkOrg)
 #   cr <comp> [--upstream] <title> <bodyfile>  Open a CR (change request/PR/MR; --upstream for cross-fork)
 #   issue <comp> [remote] <title> <label> <bodyfile> File issue (remote from forkOrg)
 #   test <comp> [TestName|args...] Run tests (auto-detected; see 'ws actions <comp>')
@@ -144,11 +144,11 @@ ws_push() {
     for _arg in "$@"; do
         if [[ "$_arg" == "--help" || "$_arg" == "-h" ]]; then
             cat <<'HELP'
-Usage: ws push [component] [branch] [--force]
+Usage: ws push [component] [branch|tag] [--force]
 
   component  Component to push (default: yggdrasil)
-  branch     Branch to push (default: current branch)
-  --force    Force push (use with care; only after a rebase typically)
+  branch|tag Component branch or local tag to push (default: current branch)
+  --force    Force push a branch (use with care; refused for tags)
 
 Pushes to the component's per-developer fork remote (resolved via
 identity.forkOrg in ecosystem config). For repos you own directly,
@@ -158,7 +158,7 @@ HELP
         fi
     done
     if [[ $# -gt 3 ]]; then
-        echo "Usage: ws push [component] [branch] [--force]" >&2
+        echo "Usage: ws push [component] [branch|tag] [--force]" >&2
         exit 1
     fi
     local comp="${1:-yggdrasil}"

--- a/scripts/ws-commit.sh
+++ b/scripts/ws-commit.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 : "${ROOT_DIR:="$(cd "$SCRIPT_DIR/.." && pwd)"}"
 
-# Auto-source .env so CLAUDE_MODEL and other env are available
+# Auto-source .env so agent attribution and other env are available
 [[ -f "$ROOT_DIR/.env" ]] && source "$ROOT_DIR/.env"
 
 # shellcheck source=ws-realm.sh
@@ -38,14 +38,16 @@ commit_help() {
         echo ""
         echo "The Co-Authored-By trailer is appended automatically."
         echo "Model attribution:"
-        echo "  The trailer name resolves as: identity.co_authored_by (if set"
-        echo "  in the merged ecosystem config) else \"Claude \$CLAUDE_MODEL\"."
-        echo "  CLAUDE_MODEL is auto-sourced from .env (built-in default: Opus"
-        echo "  4.8; effective value now: \"${CLAUDE_MODEL:-Opus 4.8}\"). Keep"
-        echo "  .env current rather than prepending it on every commit."
+        echo "  The trailer identity resolves as: identity.co_authored_by"
+        echo "  (if set in merged ecosystem config), else GDD_CO_AUTHOR,"
+        echo "  else legacy \"Claude \$CLAUDE_MODEL\"."
+        echo "  GDD_CO_AUTHOR is the full trailer identity, for example:"
+        echo "    GDD_CO_AUTHOR=\"Codex GPT-5 <noreply@openai.com>\""
+        echo "  GDD_CO_AUTHOR and CLAUDE_MODEL are auto-sourced from .env."
+        echo "  Legacy CLAUDE_MODEL effective value now: \"${CLAUDE_MODEL:-Opus 4.8}\"."
         echo "  SUB-AGENTS: if you commit while running on a non-default model"
-        echo "  (e.g. Sonnet vs the workspace Opus default), prepend it inline:"
-        echo "    CLAUDE_MODEL=\"Sonnet 4.6\" ws commit <comp> <bodyfile>"
+        echo "  (e.g. Sonnet vs the workspace default), prepend identity inline:"
+        echo "    GDD_CO_AUTHOR=\"Claude Sonnet 4.6 <noreply@anthropic.com>\" ws commit <comp> <bodyfile>"
         echo "  Inline is correct for sub-agents — a shared .env rewrite from"
         echo "  parallel sub-agents would race."
         echo ""
@@ -137,14 +139,24 @@ fi
 eco="$(ws_resolve_ecosystem)"
 co_authored_by=$(yq -r '.identity.co_authored_by // ""' "$eco" 2>/dev/null)
 if [[ -z "$co_authored_by" || "$co_authored_by" == "null" ]]; then
-    # No custom identity configured — fall back to Claude, with CLAUDE_MODEL
-    # selecting the model name. CLAUDE_MODEL does not override a configured
-    # identity (e.g. "Human Dev" or a non-Claude AI should pass through).
-    co_authored_by="Claude ${CLAUDE_MODEL:-Opus 4.8}"
+    if [[ -n "${GDD_CO_AUTHOR:-}" ]]; then
+        co_authored_by="$GDD_CO_AUTHOR"
+    else
+        # Legacy Claude default. CLAUDE_MODEL does not override a configured
+        # identity or the agent-neutral GDD_CO_AUTHOR value.
+        co_authored_by="Claude ${CLAUDE_MODEL:-Opus 4.8} <noreply@anthropic.com>"
+    fi
+elif [[ "$co_authored_by" != *"<"* ]]; then
+    co_authored_by="$co_authored_by <noreply@anthropic.com>"
 fi
 # Sanitize — newlines would break the trailer format
 co_authored_by="${co_authored_by%%$'\n'*}"
-trailer="Co-Authored-By: $co_authored_by <noreply@anthropic.com>"
+if [[ "$co_authored_by" != *"<"* || "$co_authored_by" != *">"* ]]; then
+    echo "ERROR: Co-Authored-By identity must include an email in angle brackets." >&2
+    echo "  Set GDD_CO_AUTHOR like: Codex GPT-5 <noreply@openai.com>" >&2
+    exit 1
+fi
+trailer="Co-Authored-By: $co_authored_by"
 
 # Ensure .commits/ exists for the normal-commit path (first use on a
 # fresh clone may not have it yet). Skip in dry-run mode — dry-run

--- a/scripts/ws-commit.sh
+++ b/scripts/ws-commit.sh
@@ -151,7 +151,14 @@ elif [[ "$co_authored_by" != *"<"* ]]; then
 fi
 # Sanitize — newlines would break the trailer format
 co_authored_by="${co_authored_by%%$'\n'*}"
-if [[ "$co_authored_by" != *"<"* || "$co_authored_by" != *">"* ]]; then
+# Require an email-shaped token in angle brackets (`<…@…>`). This catches
+# the common mistake — a bare name with no address (`Codex GPT-5`) or junk
+# in the brackets (`<not an email>`) — without imposing a brittle RFC-ish
+# pattern; the trailer is cosmetic attribution, not a validated contact.
+# Pattern lives in a variable (bash best practice for =~) with LITERAL
+# angle brackets — `\<`/`\>` would be word-boundary operators, not `<`/`>`.
+email_re='<[^[:space:]@<>]+@[^[:space:]@<>]+>'
+if [[ ! "$co_authored_by" =~ $email_re ]]; then
     echo "ERROR: Co-Authored-By identity must include an email in angle brackets." >&2
     echo "  Set GDD_CO_AUTHOR like: Codex GPT-5 <noreply@openai.com>" >&2
     exit 1

--- a/tests/ws-commit/dry-run.bats
+++ b/tests/ws-commit/dry-run.bats
@@ -245,6 +245,19 @@ EOF
     [[ "$output" == *"Co-Authored-By:"* ]]
 }
 
+@test "--dry-run uses GDD_CO_AUTHOR as a full agent-neutral trailer identity" {
+    echo "x" >> "$REPO_DIR/test.md"
+    write_bodyfile "$BATS_TEST_TMPDIR/body.md" \
+        "test: generic co-author" "test.md"
+
+    GDD_CO_AUTHOR="Codex GPT-5 <noreply@openai.com>" \
+        run_ws_commit yggdrasil --dry-run "$BATS_TEST_TMPDIR/body.md"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Co-Authored-By: Codex GPT-5 <noreply@openai.com>"* ]]
+    [[ "$output" != *"Co-Authored-By: Claude"* ]]
+}
+
 @test "real (non-dry-run) commit still works against the synthetic repo" {
     # Regression guard: my dry-run plumbing shouldn't have broken the
     # normal commit path. Same fixture, same bodyfile, no flag.

--- a/tests/ws-commit/dry-run.bats
+++ b/tests/ws-commit/dry-run.bats
@@ -258,6 +258,32 @@ EOF
     [[ "$output" != *"Co-Authored-By: Claude"* ]]
 }
 
+@test "GDD_CO_AUTHOR without an email is rejected" {
+    echo "x" >> "$REPO_DIR/test.md"
+    write_bodyfile "$BATS_TEST_TMPDIR/body.md" \
+        "test: missing email" "test.md"
+
+    GDD_CO_AUTHOR="Codex GPT-5" \
+        run_ws_commit yggdrasil --dry-run "$BATS_TEST_TMPDIR/body.md"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"must include an email in angle brackets"* ]]
+}
+
+@test "GDD_CO_AUTHOR with junk (no @) in the brackets is rejected" {
+    # The old check only verified < and > were present; an email-shaped
+    # token (with @) is now required so '<not an email>' no longer passes.
+    echo "x" >> "$REPO_DIR/test.md"
+    write_bodyfile "$BATS_TEST_TMPDIR/body.md" \
+        "test: junk identity" "test.md"
+
+    GDD_CO_AUTHOR="Codex GPT-5 <not an email>" \
+        run_ws_commit yggdrasil --dry-run "$BATS_TEST_TMPDIR/body.md"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"must include an email in angle brackets"* ]]
+}
+
 @test "real (non-dry-run) commit still works against the synthetic repo" {
     # Regression guard: my dry-run plumbing shouldn't have broken the
     # normal commit path. Same fixture, same bodyfile, no flag.

--- a/tests/ws-commit/help.bats
+++ b/tests/ws-commit/help.bats
@@ -14,6 +14,13 @@ load test_helper
     [[ "$output" == *".env"* ]]
 }
 
+@test "ws commit --help mentions GDD_CO_AUTHOR as the agent-neutral override" {
+    run bash "$WS_COMMIT_BIN" --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"GDD_CO_AUTHOR"* ]]
+    [[ "$output" == *"Codex GPT-5 <noreply@openai.com>"* ]]
+}
+
 @test "ws commit --help explains the sub-agent inline override" {
     run bash "$WS_COMMIT_BIN" --help
     [ "$status" -eq 0 ]

--- a/tests/ws-push/push.bats
+++ b/tests/ws-push/push.bats
@@ -1,0 +1,62 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+    init_push_repo
+}
+
+@test "pushes an explicit local tag as a tag ref" {
+    git -C "$REPO_DIR" tag v0.1.0
+
+    run_git_push v0.1.0
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Pushing tag v0.1.0"* ]]
+    remote_ref_exists refs/tags/v0.1.0
+    [ "$(git -C "$REPO_DIR" rev-parse refs/tags/v0.1.0)" = "$(remote_ref_sha refs/tags/v0.1.0)" ]
+}
+
+@test "pushing a tag does not create an upstream branch" {
+    git -C "$REPO_DIR" tag v0.2.0
+
+    run_git_push v0.2.0
+
+    [ "$status" -eq 0 ]
+    ! remote_ref_exists refs/heads/v0.2.0
+}
+
+@test "keeps explicit branch push upstream behavior" {
+    git -C "$REPO_DIR" switch -q -c feature/tag-support
+    echo "change" >> "$REPO_DIR/file.txt"
+    git -C "$REPO_DIR" add file.txt
+    git -C "$REPO_DIR" commit -q -m "feature work"
+
+    run_git_push feature/tag-support
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Pushing feature/tag-support"* ]]
+    remote_ref_exists refs/heads/feature/tag-support
+    [ "$(git -C "$REPO_DIR" rev-parse --abbrev-ref --symbolic-full-name feature/tag-support@{upstream})" = "fork/feature/tag-support" ]
+}
+
+@test "refuses an explicit name that is both a local branch and local tag" {
+    git -C "$REPO_DIR" switch -q -c release
+    git -C "$REPO_DIR" tag release
+
+    run_git_push release
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"ambiguous"* ]]
+    [[ "$output" == *"refs/heads/release"* ]]
+    [[ "$output" == *"refs/tags/release"* ]]
+}
+
+@test "refuses force-pushing tags" {
+    git -C "$REPO_DIR" tag v0.3.0
+
+    run_git_push --force v0.3.0
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Refusing to force-push tag v0.3.0"* ]]
+}

--- a/tests/ws-push/test_helper.bash
+++ b/tests/ws-push/test_helper.bash
@@ -1,0 +1,37 @@
+# Shared helpers for ws-push bats tests.
+#
+# Each test gets an isolated git repo plus a bare remote. Tests invoke
+# git-push.sh directly so they exercise push behavior without depending
+# on ecosystem component resolution.
+
+REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+GIT_PUSH_BIN="$REPO_ROOT/scripts/git-push.sh"
+
+init_push_repo() {
+    REPO_DIR="$BATS_TEST_TMPDIR/repo"
+    REMOTE_DIR="$BATS_TEST_TMPDIR/remote.git"
+
+    git init -q "$REPO_DIR"
+    git -C "$REPO_DIR" config user.name "Test User"
+    git -C "$REPO_DIR" config user.email "test@example.local"
+
+    echo "hello" > "$REPO_DIR/file.txt"
+    git -C "$REPO_DIR" add file.txt
+    git -C "$REPO_DIR" commit -q -m "seed commit"
+
+    git init -q --bare "$REMOTE_DIR"
+    git -C "$REPO_DIR" remote add fork "$REMOTE_DIR"
+    export GIT_PUSH_REMOTE="fork"
+}
+
+run_git_push() {
+    run bash -c 'cd "$1" || exit 1; shift; exec bash "$@"' bash "$REPO_DIR" "$GIT_PUSH_BIN" "$@"
+}
+
+remote_ref_exists() {
+    git --git-dir="$REMOTE_DIR" show-ref --verify --quiet "$1"
+}
+
+remote_ref_sha() {
+    git --git-dir="$REMOTE_DIR" rev-parse "$1"
+}


### PR DESCRIPTION
## Summary

- Teach `ws push` / `scripts/git-push.sh` to recognize explicit local tag names and push them with an explicit `refs/tags/<tag>:refs/tags/<tag>` refspec.
- Keep existing branch push behavior, including automatic upstream setup for branch pushes.
- Reject ambiguous local names that exist as both a branch and tag, and refuse `--force` for tag pushes.
- Add `GDD_CO_AUTHOR` as an agent-neutral full `Co-Authored-By` identity for `ws commit`, while retaining the legacy `CLAUDE_MODEL` fallback.
- Add focused Bats coverage for tag pushes, branch behavior, ambiguity handling, and tag force-push refusal.

## Test plan

- [x] `bash tests/vendor/bats-core/bin/bats --print-output-on-failure tests/ws-commit`
- [x] `bash tests/vendor/bats-core/bin/bats --print-output-on-failure tests/ws-push`
- [x] `bash tests/vendor/bats-core/bin/bats --print-output-on-failure tests/ws-smoke`
- [x] `git diff --check`

## Related

- Supports tag-pipeline workflows where `ws push <component> <tag>` should publish the local tag without falling back to raw `git push`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes external git state (tag push) and commit metadata attribution; behavior is guarded (no tag force, ambiguity checks) and covered by new Bats tests.
> 
> **Overview**
> Adds **tag publishing** to `ws push` / `git-push.sh` and introduces **`GDD_CO_AUTHOR`** as the primary, agent-neutral `Co-Authored-By` identity for `ws commit`.
> 
> **Push:** An explicit ref name is resolved as a local tag or branch. Tags push via `refs/tags/<name>:refs/tags/<name>` (no upstream branch). **Force-push is refused for tags**; **branch+tag name collisions** error out. Branch pushes keep existing upstream wiring.
> 
> **Commit attribution:** Trailer resolution is now `identity.co_authored_by` → **`GDD_CO_AUTHOR`** (full `Name <email>`) → legacy `Claude $CLAUDE_MODEL`. Invalid identities without angle-bracket email fail fast. Docs, `.env.example`, and orientation now refresh **`GDD_CO_AUTHOR`** instead of **`CLAUDE_MODEL`**; bounded `CLAUDE_MODEL=` prefix auto-approve remains legacy-only.
> 
> **Tests:** New `tests/ws-push` coverage plus `GDD_CO_AUTHOR` dry-run/help assertions for commit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17bf44a724bda93e49e17ce283035bc16354a955. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for pushing tags in `ws push`
  * Introduced `GDD_CO_AUTHOR` to customize `Co-Authored-By` commit attribution (with inline per-commit override behavior)
* **Documentation**
  * Updated commit attribution precedence and `Co-Authored-By` formatting/validation guidance
  * Refreshed `ws push`/`ws commit` help text and related attribution notes
* **Tests**
  * Added coverage for tag vs branch push behavior and ambiguous ref handling
  * Added `ws commit` tests for `GDD_CO_AUTHOR`, including validation failures and help output
<!-- end of auto-generated comment: release notes by coderabbit.ai -->