### PR TITLE
fix(ws): pin GitLab MR source project + fix timeout test

### DIFF
--- a/scripts/providers/gitlab.sh
+++ b/scripts/providers/gitlab.sh
@@ -90,6 +90,8 @@ gp_create_pr() {
 
     if [[ -n "$fork_slug" ]]; then
         cmd+=(--head "$fork_slug")
+    else
+        cmd+=(--head "$repo")
     fi
 
     "${cmd[@]}"

--- a/scripts/ws-review.sh
+++ b/scripts/ws-review.sh
@@ -18,10 +18,10 @@ ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 # --- Function definitions (must precede routing block at bottom) ---
 
 review_help() {
-    echo "Usage: ws review <comp> <cr#> [--reviewer <name>] [--since <time>] [--compact] [--limit N] [--output <phrase>]"
-    echo "       ws review <comp> threads <cr#> [--status | --resolve <id> | --resolve-all]"
-    echo "       ws review <comp> notes <cr#> [--reviewer <name>] [--since <time>]"
-    echo "       ws review <comp> reply <cr#> <thread-id> <message> [--resolve]"
+    echo "Usage: ws review <comp> <cr#> [--remote <name>] [--reviewer <name>] [--since <time>] [--compact] [--limit N] [--output <phrase>]"
+    echo "       ws review <comp> threads <cr#> [--remote <name>] [--status | --resolve <id> | --resolve-all]"
+    echo "       ws review <comp> notes <cr#> [--remote <name>] [--reviewer <name>] [--since <time>]"
+    echo "       ws review <comp> reply <cr#> <thread-id> <message> [--remote <name>] [--resolve]"
     echo ""
     echo "CR review comments and thread management."
     echo ""
@@ -47,6 +47,8 @@ review_help() {
     echo "                             the path on stdout for downstream commands like grep."
     echo "                             Replaces a '> file' redirect — native flag keeps the"
     echo "                             write confined to .outputs/ (covered by ws clean)."
+    echo "    --remote <name>          Select a specific git remote when a CR number exists"
+    echo "                             on multiple remotes for the same component."
     echo ""
     echo "  threads <cr#>              Unresolved diff threads (targeted follow-up)"
     echo "    --status                 Show resolved/unresolved counts"
@@ -66,6 +68,7 @@ review_help() {
     echo "  ws review yggdrasil 8 --compact             # Headline-only triage view"
     echo "  ws review yggdrasil 8 --compact --limit 5   # First 5 comments, headline-only"
     echo "  ws review yggdrasil 8 --output before-fix    # Save snapshot for grep follow-up"
+    echo "  ws review silence 1 --remote rpraestholm-fork-group"
     echo "  ws review mimir 5 --reviewer coderabbitai"
     echo "  ws review yggdrasil 8 --since last-push"
     echo "  ws review yggdrasil notes 8                # Top-level notes only"
@@ -736,9 +739,9 @@ _ECO=$(ws_resolve_ecosystem 2>/dev/null) || _ECO=""
 
 # Parse component (first positional arg, always required)
 if [[ $# -lt 1 ]]; then
-    echo "Usage: ws review <comp> threads <cr#> [--status | --resolve <id> | --resolve-all]" >&2
-    echo "       ws review <comp> reply <cr#> <thread-id> <message> [--resolve]" >&2
-    echo "       ws review <comp> <cr#> [--reviewer <name>] [--since <time>] [--compact]" >&2
+    echo "Usage: ws review <comp> threads <cr#> [--remote <name>] [--status | --resolve <id> | --resolve-all]" >&2
+    echo "       ws review <comp> reply <cr#> <thread-id> <message> [--remote <name>] [--resolve]" >&2
+    echo "       ws review <comp> <cr#> [--remote <name>] [--reviewer <name>] [--since <time>] [--compact]" >&2
     echo "" >&2
     echo "Run 'ws review --help' for details." >&2
     exit 1
@@ -751,6 +754,33 @@ shift
 if [[ "$COMP" == "help" ]]; then
     review_help
     exit 0
+fi
+
+REVIEW_REMOTE=""
+_FILTERED_ARGS=()
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --remote)
+            [[ $# -ge 2 ]] || { echo "ERROR: --remote requires a value" >&2; exit 1; }
+            REVIEW_REMOTE="$2"
+            shift 2
+            ;;
+        --remote=*)
+            REVIEW_REMOTE="${1#--remote=}"
+            [[ -n "$REVIEW_REMOTE" ]] || { echo "ERROR: --remote value cannot be empty" >&2; exit 1; }
+            shift
+            ;;
+        *)
+            _FILTERED_ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+set -- "${_FILTERED_ARGS[@]}"
+
+if [[ -n "$REVIEW_REMOTE" && ! "$REVIEW_REMOTE" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+    echo "ERROR: Invalid remote name '$REVIEW_REMOTE'. Use alphanumeric, dot, dash, underscore, or slash." >&2
+    exit 1
 fi
 
 # Resolve the target directory via the shared helper — accepts components,
@@ -776,6 +806,7 @@ fi
 _CANDIDATE_SLUGS=()
 _CANDIDATE_PROVIDERS=()
 _CANDIDATE_URLS=()
+_CANDIDATE_REMOTES=()
 for _r in $(cd "$COMP_DIR" && git remote); do
     _url=$(cd "$COMP_DIR" && git remote get-url "$_r" 2>/dev/null) || continue
     _prov=$(gp_detect "$_url" "$_ECO" 2>/dev/null) || continue
@@ -785,6 +816,7 @@ for _r in $(cd "$COMP_DIR" && git remote); do
         _CANDIDATE_SLUGS+=("$_slug")
         _CANDIDATE_PROVIDERS+=("$_prov")
         _CANDIDATE_URLS+=("$_url")
+        _CANDIDATE_REMOTES+=("$_r")
     fi
 done
 
@@ -807,7 +839,24 @@ fi
 
 REPO_SLUG=""
 _SELECTED_PROVIDER=""
-if [[ ${#_CANDIDATE_SLUGS[@]} -eq 1 ]]; then
+if [[ -n "$REVIEW_REMOTE" ]]; then
+    for i in "${!_CANDIDATE_REMOTES[@]}"; do
+        if [[ "${_CANDIDATE_REMOTES[$i]}" == "$REVIEW_REMOTE" ]]; then
+            REPO_SLUG="${_CANDIDATE_SLUGS[$i]}"
+            _SELECTED_PROVIDER="${_CANDIDATE_PROVIDERS[$i]}"
+            break
+        fi
+    done
+    if [[ -z "$REPO_SLUG" ]]; then
+        _available=()
+        for i in "${!_CANDIDATE_REMOTES[@]}"; do
+            _available+=("${_CANDIDATE_REMOTES[$i]}=${_CANDIDATE_SLUGS[$i]}")
+        done
+        echo "ERROR: Remote '$REVIEW_REMOTE' is not a supported review remote for '$COMP'." >&2
+        echo "  Available remotes: ${_available[*]:-(none)}" >&2
+        exit 1
+    fi
+elif [[ ${#_CANDIDATE_SLUGS[@]} -eq 1 ]]; then
     REPO_SLUG="${_CANDIDATE_SLUGS[0]}"
     _SELECTED_PROVIDER="${_CANDIDATE_PROVIDERS[0]}"
 elif [[ -n "$_PEEK_CR" ]]; then
@@ -833,9 +882,18 @@ elif [[ -n "$_PEEK_CR" ]]; then
         echo "  Tried: ${_CANDIDATE_SLUGS[*]}" >&2
         exit 1
     elif [[ ${#_MATCH_SLUGS[@]} -gt 1 ]]; then
+        _matches=()
+        for _match in "${_MATCH_SLUGS[@]}"; do
+            for i in "${!_CANDIDATE_SLUGS[@]}"; do
+                if [[ "${_CANDIDATE_SLUGS[$i]}" == "$_match" ]]; then
+                    _matches+=("${_CANDIDATE_REMOTES[$i]}=$_match")
+                    break
+                fi
+            done
+        done
         echo "ERROR: CR #$_PEEK_CR found on multiple remotes for '$COMP'." >&2
-        echo "  Matches: ${_MATCH_SLUGS[*]}" >&2
-        echo "  Remove extra remotes or specify which repo to review." >&2
+        echo "  Matches: ${_matches[*]}" >&2
+        echo "  Use --remote <name> to select one." >&2
         exit 1
     fi
     REPO_SLUG="${_MATCH_SLUGS[0]}"

--- a/scripts/ws-review.sh
+++ b/scripts/ws-review.sh
@@ -82,7 +82,7 @@ review_help() {
 
 review_comments() {
     if [[ $# -lt 1 ]]; then
-        echo "Usage: ws review <comp> <cr#> [--reviewer <name>] [--since <time>] [--compact] [--limit N] [--output <phrase>]" >&2
+        echo "Usage: ws review <comp> <cr#> [--remote <name>] [--reviewer <name>] [--since <time>] [--compact] [--limit N] [--output <phrase>]" >&2
         exit 1
     fi
 
@@ -540,7 +540,7 @@ review_comments() {
 
 review_notes() {
     if [[ $# -lt 1 ]]; then
-        echo "Usage: ws review <comp> notes <cr#> [--reviewer <name>] [--since <time>]" >&2
+        echo "Usage: ws review <comp> notes <cr#> [--remote <name>] [--reviewer <name>] [--since <time>]" >&2
         exit 1
     fi
 
@@ -611,7 +611,7 @@ review_notes() {
 
 review_threads() {
     if [[ $# -lt 1 ]]; then
-        echo "Usage: ws review <comp> threads <cr#> [--status | --resolve <id> | --resolve-all]" >&2
+        echo "Usage: ws review <comp> threads <cr#> [--remote <name>] [--status | --resolve <id> | --resolve-all]" >&2
         exit 1
     fi
 
@@ -683,7 +683,7 @@ review_threads() {
 
 review_reply() {
     if [[ $# -lt 3 || $# -gt 4 ]]; then
-        echo "Usage: ws review <comp> reply <cr#> <thread-id> <message> [--resolve]" >&2
+        echo "Usage: ws review <comp> reply <cr#> <thread-id> <message> [--remote <name>] [--resolve]" >&2
         exit 1
     fi
 
@@ -758,7 +758,31 @@ fi
 
 REVIEW_REMOTE=""
 _FILTERED_ARGS=()
+# `--remote` is extracted here, ahead of subcommand dispatch, because it drives
+# the remote/slug resolution below. The wrinkle is `reply <cr#> <thread-id>
+# <message>`: its <message> is free-form and may legitimately begin with
+# `--remote`, so that positional must pass through verbatim rather than be
+# consumed as the flag. Locate the subcommand keyword first (looking past any
+# leading `--remote` flag), then shield the reply message positional.
+_subcmd=""
+_peek_args=("$@")
+_pi=0
+while [[ $_pi -lt ${#_peek_args[@]} ]]; do
+    case "${_peek_args[$_pi]}" in
+        --remote) _pi=$((_pi + 2)) ;;
+        --remote=*) _pi=$((_pi + 1)) ;;
+        *) _subcmd="${_peek_args[$_pi]}"; break ;;
+    esac
+done
+# For `reply`, the <message> is the 4th positional: reply, cr#, thread-id, message.
+_positional=0
 while [[ $# -gt 0 ]]; do
+    if [[ "$_subcmd" == "reply" && $_positional -eq 3 ]]; then
+        _FILTERED_ARGS+=("$1")
+        _positional=$((_positional + 1))
+        shift
+        continue
+    fi
     case "$1" in
         --remote)
             [[ $# -ge 2 ]] || { echo "ERROR: --remote requires a value" >&2; exit 1; }
@@ -772,6 +796,7 @@ while [[ $# -gt 0 ]]; do
             ;;
         *)
             _FILTERED_ARGS+=("$1")
+            _positional=$((_positional + 1))
             shift
             ;;
     esac
@@ -839,11 +864,16 @@ fi
 
 REPO_SLUG=""
 _SELECTED_PROVIDER=""
+# Track the exact selected remote's URL alongside its slug. Matching by slug
+# alone is ambiguous when two remotes share owner/repo across hosts or provider
+# mappings — token setup below needs the precise URL, not "first slug match".
+_SELECTED_URL=""
 if [[ -n "$REVIEW_REMOTE" ]]; then
     for i in "${!_CANDIDATE_REMOTES[@]}"; do
         if [[ "${_CANDIDATE_REMOTES[$i]}" == "$REVIEW_REMOTE" ]]; then
             REPO_SLUG="${_CANDIDATE_SLUGS[$i]}"
             _SELECTED_PROVIDER="${_CANDIDATE_PROVIDERS[$i]}"
+            _SELECTED_URL="${_CANDIDATE_URLS[$i]}"
             break
         fi
     done
@@ -859,11 +889,16 @@ if [[ -n "$REVIEW_REMOTE" ]]; then
 elif [[ ${#_CANDIDATE_SLUGS[@]} -eq 1 ]]; then
     REPO_SLUG="${_CANDIDATE_SLUGS[0]}"
     _SELECTED_PROVIDER="${_CANDIDATE_PROVIDERS[0]}"
+    _SELECTED_URL="${_CANDIDATE_URLS[0]}"
 elif [[ -n "$_PEEK_CR" ]]; then
     # Try each slug — collect all matches (CR numbers aren't unique across repos)
-    # Deduplicate: skip slug/provider pairs we've already probed
+    # Deduplicate: skip slug/provider pairs we've already probed. Carry the
+    # remote name and URL through the probe so the error/selection paths use the
+    # matched remote identity directly instead of reconstructing it by slug.
     _MATCH_SLUGS=()
     _MATCH_PROVIDERS=()
+    _MATCH_REMOTES=()
+    _MATCH_URLS=()
     _seen=""
     for i in "${!_CANDIDATE_SLUGS[@]}"; do
         _slug="${_CANDIDATE_SLUGS[$i]}"
@@ -875,6 +910,8 @@ elif [[ -n "$_PEEK_CR" ]]; then
         if gp_review_summary "$_slug" "$_PEEK_CR" &>/dev/null; then
             _MATCH_SLUGS+=("$_slug")
             _MATCH_PROVIDERS+=("$_prov")
+            _MATCH_REMOTES+=("${_CANDIDATE_REMOTES[$i]}")
+            _MATCH_URLS+=("${_CANDIDATE_URLS[$i]}")
         fi
     done
     if [[ ${#_MATCH_SLUGS[@]} -eq 0 ]]; then
@@ -883,13 +920,8 @@ elif [[ -n "$_PEEK_CR" ]]; then
         exit 1
     elif [[ ${#_MATCH_SLUGS[@]} -gt 1 ]]; then
         _matches=()
-        for _match in "${_MATCH_SLUGS[@]}"; do
-            for i in "${!_CANDIDATE_SLUGS[@]}"; do
-                if [[ "${_CANDIDATE_SLUGS[$i]}" == "$_match" ]]; then
-                    _matches+=("${_CANDIDATE_REMOTES[$i]}=$_match")
-                    break
-                fi
-            done
+        for i in "${!_MATCH_SLUGS[@]}"; do
+            _matches+=("${_MATCH_REMOTES[$i]}=${_MATCH_SLUGS[$i]}")
         done
         echo "ERROR: CR #$_PEEK_CR found on multiple remotes for '$COMP'." >&2
         echo "  Matches: ${_matches[*]}" >&2
@@ -898,10 +930,12 @@ elif [[ -n "$_PEEK_CR" ]]; then
     fi
     REPO_SLUG="${_MATCH_SLUGS[0]}"
     _SELECTED_PROVIDER="${_MATCH_PROVIDERS[0]}"
+    _SELECTED_URL="${_MATCH_URLS[0]}"
 else
     # Can't probe without a CR number — use first slug
     REPO_SLUG="${_CANDIDATE_SLUGS[0]}"
     _SELECTED_PROVIDER="${_CANDIDATE_PROVIDERS[0]}"
+    _SELECTED_URL="${_CANDIDATE_URLS[0]}"
 fi
 
 # Ensure the selected provider is loaded
@@ -909,12 +943,10 @@ gp_load "$_SELECTED_PROVIDER"
 
 # Pre-populate the provider token from ecosystem config so gp_check_cli
 # doesn't fall through to glab auth status when only split tokens are set.
-for _i in "${!_CANDIDATE_SLUGS[@]}"; do
-    if [[ "${_CANDIDATE_SLUGS[$_i]}" == "$REPO_SLUG" ]]; then
-        gp_set_token_for_url "${_CANDIDATE_URLS[$_i]}" "$_ECO"
-        break
-    fi
-done
+# Use the exact selected remote URL captured above — not a re-match by slug.
+if [[ -n "$_SELECTED_URL" ]]; then
+    gp_set_token_for_url "$_SELECTED_URL" "$_ECO"
+fi
 
 # Provider-specific auth check
 gp_check_cli || exit 1

--- a/tests/hook/test_helper.bash
+++ b/tests/hook/test_helper.bash
@@ -19,9 +19,9 @@ HOOK_BIN="$REPO_ROOT/.claude/hooks/gdd-permission-hook.sh"
 # Homebrew coreutils install (`gtimeout`). Tests need one or the other
 # — see tests/README.md for the install hint.
 if command -v timeout >/dev/null 2>&1; then
-    TIMEOUT_BIN="timeout"
+    TIMEOUT_BIN="$(command -v timeout)"
 elif command -v gtimeout >/dev/null 2>&1; then
-    TIMEOUT_BIN="gtimeout"
+    TIMEOUT_BIN="$(command -v gtimeout)"
 else
     echo "ERROR: neither 'timeout' nor 'gtimeout' found on PATH." >&2
     echo "  Install GNU coreutils — on macOS: 'brew install coreutils'." >&2

--- a/tests/ws-clean/test_helper.bash
+++ b/tests/ws-clean/test_helper.bash
@@ -16,9 +16,9 @@ WS_BIN="$REPO_ROOT/scripts/ws"
 # aborting the whole file's load (which buries the reason in a load error).
 detect_timeout_bin() {
     if command -v timeout >/dev/null 2>&1; then
-        TIMEOUT_BIN="timeout"
+        TIMEOUT_BIN="$(command -v timeout)"
     elif command -v gtimeout >/dev/null 2>&1; then
-        TIMEOUT_BIN="gtimeout"
+        TIMEOUT_BIN="$(command -v gtimeout)"
     else
         skip "neither 'timeout' nor 'gtimeout' found; install GNU coreutils (macOS: brew install coreutils) — see tests/README.md"
     fi

--- a/tests/ws-cr/gitlab-provider.bats
+++ b/tests/ws-cr/gitlab-provider.bats
@@ -1,0 +1,44 @@
+#!/usr/bin/env bats
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    GLAB_LOG="$BATS_TEST_TMPDIR/glab.args"
+    BODYFILE="$BATS_TEST_TMPDIR/body.md"
+    echo "body text" > "$BODYFILE"
+
+    # shellcheck source=../../scripts/providers/gitlab.sh
+    source "$REPO_ROOT/scripts/providers/gitlab.sh"
+}
+
+glab() {
+    printf '%s\n' "$*" > "$GLAB_LOG"
+}
+
+@test "same-project GitLab MR pins the source project with --head" {
+    run gp_create_pr \
+        --repo "example-group/forked-project" \
+        --base "main" \
+        --head "feature/source-project" \
+        --title "fix: pin MR source project" \
+        --body-file "$BODYFILE"
+
+    [ "$status" -eq 0 ]
+    [[ "$(cat "$GLAB_LOG")" == *"--repo example-group/forked-project"* ]]
+    [[ "$(cat "$GLAB_LOG")" == *"--source-branch feature/source-project"* ]]
+    [[ "$(cat "$GLAB_LOG")" == *"--head example-group/forked-project"* ]]
+}
+
+@test "cross-fork GitLab MR keeps the fork slug as --head" {
+    run gp_create_pr \
+        --repo "upstream-group/project" \
+        --base "main" \
+        --head "feature/source-project" \
+        --fork-slug "example-group/forked-project" \
+        --title "fix: pin MR source project" \
+        --body-file "$BODYFILE"
+
+    [ "$status" -eq 0 ]
+    [[ "$(cat "$GLAB_LOG")" == *"--repo upstream-group/project"* ]]
+    [[ "$(cat "$GLAB_LOG")" == *"--source-branch feature/source-project"* ]]
+    [[ "$(cat "$GLAB_LOG")" == *"--head example-group/forked-project"* ]]
+}

--- a/tests/ws-review/review-remote.bats
+++ b/tests/ws-review/review-remote.bats
@@ -5,6 +5,7 @@ setup() {
     WS_BIN="$REPO_ROOT/scripts/ws"
     WORK="$BATS_TEST_TMPDIR/work"
     BIN_DIR="$BATS_TEST_TMPDIR/bin"
+    BODY_LOG="$WORK/glab-post-body.txt"
     mkdir -p "$WORK/components/app" "$WORK/realms" "$WORK/hoards" "$BIN_DIR"
 
     cat > "$WORK/ecosystem.yaml" <<'YAML'
@@ -25,6 +26,10 @@ YAML
     git -C "$WORK/components/app" remote add origin https://gitlab.com/upstream-group/project.git
     git -C "$WORK/components/app" remote add fork https://gitlab.com/example-group/forked-project.git
 
+    # Stub glab. The GET MR endpoint returns a DISTINCT title per project path
+    # so a test can prove which project the selected remote actually queried —
+    # not merely that the rendered header slug changed. POSTed note bodies are
+    # logged so the reply test can assert the message reached the API verbatim.
     cat > "$BIN_DIR/glab" <<'BASH'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -33,21 +38,41 @@ if [[ "${1:-}" != "api" ]]; then
     echo "unexpected glab command: $*" >&2
     exit 1
 fi
+shift
 
-case "${2:-}" in
-    projects/*/merge_requests/1)
-        cat <<'JSON'
-{"title":"Test MR","state":"opened","author":{"username":"review-bot"},"source_branch":"feature/source-project","target_branch":"main","web_url":"https://gitlab.com/example-group/forked-project/-/merge_requests/1"}
-JSON
+method="GET"
+path=""
+body=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --method) method="$2"; shift 2 ;;
+        -f) case "${2:-}" in body=*) body="${2#body=}" ;; esac; shift 2 ;;
+        projects/*) path="$1"; shift ;;
+        *) shift ;;
+    esac
+done
+
+if [[ "$method" == "POST" && "$path" == */notes ]]; then
+    printf '%s' "$body" > "${GLAB_BODY_LOG:-/dev/null}"
+    echo '{"id":1}'
+    exit 0
+fi
+
+case "$path" in
+    projects/upstream-group%2Fproject/merge_requests/1)
+        echo '{"title":"Upstream MR","state":"opened","author":{"username":"review-bot"},"source_branch":"feature/upstream","target_branch":"main","web_url":"https://gitlab.com/upstream-group/project/-/merge_requests/1"}'
         ;;
-    projects/*/merge_requests/1/approvals)
+    projects/example-group%2Fforked-project/merge_requests/1)
+        echo '{"title":"Fork MR","state":"opened","author":{"username":"review-bot"},"source_branch":"feature/source-project","target_branch":"main","web_url":"https://gitlab.com/example-group/forked-project/-/merge_requests/1"}'
+        ;;
+    */merge_requests/1/approvals)
         echo '{"approved_by":[]}'
         ;;
-    projects/*/merge_requests/1/discussions)
+    */merge_requests/1/discussions)
         echo '[]'
         ;;
     *)
-        echo "unexpected glab api path: ${2:-}" >&2
+        echo "unexpected glab api path: $path" >&2
         exit 1
         ;;
 esac
@@ -65,6 +90,7 @@ run_ws_review() {
         "ECOSYSTEM=$WORK/ecosystem.yaml" \
         "ECOSYSTEM_LOCAL=$WORK/ecosystem.local.yaml" \
         "GITLAB_TOKEN=dummy-token" \
+        "GLAB_BODY_LOG=$BODY_LOG" \
         bash "$WS_BIN" review "$@"
 }
 
@@ -78,11 +104,25 @@ run_ws_review() {
     [[ "$output" == *"--remote <name>"* ]]
 }
 
-@test "review --remote selects a specific remote when CR numbers overlap" {
+@test "review --remote selects a specific remote and queries its project" {
     run_ws_review app 1 --remote fork --compact
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"=== CR #1 (example-group/forked-project) ==="* ]]
-    [[ "$output" == *"Title: Test MR"* ]]
+    # The distinct per-project title proves the fork project endpoint was hit,
+    # not just that the header slug was relabeled.
+    [[ "$output" == *"Title: Fork MR"* ]]
+    [[ "$output" != *"Upstream MR"* ]]
     [[ "$output" != *"found on multiple remotes"* ]]
+}
+
+@test "reply preserves a message that begins with --remote" {
+    # The <message> positional is free-form; a message that starts with
+    # --remote must reach the API verbatim, not be consumed as the flag.
+    # The trailing --remote selects the remote (required: CR #1 exists on both).
+    run_ws_review app reply 1 abc123 '--remote=spoof' --remote fork
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Replied to thread on CR #1 (example-group/forked-project)"* ]]
+    [ "$(cat "$BODY_LOG")" = "--remote=spoof" ]
 }

--- a/tests/ws-review/review-remote.bats
+++ b/tests/ws-review/review-remote.bats
@@ -1,0 +1,88 @@
+#!/usr/bin/env bats
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    WS_BIN="$REPO_ROOT/scripts/ws"
+    WORK="$BATS_TEST_TMPDIR/work"
+    BIN_DIR="$BATS_TEST_TMPDIR/bin"
+    mkdir -p "$WORK/components/app" "$WORK/realms" "$WORK/hoards" "$BIN_DIR"
+
+    cat > "$WORK/ecosystem.yaml" <<'YAML'
+defaults:
+  gitProviders:
+    gitlab.com: gitlab
+components:
+  app:
+    repo: https://gitlab.com/upstream-group/project.git
+YAML
+
+    git -C "$WORK/components/app" init -q
+    git -C "$WORK/components/app" config user.name "Test User"
+    git -C "$WORK/components/app" config user.email "test@example.local"
+    echo "hello" > "$WORK/components/app/README.md"
+    git -C "$WORK/components/app" add README.md
+    git -C "$WORK/components/app" commit -q -m "seed"
+    git -C "$WORK/components/app" remote add origin https://gitlab.com/upstream-group/project.git
+    git -C "$WORK/components/app" remote add fork https://gitlab.com/example-group/forked-project.git
+
+    cat > "$BIN_DIR/glab" <<'BASH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" != "api" ]]; then
+    echo "unexpected glab command: $*" >&2
+    exit 1
+fi
+
+case "${2:-}" in
+    projects/*/merge_requests/1)
+        cat <<'JSON'
+{"title":"Test MR","state":"opened","author":{"username":"review-bot"},"source_branch":"feature/source-project","target_branch":"main","web_url":"https://gitlab.com/example-group/forked-project/-/merge_requests/1"}
+JSON
+        ;;
+    projects/*/merge_requests/1/approvals)
+        echo '{"approved_by":[]}'
+        ;;
+    projects/*/merge_requests/1/discussions)
+        echo '[]'
+        ;;
+    *)
+        echo "unexpected glab api path: ${2:-}" >&2
+        exit 1
+        ;;
+esac
+BASH
+    chmod +x "$BIN_DIR/glab"
+}
+
+run_ws_review() {
+    run env \
+        "PATH=$BIN_DIR:$PATH" \
+        "ROOT_DIR=$WORK" \
+        "COMPONENTS_DIR=$WORK/components" \
+        "REALMS_DIR=$WORK/realms" \
+        "HOARDS_DIR=$WORK/hoards" \
+        "ECOSYSTEM=$WORK/ecosystem.yaml" \
+        "ECOSYSTEM_LOCAL=$WORK/ecosystem.local.yaml" \
+        "GITLAB_TOKEN=dummy-token" \
+        bash "$WS_BIN" review "$@"
+}
+
+@test "review errors actionably when a CR number exists on multiple remotes" {
+    run_ws_review app 1 --compact
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"CR #1 found on multiple remotes"* ]]
+    [[ "$output" == *"origin=upstream-group/project"* ]]
+    [[ "$output" == *"fork=example-group/forked-project"* ]]
+    [[ "$output" == *"--remote <name>"* ]]
+}
+
+@test "review --remote selects a specific remote when CR numbers overlap" {
+    run_ws_review app 1 --remote fork --compact
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"=== CR #1 (example-group/forked-project) ==="* ]]
+    [[ "$output" == *"Title: Test MR"* ]]
+    [[ "$output" != *"found on multiple remotes"* ]]
+}

--- a/tests/ws-smoke/test_helper.bash
+++ b/tests/ws-smoke/test_helper.bash
@@ -16,9 +16,9 @@ WS_BIN="$REPO_ROOT/scripts/ws"
 # Resolve `timeout` (Linux/Git Bash) or `gtimeout` (macOS Homebrew
 # coreutils). See tests/README.md for the install hint.
 if command -v timeout >/dev/null 2>&1; then
-    TIMEOUT_BIN="timeout"
+    TIMEOUT_BIN="$(command -v timeout)"
 elif command -v gtimeout >/dev/null 2>&1; then
-    TIMEOUT_BIN="gtimeout"
+    TIMEOUT_BIN="$(command -v gtimeout)"
 else
     echo "ERROR: neither 'timeout' nor 'gtimeout' found on PATH." >&2
     echo "  Install GNU coreutils — on macOS: 'brew install coreutils'." >&2


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @Cervator via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

- Pass an explicit `--head <repo>` to `glab mr create` for same-project GitLab MRs so `ws cr` does not infer the upstream `origin` project as the MR source.
- Add `ws review --remote <name>` so review triage can select one remote when the same CR number exists on both upstream and fork remotes.
- Add focused Bats coverage for same-project and cross-fork GitLab MR command construction.
- Add Bats coverage for duplicate-remote review errors and explicit remote selection.
- Store absolute `timeout`/`gtimeout` paths in shared test helpers so PATH-stripping tests remain portable on macOS/Homebrew setups.

## Test plan

- [x] RED: `ws test yggdrasil "same-project GitLab MR pins"` failed on the missing `--head <repo>` assertion.
- [x] RED: `ws test yggdrasil "review --remote"` failed before selector support.
- [x] RED: `ws test yggdrasil "review errors actionably"` failed before ambiguity output listed remote names.
- [x] `ws test yggdrasil "GitLab MR"`
- [x] `ws test yggdrasil "review"`
- [x] `ws review silence 1 --remote rpraestholm-fork-group --compact --limit 30 --output silence-mr1-review-remote`
- [x] `ws review silence threads 1 --remote rpraestholm-fork-group --status`
- [x] `ws test yggdrasil "ws orient --help works when yq is not on PATH"`
- [x] `ws test yggdrasil`
- [x] `git diff --check`

## Related

- Follow-up from dogfooding `ws cr` on a same-project GitLab MR from a non-`origin` fork remote.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI/script and test harness changes only; no auth, data, or production runtime paths beyond clearer GitLab MR and review remote selection.
> 
> **Overview**
> Fixes **same-project GitLab MR creation** by always passing `--head` to `glab mr create`: fork slugs stay as before, and when there is no fork slug the target `--repo` is used so `ws cr` does not treat `origin`/upstream as the MR source project.
> 
> Adds **`ws review --remote <name>`** (all review subcommands) so you can pick a git remote when the same CR number exists on upstream and fork; ambiguous matches now list `remote=slug` pairs and tell you to pass `--remote`.
> 
> Test-only: Bats helpers store an **absolute path** for `timeout`/`gtimeout`, and new coverage locks in GitLab MR `--head` construction and review remote selection/ambiguity errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2cd3a4ca74921076edaf3a0a9d539a78de44cb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--remote <name>` / `--remote=<name>` to `ws review` to choose which git remote is used for resolving and posting review content, including multi-remote disambiguation.

* **Bug Fixes**
  * Fixed GitLab merge request creation for non-fork projects to include the correct `--head` target.

* **Tests**
  * Improved test helpers to resolve the actual `timeout`/`gtimeout` executable path.
  * Added coverage for GitLab provider PR argument handling and for `ws review` behavior when CR/MRs exist on multiple remotes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->