### PR TITLE
docs: de-wrap hard-wrapped prose (no-wrap convention)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,6 @@
 # Yggdrasil — Claude Code
 
-**Read [`AGENTS.md`](AGENTS.md) first** — it contains shared workspace instructions
-including **session startup** (GDD orientation), repo roles, skills, git workflow,
-utility scripts, auth setup, and issue/CR conventions.
+**Read [`AGENTS.md`](AGENTS.md) first** — it contains shared workspace instructions including **session startup** (GDD orientation), repo roles, skills, git workflow, utility scripts, auth setup, and issue/CR conventions.
 
 This file covers only Claude-specific overrides.
 
@@ -10,21 +8,14 @@ This file covers only Claude-specific overrides.
 
 ## Session Conventions
 
-- **Start Claude from `yggdrasil/`** — this is the workspace root. All sessions
-  should use it as the working directory. Avoid starting from `GitWS/` or
-  component subdirectories.
+- **Start Claude from `yggdrasil/`** — this is the workspace root. All sessions should use it as the working directory. Avoid starting from `GitWS/` or component subdirectories.
 - **Workspace CLI:** The `ws` CLI is the shared interface for both humans and AI agents. Always use `bash scripts/ws <cmd>` for workspace operations. Use `bash scripts/ws exec <component> <cmd>` to run commands in component directories — never manually `cd` to components. Subcommands that take a target (commit, push, cr, issue, review, log, diagnose, test, lint) also accept realm and hoard names, not just components. Available: `ws list`, `ws status`, `ws clone`, `ws pull`, `ws push`, `ws cr`, `ws issue`, `ws test`, `ws lint`, `ws review`, `ws commit`, `ws log`, `ws clean`, `ws resolve`, `ws vscode`, `ws exec`, `ws realm`, `ws hoard`, `ws component`, `ws actions`, `ws help`.
-- **Keep commands simple.** `gh`, `yq`, and Git Bash utilities are on PATH.
-  Prefer `bash scripts/ws exec <comp> <cmd>` over manual `cd` + command.
-- On first use of `ws` in a session, briefly note: "Using the workspace CLI
-  (`scripts/ws`). Run `bash scripts/ws help` in your terminal for available
-  commands. Add `export PATH="<yggdrasil>/scripts:$PATH"` to your shell
-  profile for shorthand access."
+- **Keep commands simple.** `gh`, `yq`, and Git Bash utilities are on PATH. Prefer `bash scripts/ws exec <comp> <cmd>` over manual `cd` + command.
+- On first use of `ws` in a session, briefly note: "Using the workspace CLI (`scripts/ws`). Run `bash scripts/ws help` in your terminal for available commands. Add `export PATH="<yggdrasil>/scripts:$PATH"` to your shell profile for shorthand access."
 
 ## Workspace Structure
 
-Yggdrasil is the workspace root. Component repos live in `components/` and
-community realms in `realms/` — both gitignored, independent Git repos.
+Yggdrasil is the workspace root. Component repos live in `components/` and community realms in `realms/` — both gitignored, independent Git repos.
 
 ```text
 yggdrasil/
@@ -48,15 +39,12 @@ yggdrasil/
     ws-vscode.sh          # Generate VS Code workspace file
 ```
 
-Config is three-layer merged: `ecosystem.yaml` → realm → `ecosystem.local.yaml`.
-Use `bash scripts/ws list` to see what's declared and what's checked out locally.
+Config is three-layer merged: `ecosystem.yaml` → realm → `ecosystem.local.yaml`. Use `bash scripts/ws list` to see what's declared and what's checked out locally.
 
 
 ## Committing
 
-**Always use `ws commit`** — never raw `git add` / `git commit`. The `ws commit`
-command handles file staging (via bodyfile `add:` frontmatter) and appends the
-Co-Authored-By trailer automatically. Write a bodyfile to `.commits/` and use:
+**Always use `ws commit`** — never raw `git add` / `git commit`. The `ws commit` command handles file staging (via bodyfile `add:` frontmatter) and appends the Co-Authored-By trailer automatically. Write a bodyfile to `.commits/` and use:
 
 ```bash
 bash scripts/ws commit <component> .commits/<name>.md

--- a/docs/code-style.md
+++ b/docs/code-style.md
@@ -1,9 +1,6 @@
 # Code Style
 
-**Comments and docs describe current state, not history.** Code comments,
-test names, and Javadoc should be grounded in what the code does now — not
-what it used to do or what bug it fixed. Historical context belongs in commit
-messages and CR descriptions, which are the record of change.
+**Comments and docs describe current state, not history.** Code comments, test names, and Javadoc should be grounded in what the code does now — not what it used to do or what bug it fixed. Historical context belongs in commit messages and CR descriptions, which are the record of change.
 
 ## Examples
 

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -2,44 +2,28 @@
 
 ## Prerequisites
 
-After cloning, run `bash scripts/ws preflight` from the workspace root —
-it checks each tool below and prints per-OS install hints for anything
-missing.
+After cloning, run `bash scripts/ws preflight` from the workspace root — it checks each tool below and prints per-OS install hints for anything missing.
 
 **Required:**
 
-- **Bash** — On Windows, use Git Bash (bundled with Git for Windows).
-  Run all `ws` commands from a Git Bash shell, not cmd or PowerShell.
+- **Bash** — On Windows, use Git Bash (bundled with Git for Windows). Run all `ws` commands from a Git Bash shell, not cmd or PowerShell.
 - **Git** itself.
-- **[yq v4+](https://github.com/mikefarah/yq)** — Mike Farah's
-  Go-based YAML processor. *Not* the Python `yq` from PyPI; that's a
-  different tool with incompatible syntax.
-- **[jq](https://jqlang.github.io/jq/)** — JSON processor (used by
-  `ws review` and several internal scripts).
+- **[yq v4+](https://github.com/mikefarah/yq)** — Mike Farah's Go-based YAML processor. *Not* the Python `yq` from PyPI; that's a different tool with incompatible syntax.
+- **[jq](https://jqlang.github.io/jq/)** — JSON processor (used by `ws review` and several internal scripts).
 
 **Provider CLI** (need at least one — match your hosting choice):
 
 - **[gh](https://cli.github.com/)** — for GitHub-hosted components.
-- **[glab](https://gitlab.com/gitlab-org/cli)** — for GitLab-hosted
-  components (gitlab.com or self-hosted instances).
+- **[glab](https://gitlab.com/gitlab-org/cli)** — for GitLab-hosted components (gitlab.com or self-hosted instances).
 
 **Recommended companion (agent-side):**
 
-- **[Obra Superpowers](https://github.com/obra/superpowers)** — a
-  Claude Code plugin that ships skills GDD plans reference
-  (`superpowers:executing-plans`, `superpowers:subagent-driven-development`,
-  `superpowers:brainstorming`, `superpowers:test-driven-development`,
-  `superpowers:receiving-code-review`, etc.). GDD works without it,
-  but plan-driven and review-heavy sessions assume it's available.
-  The `gdd-orientation` skill checks for it at session start and
-  surfaces a nudge if absent.
+- **[Obra Superpowers](https://github.com/obra/superpowers)** — a Claude Code plugin that ships skills GDD plans reference (`superpowers:executing-plans`, `superpowers:subagent-driven-development`, `superpowers:brainstorming`, `superpowers:test-driven-development`, `superpowers:receiving-code-review`, etc.). GDD works without it, but plan-driven and review-heavy sessions assume it's available. The `gdd-orientation` skill checks for it at session start and surfaces a nudge if absent.
 
 **Optional** (only needed for specific component types):
 
-- **[uv](https://docs.astral.sh/uv/)** — Python package manager,
-  for MCP servers and Python components.
-- **realpath** — usually present (coreutils on Linux, Git Bash on
-  Windows); on macOS comes via `brew install coreutils`.
+- **[uv](https://docs.astral.sh/uv/)** — Python package manager, for MCP servers and Python components.
+- **realpath** — usually present (coreutils on Linux, Git Bash on Windows); on macOS comes via `brew install coreutils`.
 
 ### Install hints by OS
 
@@ -51,14 +35,9 @@ missing.
 | gh | `brew install gh` | `winget install GitHub.cli` | [GitHub CLI repo setup](https://cli.github.com) |
 | glab | `brew install glab` | `winget install GLab.GLab` | Download from [glab releases](https://gitlab.com/gitlab-org/cli/-/releases) |
 
-If `winget` isn't available on your Windows version (older SKUs,
-locked-down environments), Chocolatey is the fallback —
-`choco install <tool>` from an **elevated PowerShell** (right-click
-→ Run as administrator). `winget` doesn't need elevation.
+If `winget` isn't available on your Windows version (older SKUs, locked-down environments), Chocolatey is the fallback — `choco install <tool>` from an **elevated PowerShell** (right-click → Run as administrator). `winget` doesn't need elevation.
 
-For provider authentication setup (PATs, `.env` configuration,
-multi-provider workspaces), see
-[`docs/git-provider-setup.md`](git-provider-setup.md).
+For provider authentication setup (PATs, `.env` configuration, multi-provider workspaces), see [`docs/git-provider-setup.md`](git-provider-setup.md).
 
 ## Getting Started
 
@@ -71,8 +50,7 @@ bash scripts/ws clone --all   # Clone all components
 
 ## Workspace CLI (`ws`)
 
-The `ws` script is a unified entry point for workspace operations. It wraps
-the individual `ws-*.sh` scripts and adds component-aware command execution.
+The `ws` script is a unified entry point for workspace operations. It wraps the individual `ws-*.sh` scripts and adds component-aware command execution.
 
 ### Usage
 
@@ -126,8 +104,7 @@ bash scripts/ws log --oneline
 
 ### Optional: Add to PATH
 
-For shorter commands in your terminal, add to your shell profile
-(`~/.bashrc`, `~/.zshrc`, etc.):
+For shorter commands in your terminal, add to your shell profile (`~/.bashrc`, `~/.zshrc`, etc.):
 
 ```bash
 export PATH="/path/to/yggdrasil/scripts:$PATH"
@@ -145,11 +122,7 @@ ws push mimir
 
 Claude Code permissions are configured at two levels:
 
-- **Project** (`.claude/settings.json`, committed) — safe commands auto-approved,
-  `exec` always requires human approval.
+- **Project** (`.claude/settings.json`, committed) — safe commands auto-approved, `exec` always requires human approval.
 - **Local** (`.claude/settings.local.json`, gitignored) — your personal overrides.
 
-To set up local permissions for bulk operations, create
-`.claude/settings.local.json` (gitignored) and add auto-approve patterns
-for side-effect commands you use frequently.
-See `docs/ws-cli-guide.md` for the full pattern reference.
+To set up local permissions for bulk operations, create `.claude/settings.local.json` (gitignored) and add auto-approve patterns for side-effect commands you use frequently. See `docs/ws-cli-guide.md` for the full pattern reference.

--- a/docs/gdd/access.md
+++ b/docs/gdd/access.md
@@ -1,22 +1,15 @@
 # Access — identities, tokens, and remote permissions
 
-The yggdrasil workspace runs with two distinct permission systems
-that are easy to confuse but answer different questions:
+The yggdrasil workspace runs with two distinct permission systems that are easy to confuse but answer different questions:
 
 | Question | Mechanism | Doc |
 |----------|-----------|-----|
 | *Can the agent run this **shell command** without a confirmation prompt?* | `.claude/settings.json` allowlist + Claude Code matcher | [permissions.md](permissions.md) |
 | *Can the agent perform this **remote Git operation** on a repo?* | Token scope + collaborator/fork status + identity selection | this doc |
 
-Both layers must approve an action that crosses both surfaces. A
-`git push` is allowed locally (it's in the matcher's auto-allow set
-or an explicit pattern), but the remote rejects it if the PAT lacks
-push scope or the agent identity isn't a collaborator on the repo.
-Layered defense.
+Both layers must approve an action that crosses both surfaces. A `git push` is allowed locally (it's in the matcher's auto-allow set or an explicit pattern), but the remote rejects it if the PAT lacks push scope or the agent identity isn't a collaborator on the repo. Layered defense.
 
-This doc covers the remote layer: who the agent is, what tokens it
-holds, and how the workspace's fork-and-PR pattern keeps human and
-agent contributions cleanly attributed.
+This doc covers the remote layer: who the agent is, what tokens it holds, and how the workspace's fork-and-PR pattern keeps human and agent contributions cleanly attributed.
 
 ---
 
@@ -24,68 +17,40 @@ agent contributions cleanly attributed.
 
 A GDD session can have **two** Git identities in play:
 
-- **The human contributor** (you). Your GitHub/GitLab username, your
-  PAT for any commands you run interactively. Used for committing
-  via local git config.
-- **The agent identity** (e.g. `agent-refr`). A separate account
-  with its own scoped PAT. Used for `ws push`, `ws cr`, `ws review`
-  reply/resolve, and `gh api` calls that happen via the agent's
-  tooling.
+- **The human contributor** (you). Your GitHub/GitLab username, your PAT for any commands you run interactively. Used for committing via local git config.
+- **The agent identity** (e.g. `agent-refr`). A separate account with its own scoped PAT. Used for `ws push`, `ws cr`, `ws review` reply/resolve, and `gh api` calls that happen via the agent's tooling.
 
 **Why separate identities?** Three reasons:
 
-1. **Reviewable attribution.** Every commit, PR, and review thread
-   is clearly authored by a human or an agent. Co-Authored-By
-   trailers in commit messages preserve the pairing; the actual
-   `Author:` field reflects whoever ran the operation.
-2. **Scope minimization.** The agent PAT can hold *just enough*
-   scope for routine work (`repo`, plus a couple of read scopes).
-   The human PAT might hold more (workflow editing, package
-   publishing, etc.). Compromise of the agent token is bounded.
-3. **Accountability and revocation.** If something goes wrong, you
-   can revoke the agent token immediately without affecting your own
-   day-to-day Git access.
+1. **Reviewable attribution.** Every commit, PR, and review thread is clearly authored by a human or an agent. Co-Authored-By trailers in commit messages preserve the pairing; the actual `Author:` field reflects whoever ran the operation.
+2. **Scope minimization.** The agent PAT can hold *just enough* scope for routine work (`repo`, plus a couple of read scopes). The human PAT might hold more (workflow editing, package publishing, etc.). Compromise of the agent token is bounded.
+3. **Accountability and revocation.** If something goes wrong, you can revoke the agent token immediately without affecting your own day-to-day Git access.
 
-Setup mechanics — installing the CLI tools, generating the tokens,
-loading them via `.env` — live in
-[`docs/git-provider-setup.md`](../git-provider-setup.md). This doc
-focuses on the *patterns* that compose those tokens with the
-workspace's fork-and-PR model.
+Setup mechanics — installing the CLI tools, generating the tokens, loading them via `.env` — live in [`docs/git-provider-setup.md`](../git-provider-setup.md). This doc focuses on the *patterns* that compose those tokens with the workspace's fork-and-PR model.
 
 ---
 
 ## 2. The `forkOrg` pattern
 
-For repos owned by an org you're not a maintainer of (typical for
-upstream open-source contribution), the workflow is:
+For repos owned by an org you're not a maintainer of (typical for upstream open-source contribution), the workflow is:
 
 1. The agent forks the repo under its own org (`forkOrg`).
 2. `ws push <component> <branch>` pushes to that fork.
-3. `ws cr <component> "<title>" <bodyfile>` opens a PR from the
-   fork to the upstream.
+3. `ws cr <component> "<title>" <bodyfile>` opens a PR from the fork to the upstream.
 
-The `forkOrg` is configured per-developer in `ecosystem.local.yaml`
-under `identity.forkOrg:`. With a single remote on a component, no
-disambiguation is needed; with multiple remotes (e.g. you've added
-both upstream and a personal fork manually), `forkOrg` picks which
-side to push to.
+The `forkOrg` is configured per-developer in `ecosystem.local.yaml` under `identity.forkOrg:`. With a single remote on a component, no disambiguation is needed; with multiple remotes (e.g. you've added both upstream and a personal fork manually), `forkOrg` picks which side to push to.
 
-For repos you DO own (your personal namespace), no fork is needed —
-the workspace just pushes to your remote directly.
+For repos you DO own (your personal namespace), no fork is needed — the workspace just pushes to your remote directly.
 
 ---
 
 ## 3. The collaborator pattern (personal repos)
 
-For personal repos — most commonly hoards (`hoards/thalami-<user>/`)
-or personal components — the agent needs write access without forking.
-The pattern: **add the agent identity as a collaborator** on the
-GitHub repo.
+For personal repos — most commonly hoards (`hoards/thalami-<user>/`) or personal components — the agent needs write access without forking. The pattern: **add the agent identity as a collaborator** on the GitHub repo.
 
 Steps for a thalami hoard:
 
-1. Create the personal repo: `gh repo create <user>/thalami-<user>
-   --private --source=hoards/thalami-<user> --remote=<user> --push`.
+1. Create the personal repo: `gh repo create <user>/thalami-<user> --private --source=hoards/thalami-<user> --remote=<user> --push`.
 2. Add the agent as collaborator:
 
    ```bash
@@ -93,22 +58,15 @@ Steps for a thalami hoard:
        -X PUT -f permission=push
    ```
 
-3. The agent's PAT (which has `repo` scope) now inherits write
-   access via the collaboration — `ws push thalami-<user>` works
-   without needing the agent to fork your personal repo.
+3. The agent's PAT (which has `repo` scope) now inherits write access via the collaboration — `ws push thalami-<user>` works without needing the agent to fork your personal repo.
 
-This pattern is key for GDD's "personal piles" story. Without it,
-multi-machine thalami sync would require manual git operations from
-the human's account on every machine.
+This pattern is key for GDD's "personal piles" story. Without it, multi-machine thalami sync would require manual git operations from the human's account on every machine.
 
 ---
 
 ## 4. Token scopes in practice
 
-The agent PAT's scope set determines what it can do remotely. The
-recommended baseline is one write scope plus three read scopes —
-all the read scopes are low-risk additions that just remove
-recurring papercuts in routine PR/review operations:
+The agent PAT's scope set determines what it can do remotely. The recommended baseline is one write scope plus three read scopes — all the read scopes are low-risk additions that just remove recurring papercuts in routine PR/review operations:
 
 | Scope | What it enables |
 |-------|-----------------|
@@ -117,43 +75,21 @@ recurring papercuts in routine PR/review operations:
 | `read:discussion` | Read discussion threads. `gh pr edit` checks this. |
 | `read:project` | Read GitHub Projects (boards, items). `gh pr edit --body-file` checks this. |
 
-`workflow` scope is needed only if the agent edits files under
-`.github/workflows/`. Most GDD work doesn't touch CI definitions.
+`workflow` scope is needed only if the agent edits files under `.github/workflows/`. Most GDD work doesn't touch CI definitions.
 
-The three `read:*` scopes don't grant any mutation power and don't
-unlock any code the agent can't already reach via `repo` — they're
-metadata reads that gate routine `gh pr edit`-shaped operations.
-Compromise of the agent token isn't meaningfully expanded by adding
-them; declining them just means hitting the `gh api PATCH` fallback
-below for every PR-edit-shaped call.
+The three `read:*` scopes don't grant any mutation power and don't unlock any code the agent can't already reach via `repo` — they're metadata reads that gate routine `gh pr edit`-shaped operations. Compromise of the agent token isn't meaningfully expanded by adding them; declining them just means hitting the `gh api PATCH` fallback below for every PR-edit-shaped call.
 
-**Strict-minimum** (when org policy or paranoia gates the read
-scopes): `repo` alone, with the `gh api -X PATCH
-repos/<owner>/<repo>/pulls/<n> --input <file>` workaround for
-PR-edit operations. `gh api` expects the HTTP method via
-`-X`/`--method`, not as a positional argument. On Windows Git
-Bash, drop the leading `/` from the API path to avoid MSYS path
-conversion rewriting it as a Windows filesystem path.
+**Strict-minimum** (when org policy or paranoia gates the read scopes): `repo` alone, with the `gh api -X PATCH repos/<owner>/<repo>/pulls/<n> --input <file>` workaround for PR-edit operations. `gh api` expects the HTTP method via `-X`/`--method`, not as a positional argument. On Windows Git Bash, drop the leading `/` from the API path to avoid MSYS path conversion rewriting it as a Windows filesystem path.
 
-When in doubt about whether a token covers an operation, run
-`ws diagnose <component>` — it reports per-component remote
-detection, expected token variable, and whether the token is
-present and authenticated.
+When in doubt about whether a token covers an operation, run `ws diagnose <component>` — it reports per-component remote detection, expected token variable, and whether the token is present and authenticated.
 
 ---
 
 ## 5. Multi-provider workflows
 
-The workspace is provider-agnostic. A component on GitHub uses
-`GH_TOKEN`; a component on GitLab uses `GITLAB_TOKEN`; a self-hosted
-Forgejo or Gitea instance uses whatever variable you map under
-`defaults.gitTokens` in the realm or local config.
+The workspace is provider-agnostic. A component on GitHub uses `GH_TOKEN`; a component on GitLab uses `GITLAB_TOKEN`; a self-hosted Forgejo or Gitea instance uses whatever variable you map under `defaults.gitTokens` in the realm or local config.
 
-`ws push`, `ws cr`, `ws review`, etc. all auto-detect the provider
-from the component's remote URL and pick the right CLI (`gh` vs
-`glab`) and the right token. Mixed-provider workspaces (some
-components on GitHub, some on GitLab) work without per-command
-configuration — the dispatcher handles it.
+`ws push`, `ws cr`, `ws review`, etc. all auto-detect the provider from the component's remote URL and pick the right CLI (`gh` vs `glab`) and the right token. Mixed-provider workspaces (some components on GitHub, some on GitLab) work without per-command configuration — the dispatcher handles it.
 
 Tokens for additional providers go in `.env`:
 
@@ -163,20 +99,9 @@ export GITLAB_TOKEN=glpat_xxx
 # Add more as needed for self-hosted instances
 ```
 
-The mapping from provider → token variable lives in your realm's
-`ecosystem.yaml` under `defaults.gitTokens`, or override per-developer
-in `ecosystem.local.yaml`.
+The mapping from provider → token variable lives in your realm's `ecosystem.yaml` under `defaults.gitTokens`, or override per-developer in `ecosystem.local.yaml`.
 
-**Default behavior with no `gitTokens` entry.** For GitHub remotes,
-`gh` reads `$GH_TOKEN` automatically — no `gitTokens` entry needed
-in the common case. Same for GitLab: `glab` reads `$GITLAB_TOKEN`.
-`ws diagnose` reports this as `✓ <VAR> is set (default for
-<provider>; no gitTokens entry needed)`. You only need an explicit
-`gitTokens` entry when you want **fine-grained per-namespace control**
-— e.g., the org repos use the team's `GH_TOKEN` but your personal
-forks under `<your-user>` should use a different `GH_TOKEN_PERSONAL`.
-In that case, add a longer-prefix `gitTokens` entry that wins the
-longest-prefix match for the personal namespace:
+**Default behavior with no `gitTokens` entry.** For GitHub remotes, `gh` reads `$GH_TOKEN` automatically — no `gitTokens` entry needed in the common case. Same for GitLab: `glab` reads `$GITLAB_TOKEN`. `ws diagnose` reports this as `✓ <VAR> is set (default for <provider>; no gitTokens entry needed)`. You only need an explicit `gitTokens` entry when you want **fine-grained per-namespace control** — e.g., the org repos use the team's `GH_TOKEN` but your personal forks under `<your-user>` should use a different `GH_TOKEN_PERSONAL`. In that case, add a longer-prefix `gitTokens` entry that wins the longest-prefix match for the personal namespace:
 
 ```yaml
 defaults:
@@ -187,72 +112,35 @@ defaults:
       var: GH_TOKEN_PERSONAL
 ```
 
-Without that entry, both namespaces flow through the same default
-`GH_TOKEN` — fine for most setups; only worth splitting when the
-isolation is intentional.
+Without that entry, both namespaces flow through the same default `GH_TOKEN` — fine for most setups; only worth splitting when the isolation is intentional.
 
 ### GitLab specifics (gitlab.com or self-hosted)
 
-GitLab's API model differs from GitHub's enough that the same
-abstract pattern (fork → push → MR) plays out differently in
-practice. Notes from real workflows on self-hosted GitLab:
+GitLab's API model differs from GitHub's enough that the same abstract pattern (fork → push → MR) plays out differently in practice. Notes from real workflows on self-hosted GitLab:
 
-**The biggest model flip:** on GitHub, `gh pr create` POSTs to the
-**upstream's** API. On GitLab, `glab mr create` POSTs to the
-**fork's** API — the `--repo` flag looks like a target but the
-actual POST goes through the fork project. Consequence: the **fork
-write token**, not the upstream reporter token, is the one needed
-for MR creation, even though the MR targets upstream. This may catch
-people the first time.
+**The biggest model flip:** on GitHub, `gh pr create` POSTs to the **upstream's** API. On GitLab, `glab mr create` POSTs to the **fork's** API — the `--repo` flag looks like a target but the actual POST goes through the fork project. Consequence: the **fork write token**, not the upstream reporter token, is the one needed for MR creation, even though the MR targets upstream. This may catch people the first time.
 
-**Two-token model.** Every fork-based GitLab operation needs two
-distinct tokens, configured in `defaults.gitTokens` (longest URL
-prefix wins, so a fork-group entry shadows the upstream group entry
-for repos in the fork namespace):
+**Two-token model.** Every fork-based GitLab operation needs two distinct tokens, configured in `defaults.gitTokens` (longest URL prefix wins, so a fork-group entry shadows the upstream group entry for repos in the fork namespace):
 
 | Token | Role | Used for |
 |-------|------|----------|
 | **Fork write** | Developer on fork group | Push branches, create MRs |
 | **Upstream reporter** | Reporter on upstream group | Read default branch, read MR threads (`ws review`), file issues |
 
-**GitLab PATs cannot be downscoped.** A Personal Access Token runs
-*as you* and inherits your full account access — there's no way to
-issue a "read-only on group X" PAT when you're an Owner there. The
-GitLab-native workaround is **Group Access Tokens** or **Project
-Access Tokens**, which carry an explicit role independent of any
-user. On paid tiers and self-hosted instances, create one at
-`Settings → Access Tokens` for the group/project. On gitlab.com
-free tier these aren't available — point both token vars at the
-same PAT and accept the over-scope.
+**GitLab PATs cannot be downscoped.** A Personal Access Token runs *as you* and inherits your full account access — there's no way to issue a "read-only on group X" PAT when you're an Owner there. The GitLab-native workaround is **Group Access Tokens** or **Project Access Tokens**, which carry an explicit role independent of any user. On paid tiers and self-hosted instances, create one at `Settings → Access Tokens` for the group/project. On gitlab.com free tier these aren't available — point both token vars at the same PAT and accept the over-scope.
 
-**Bot attribution trade-off.** MRs opened via a Group Access Token
-appear as authored by `project_NNN_bot_...`, not your personal
-account. The workspace mitigates this with two layers:
-(1) the fork namespace path makes your username visible in the MR
-source header, (2) `@HUMAN_ACCOUNT` substitution puts your handle
-in the MR body. Adequate for team workflows; not sufficient for
-formal audit trails that require the GitLab `author` field to be a
-human identity.
+**Bot attribution trade-off.** MRs opened via a Group Access Token appear as authored by `project_NNN_bot_...`, not your personal account. The workspace mitigates this with two layers: (1) the fork namespace path makes your username visible in the MR source header, (2) `@HUMAN_ACCOUNT` substitution puts your handle in the MR body. Adequate for team workflows; not sufficient for formal audit trails that require the GitLab `author` field to be a human identity.
 
 **glab gotchas worth knowing up front:**
 
-- `glab issue list` and several other subcommands require
-  `GITLAB_HOST` in the environment for self-hosted instances. There's
-  no `--hostname` flag on subcommands. Set it in `.env`.
+- `glab issue list` and several other subcommands require `GITLAB_HOST` in the environment for self-hosted instances. There's no `--hostname` flag on subcommands. Set it in `.env`.
 - `glab auth login` configures API calls but does **not** automatically make raw HTTPS Git operations non-interactive. `ws push` uses the matching `.env` / `defaults.gitTokens` token for its own HTTPS push process and disables credential-helper prompts, so it does not need a keychain entry. Raw `git clone` / `git push` still need SSH URLs or a credential helper if you run them outside `ws`.
-- `GITLAB_TOKEN` must be set for `glab` to authenticate (parallel to
-  `GH_TOKEN` for `gh`).
-- `glab mr create --head <ref>` expects the **full fork project
-  slug** (e.g. `<your-user>/<repo>`), not just a branch name.
+- `GITLAB_TOKEN` must be set for `glab` to authenticate (parallel to `GH_TOKEN` for `gh`).
+- `glab mr create --head <ref>` expects the **full fork project slug** (e.g. `<your-user>/<repo>`), not just a branch name.
 
-**`identity.forkOrg` must match the GitLab namespace exactly.** If
-your forks live at `gitlab.com/<your-user>/...`, set `forkOrg:
-<your-user>` in `ecosystem.local.yaml`. Easy to get wrong if your
-fork namespace differs from your login handle.
+**`identity.forkOrg` must match the GitLab namespace exactly.** If your forks live at `gitlab.com/<your-user>/...`, set `forkOrg: <your-user>` in `ecosystem.local.yaml`. Easy to get wrong if your fork namespace differs from your login handle.
 
-**The verified workflow on GitLab** (in practice on self-hosted,
-mirrors the GitHub flow but with provider-specific details
-substituted):
+**The verified workflow on GitLab** (in practice on self-hosted, mirrors the GitHub flow but with provider-specific details substituted):
 
 ```text
 ws diagnose <comp>                          # check token coverage first
@@ -268,8 +156,7 @@ git checkout main
 git pull <upstream-remote> main
 ```
 
-Running `ws diagnose <comp>` before the first push to a new
-component reveals missing token vars before you hit a 403 mid-CR.
+Running `ws diagnose <comp>` before the first push to a new component reveals missing token vars before you hit a 403 mid-CR.
 
 ---
 
@@ -287,40 +174,22 @@ It reports:
 - The expected token variable for that provider.
 - Whether the token is set in the environment (✓ / ✗).
 - Whether `gh auth status` (or equivalent) succeeds.
-- Whether the agent identity has access to the remote (read at
-  minimum; push requires further verification by attempting one).
+- Whether the agent identity has access to the remote (read at minimum; push requires further verification by attempting one).
 
-If `ws diagnose` shows ✗ for token coverage, the operation will
-fail with an opaque auth error at runtime; fix the missing token
-or scope first. The orientation skill runs `ws diagnose` proactively
-on components likely to be pushed during the session — see
-[`gdd-orientation` Step 6b](../../.agent/skills/gdd-orientation/SKILL.md).
+If `ws diagnose` shows ✗ for token coverage, the operation will fail with an opaque auth error at runtime; fix the missing token or scope first. The orientation skill runs `ws diagnose` proactively on components likely to be pushed during the session — see [`gdd-orientation` Step 6b](../../.agent/skills/gdd-orientation/SKILL.md).
 
 ---
 
 ## 7. Future direction: scope-templated PATs
 
-Today's pattern asks the human to manually create a PAT with the
-right scopes. A future improvement is workflow-aware scope templates
-— "workflow A needs scopes X+Y; workflow B needs X+Z" — surfaced
-as `ws diagnose` recommendations or `ws auth setup` interactive
-flows. Not implemented in v1; tracked under the broader
-"onboarding and identity" design doc (see Thalamus / project-level
-backlog).
+Today's pattern asks the human to manually create a PAT with the right scopes. A future improvement is workflow-aware scope templates — "workflow A needs scopes X+Y; workflow B needs X+Z" — surfaced as `ws diagnose` recommendations or `ws auth setup` interactive flows. Not implemented in v1; tracked under the broader "onboarding and identity" design doc (see Thalamus / project-level backlog).
 
 ---
 
 ## See also
 
-- [Permissions](permissions.md) — the *local* permission system
-  (shell command allowlisting). Pairs with this doc; together they
-  cover "what the agent can do."
-- [`docs/git-provider-setup.md`](../git-provider-setup.md) —
-  setup mechanics: installing CLIs, generating tokens, loading
-  via `.env`.
-- [Trust and Safety](trust-and-safety.md) — the broader trust
-  hierarchy that places agent vs human identity in context.
-- [Hoards](hoards.md) — the canonical case for the collaborator
-  pattern (personal multi-machine sync).
-- [Features Tour](features.md) — where access control fits in the
-  larger feature set.
+- [Permissions](permissions.md) — the *local* permission system (shell command allowlisting). Pairs with this doc; together they cover "what the agent can do."
+- [`docs/git-provider-setup.md`](../git-provider-setup.md) — setup mechanics: installing CLIs, generating tokens, loading via `.env`.
+- [Trust and Safety](trust-and-safety.md) — the broader trust hierarchy that places agent vs human identity in context.
+- [Hoards](hoards.md) — the canonical case for the collaborator pattern (personal multi-machine sync).
+- [Features Tour](features.md) — where access control fits in the larger feature set.

--- a/docs/gdd/adapters.md
+++ b/docs/gdd/adapters.md
@@ -26,7 +26,7 @@ ai_context:
 - **`commands`** — a map from action name to shell command. Keys are free-form (`build`, `test`, `lint`, `serve`, anything the community cares to expose). Values run from the component directory.
 - **`ai_context`** — optional list of paths agents should orient against when working on the component, with one-line descriptions.
 
-A starter file with comments ships in the upstream [`realm-template`](https://github.com/SiliconSage/realm-template) repo (cloned via `ws realm init`) at `adapters/example.yaml`. Copy it to your community realm at `realms/<your-realm>/adapters/<comp>.yaml` and edit. See [Realms](realms.md) for the realm-template's role in the workspace.
+A starter file with comments ships in the upstream [`realm-template`](https://github.com/SiliconSaga/realm-template) repo (cloned via `ws realm init`) at `adapters/example.yaml`. Copy it to your community realm at `realms/<your-realm>/adapters/<comp>.yaml` and edit. See [Realms](realms.md) for the realm-template's role in the workspace.
 
 ---
 

--- a/docs/gdd/adapters.md
+++ b/docs/gdd/adapters.md
@@ -23,13 +23,10 @@ ai_context:
     description: "Architecture overview for AI orientation"
 ```
 
-- **`commands`** — a map from action name to shell command. Keys are
-  free-form (`build`, `test`, `lint`, `serve`, anything the community
-  cares to expose). Values run from the component directory.
-- **`ai_context`** — optional list of paths agents should orient
-  against when working on the component, with one-line descriptions.
+- **`commands`** — a map from action name to shell command. Keys are free-form (`build`, `test`, `lint`, `serve`, anything the community cares to expose). Values run from the component directory.
+- **`ai_context`** — optional list of paths agents should orient against when working on the component, with one-line descriptions.
 
-A starter file with comments ships in the upstream [`realm-template`](https://github.com/SiliconSaga/realm-template) repo (cloned via `ws realm init`) at `adapters/example.yaml`. Copy it to your community realm at `realms/<your-realm>/adapters/<comp>.yaml` and edit. See [Realms](realms.md) for the realm-template's role in the workspace.
+A starter file with comments ships in the upstream [`realm-template`](https://github.com/SiliconSage/realm-template) repo (cloned via `ws realm init`) at `adapters/example.yaml`. Copy it to your community realm at `realms/<your-realm>/adapters/<comp>.yaml` and edit. See [Realms](realms.md) for the realm-template's role in the workspace.
 
 ---
 
@@ -64,10 +61,8 @@ ws actions <component>
 
 The command prints two sections:
 
-- **Configured (from realm)** — commands declared in the adapter file,
-  if one exists for the component.
-- **Auto-detected** — what the workspace would fall back to if no
-  adapter file existed (e.g. `./gradlew build`, `go test ./...`).
+- **Configured (from realm)** — commands declared in the adapter file, if one exists for the component.
+- **Auto-detected** — what the workspace would fall back to if no adapter file existed (e.g. `./gradlew build`, `go test ./...`).
 
 If the component has neither an adapter file nor a recognized build system, `ws actions` prints a hint pointing at the path you'd create to add one.
 
@@ -79,21 +74,14 @@ For execution (`ws test`), realm-configured `commands.test` takes precedence ove
 
 The auto-detect fallback covers the common case for `ws test` — a Gradle component gets `./gradlew test` for free. Add an adapter file when:
 
-- The component uses a non-default test runner the workspace doesn't
-  auto-detect.
-- You want to document project-specific commands (e.g. `e2e`,
-  `migrate`, `bench`) so `ws actions` surfaces them for agents and
-  contributors.
-- Different communities want different defaults for the same
-  component (one realm wires `test` to a quick subset, another wires
-  it to the full suite).
+- The component uses a non-default test runner the workspace doesn't auto-detect.
+- You want to document project-specific commands (e.g. `e2e`, `migrate`, `bench`) so `ws actions` surfaces them for agents and contributors.
+- Different communities want different defaults for the same component (one realm wires `test` to a quick subset, another wires it to the full suite).
 
 ---
 
 ## See also
 
-- [Realms](realms.md) — where adapter files live and why they're
-  realm-side configuration.
-- [Ecosystem Architecture](../ecosystem-architecture.md) — how realms
-  fit into the three-layer config merge.
+- [Realms](realms.md) — where adapter files live and why they're realm-side configuration.
+- [Ecosystem Architecture](../ecosystem-architecture.md) — how realms fit into the three-layer config merge.
 - [`ws help actions`](../ws-cli-guide.md) — CLI behavior and arguments.

--- a/docs/gdd/cr-internals.md
+++ b/docs/gdd/cr-internals.md
@@ -1,26 +1,19 @@
 # CR Internals — Cross-Fork Change Requests
 
-This document covers the internal mechanics of cross-fork CR creation in yggdrasil.
-It is aimed at realm maintainers and contributors debugging token or MR creation
-issues — not regular GDD users.
+This document covers the internal mechanics of cross-fork CR creation in yggdrasil. It is aimed at realm maintainers and contributors debugging token or MR creation issues — not regular GDD users.
 
 ## Overview: The Two-Token Model
 
-When you run `ws cr <component> --upstream`, yggdrasil operates with two tokens
-in the cross-fork case:
+When you run `ws cr <component> --upstream`, yggdrasil operates with two tokens in the cross-fork case:
 
 | Token | Role | Used for |
 |---|---|---|
 | Fork write token | Developer (fork group) | Pushing branches, creating MRs/PRs |
 | Upstream reporter token | Reporter (upstream group) | Reading upstream metadata, creating issues, reading MR comments and threads (`ws review`) |
 
-Both tokens are needed. The upstream reporter token covers all read and issue operations
-against the upstream project — not just default-branch lookup. Eliminating it from
-the CR path would still leave it required for `ws review` and `ws issue`.
+Both tokens are needed. The upstream reporter token covers all read and issue operations against the upstream project — not just default-branch lookup. Eliminating it from the CR path would still leave it required for `ws review` and `ws issue`.
 
-These tokens are configured in the ecosystem config's `defaults.gitTokens` map,
-keyed by URL prefix. The longest matching prefix wins, so a fork-group token
-(longer path) takes precedence over a parent-group token for the same host.
+These tokens are configured in the ecosystem config's `defaults.gitTokens` map, keyed by URL prefix. The longest matching prefix wins, so a fork-group token (longer path) takes precedence over a parent-group token for the same host.
 
 ## GitHub: Cross-Fork PR Flow
 
@@ -32,22 +25,15 @@ ws cr <component> --upstream
        --base  main
 ```
 
-On **GitHub**, the `gh` CLI creates the PR by calling the **upstream project's API**.
-PR creation only requires read access to the upstream (GitHub allows PR creation
-from any repo you can read, including public ones).
+On **GitHub**, the `gh` CLI creates the PR by calling the **upstream project's API**. PR creation only requires read access to the upstream (GitHub allows PR creation from any repo you can read, including public ones).
 
 **Whether one or two tokens are needed depends on token type:**
 
-- **Classic PAT or account with team membership on both sides**: a single token
-  covers push to fork and PR creation against upstream. No split needed.
-- **Fine-grained PAT scoped to fork org only**: works when the upstream is public
-  (readable without explicit access). The SiliconSaga/MovingBlocks setup is an
-  example — `GH_TOKEN` is scoped to SiliconSaga, and MovingBlocks repos are public.
-- **Fine-grained PAT with explicit upstream access**: also a single token, just
-  scoped to both orgs.
+- **Classic PAT or account with team membership on both sides**: a single token covers push to fork and PR creation against upstream. No split needed.
+- **Fine-grained PAT scoped to fork org only**: works when the upstream is public (readable without explicit access). The SiliconSaga/MovingBlocks setup is an example — `GH_TOKEN` is scoped to SiliconSaga, and MovingBlocks repos are public.
+- **Fine-grained PAT with explicit upstream access**: also a single token, just scoped to both orgs.
 
-The two-token split is not a GitHub requirement — it's a GitLab necessity that
-happens to map onto GitHub fine-grained tokens naturally.
+The two-token split is not a GitHub requirement — it's a GitLab necessity that happens to map onto GitHub fine-grained tokens naturally.
 
 ## GitLab: Cross-Fork MR Flow
 
@@ -60,13 +46,9 @@ ws cr <component> --upstream
        --target-branch  main
 ```
 
-On **GitLab**, `glab mr create` uses the `--head OWNER/REPO` flag to identify
-the fork. With this flag, glab calls the **fork project's API** to create the
-MR — not the upstream's API. GitLab's MR creation endpoint lives on the source
-(fork) project.
+On **GitLab**, `glab mr create` uses the `--head OWNER/REPO` flag to identify the fork. With this flag, glab calls the **fork project's API** to create the MR — not the upstream's API. GitLab's MR creation endpoint lives on the source (fork) project.
 
-This is the opposite of how GitHub works, and opposite of what the `--repo`
-argument implies at first glance.
+This is the opposite of how GitHub works, and opposite of what the `--repo` argument implies at first glance.
 
 **Consequence for token selection in git-cr.sh:**
 
@@ -80,9 +62,7 @@ argument implies at first glance.
                 ...
 ```
 
-The token must be switched between the two calls. Using only the reporter
-token for both will produce a `403 Forbidden` from the fork project, since
-the reporter token has no write access there.
+The token must be switched between the two calls. Using only the reporter token for both will produce a `403 Forbidden` from the fork project, since the reporter token has no write access there.
 
 ## Summary: Which Token Goes Where
 
@@ -94,76 +74,41 @@ the reporter token has no write access there.
 | `ws review` (MR comments, threads) | Any token with upstream read | Upstream reporter token |
 | `ws issue` (create issue on upstream) | Any token with upstream read | Upstream reporter token |
 
-On GitHub, "any token with upstream read" may be a single token that also covers
-the fork — especially with classic PATs or public upstreams. On GitLab with private
-groups, separate tokens are required because the fork group and upstream group each
-need explicit access grants.
+On GitHub, "any token with upstream read" may be a single token that also covers the fork — especially with classic PATs or public upstreams. On GitLab with private groups, separate tokens are required because the fork group and upstream group each need explicit access grants.
 
-The fundamental difference: GitHub owns the PR on the upstream side; GitLab owns
-the MR on the source (fork) side. This is reflected in which project's API
-endpoint is called during creation.
+The fundamental difference: GitHub owns the PR on the upstream side; GitLab owns the MR on the source (fork) side. This is reflected in which project's API endpoint is called during creation.
 
 ## Token Types, Machine Users, and Corporate GitLab
 
 ### GitHub: two approaches to scoping
 
-On GitHub you have two legitimate options for limiting the blast radius of an
-automation token:
+On GitHub you have two legitimate options for limiting the blast radius of an automation token:
 
-1. **Fine-grained PAT on your own account** — GitHub lets you scope these below
-   your actual access level. You can be an org owner and issue a PAT that only
-   has write on your fork org and read on the upstream. The PR is posted as *you*,
-   with your full username and avatar visible in the GitHub UI. The scoping is
-   enforced at the token level, not the account level.
+1. **Fine-grained PAT on your own account** — GitHub lets you scope these below your actual access level. You can be an org owner and issue a PAT that only has write on your fork org and read on the upstream. The PR is posted as *you*, with your full username and avatar visible in the GitHub UI. The scoping is enforced at the token level, not the account level.
 
-2. **Dedicated machine user** (separate GitHub account) — an older pattern that
-   predates fine-grained PATs. A separate account with a classic token is granted 
-   only the team memberships it needs. The PR appears as the machine user, not you 
-   personally. Still common and valid, but no longer strictly necessary on GitHub.
+2. **Dedicated machine user** (separate GitHub account) — an older pattern that predates fine-grained PATs. A separate account with a classic token is granted only the team memberships it needs. The PR appears as the machine user, not you personally. Still common and valid, but no longer strictly necessary on GitHub.
 
-The key point: on GitHub, option 1 lets you post as your own human account while
-still running with restricted permissions.
+The key point: on GitHub, option 1 lets you post as your own human account while still running with restricted permissions.
 
 ### GitLab: PATs cannot be downscoped
 
-A GitLab Personal Access Token runs as the creating user and inherits their full
-access level. If your account is Owner of `group/project`, your PAT is effectively
-Owner too — there is no way to issue a PAT that has only Reporter access to a
-group where you have Owner access.
+A GitLab Personal Access Token runs as the creating user and inherits their full access level. If your account is Owner of `group/project`, your PAT is effectively Owner too — there is no way to issue a PAT that has only Reporter access to a group where you have Owner access.
 
-The GitLab-native solution is **Group Access Tokens** and **Project Access Tokens**,
-which are created with an explicit role independent of any user. This is what
-yggdrasil uses on self-hosted/paid tiers (e.g. `GITLAB_GDD_GROUP_REPORTER_TOKEN`,
-`GITLAB_GDD_GROUP_WRITE_TOKEN`). On gitlab.com free tier, these token types are not
-available — use a Personal Access Token instead, and point both env vars at the
-same PAT to maintain the routing pattern.
+The GitLab-native solution is **Group Access Tokens** and **Project Access Tokens**, which are created with an explicit role independent of any user. This is what yggdrasil uses on self-hosted/paid tiers (e.g. `GITLAB_GDD_GROUP_REPORTER_TOKEN`, `GITLAB_GDD_GROUP_WRITE_TOKEN`). On gitlab.com free tier, these token types are not available — use a Personal Access Token instead, and point both env vars at the same PAT to maintain the routing pattern.
 
-**Machine users on corporate GitLab** are often not an option either — user
-accounts may be managed by IT/SSO, so you can't create a dedicated bot account
-as easily as you could on the public cloud GitLab or GitHub.
+**Machine users on corporate GitLab** are often not an option either — user accounts may be managed by IT/SSO, so you can't create a dedicated bot account as easily as you could on the public cloud GitLab or GitHub.
 
-The result: on GitLab, CRs submitted by the agent appear as opened by a bot user
-(`project_NNN_bot_...`), not your personal account.
+The result: on GitLab, CRs submitted by the agent appear as opened by a bot user (`project_NNN_bot_...`), not your personal account.
 
 ### Human attribution on GitLab
 
-Since the GitLab UI shows the bot as the MR author, yggdrasil uses two layers of
-attribution to tie the CR back to the human who initiated it:
+Since the GitLab UI shows the bot as the MR author, yggdrasil uses two layers of attribution to tie the CR back to the human who initiated it:
 
-1. **Fork namespace path** — the MR source is `youruser/project`, making the
-   human's name visible in the MR header even if the opener is a bot.
+1. **Fork namespace path** — the MR source is `youruser/project`, making the human's name visible in the MR header even if the opener is a bot.
 
-2. **`@HUMAN_ACCOUNT` in the MR body** — the CR template substitutes the
-   `identity.human_account` value (e.g. `@youruser`) into the body at creation
-   time, so the human is explicitly named in the description.
+2. **`@HUMAN_ACCOUNT` in the MR body** — the CR template substitutes the `identity.human_account` value (e.g. `@youruser`) into the body at creation time, so the human is explicitly named in the description.
 
-This is an accepted trade-off for now. It provides adequate attribution for
-most team workflows, but may not satisfy formal audit requirements that expect
-the GitLab *author* field to match a human identity. If that becomes a
-requirement, the path forward would be a per-developer PAT with exactly Reporter
-access to the upstream — but since GitLab PATs can't be downscoped, that token
-would carry your full account permissions on that group, which is a wider blast
-radius than the Group Access Token approach.
+This is an accepted trade-off for now. It provides adequate attribution for most team workflows, but may not satisfy formal audit requirements that expect the GitLab *author* field to match a human identity. If that becomes a requirement, the path forward would be a per-developer PAT with exactly Reporter access to the upstream — but since GitLab PATs can't be downscoped, that token would carry your full account permissions on that group, which is a wider blast radius than the Group Access Token approach.
 
 ## See Also
 

--- a/docs/gdd/hoards.md
+++ b/docs/gdd/hoards.md
@@ -1,41 +1,21 @@
 # Hoards
 
-A **hoard** is a personal git repo that lives inside the workspace at
-`hoards/<type>-<user>/`, alongside the components and realms. The
-yggdrasil workspace is the only "shared" part of the tree — components
-and realms come from elsewhere; hoards come from *you*. They're a
-catch-all for content that isn't a component (a project) and isn't a
-realm (community config), but still wants to live next to your work
-and ride the same `ws` CLI for sync.
+A **hoard** is a personal git repo that lives inside the workspace at `hoards/<type>-<user>/`, alongside the components and realms. The yggdrasil workspace is the only "shared" part of the tree — components and realms come from elsewhere; hoards come from *you*. They're a catch-all for content that isn't a component (a project) and isn't a realm (community config), but still wants to live next to your work and ride the same `ws` CLI for sync.
 
-The canonical hoard type is **thalami** — the per-developer container
-for the [Thalamus](thalamus.md). Other hoard types are likely to
-emerge as the framework gets used (knowledgebase vaults, scratch
-spaces, personal experiments); the architecture is intentionally
-generic so they slot in without redesign.
+The canonical hoard type is **thalami** — the per-developer container for the [Thalamus](thalamus.md). Other hoard types are likely to emerge as the framework gets used (knowledgebase vaults, scratch spaces, personal experiments); the architecture is intentionally generic so they slot in without redesign.
 
 ---
 
 ## Why hoards live where they do
 
-A hoard is "personal" but not necessarily "private." A thalami hoard
-typically pushes to a private GitHub repo on your namespace, but
-nothing stops you from keeping it local-only or making it public.
+A hoard is "personal" but not necessarily "private." A thalami hoard typically pushes to a private GitHub repo on your namespace, but nothing stops you from keeping it local-only or making it public.
 
 The placement at `hoards/<type>-<user>/` matters for two reasons:
 
-1. **`ws` operations work transparently.** `ws status`, `ws commit`,
-   `ws push`, `ws log` all walk hoards the same way they walk
-   components — no `cd hoards/...` needed.
-2. **Multi-machine sync via git.** Edit on one machine, commit, push,
-   pull on another. The thalami type uses per-machine files
-   (`<machine>-thalamus.md`) so two machines don't collide on the
-   same lines, but they share the hoard's audit log and any
-   committed history.
+1. **`ws` operations work transparently.** `ws status`, `ws commit`, `ws push`, `ws log` all walk hoards the same way they walk components — no `cd hoards/...` needed.
+2. **Multi-machine sync via git.** Edit on one machine, commit, push, pull on another. The thalami type uses per-machine files (`<machine>-thalamus.md`) so two machines don't collide on the same lines, but they share the hoard's audit log and any committed history.
 
-Hoards are gitignored from the workspace itself — they're independent
-git repos, just like components. The workspace's `.gitignore` lists
-`hoards/`; the workspace's history doesn't track them.
+Hoards are gitignored from the workspace itself — they're independent git repos, just like components. The workspace's `.gitignore` lists `hoards/`; the workspace's history doesn't track them.
 
 ---
 
@@ -47,101 +27,56 @@ ws hoard init                  # creates hoards/thalami-<your-user>/
 ws hoard init --from-thalamus
 ```
 
-The output prints a `gh repo create` next-step. For a private personal
-hoard, run something like:
+The output prints a `gh repo create` next-step. For a private personal hoard, run something like:
 
 ```bash
 gh repo create <user>/thalami-<user> --private \
   --source=hoards/thalami-<user> --remote=<user> --push
 ```
 
-If you want the agent's PAT to be able to push to your hoard (so
-`ws push thalami-<user>` works without a personal interactive
-auth step), add `agent-refr` (or whatever your agent identity is)
-as a GitHub collaborator on the hoard repo. The PAT inherits write
-access via that collaboration.
+If you want the agent's PAT to be able to push to your hoard (so `ws push thalami-<user>` works without a personal interactive auth step), add `agent-refr` (or whatever your agent identity is) as a GitHub collaborator on the hoard repo. The PAT inherits write access via that collaboration.
 
-After `init`, `ws status` will show the new hoard in its listing,
-and the next session's orientation will resolve it as the active
-thalami hoard.
+After `init`, `ws status` will show the new hoard in its listing, and the next session's orientation will resolve it as the active thalami hoard.
 
 ---
 
 ## Per-machine files
 
-The thalami hoard contains one `<machine>-thalamus.md` file per
-workstation you use. The machine name comes from the environment
-variable `$HOSTNAME` with any domain suffix stripped (so
-`dionysus.local` becomes `dionysus`); set `machine: <name>` in
-`ecosystem.local.yaml` to override if your hostname is unstable.
+The thalami hoard contains one `<machine>-thalamus.md` file per workstation you use. The machine name comes from the environment variable `$HOSTNAME` with any domain suffix stripped (so `dionysus.local` becomes `dionysus`); set `machine: <name>` in `ecosystem.local.yaml` to override if your hostname is unstable.
 
 Each per-machine file carries:
 
-- **Frontmatter** for per-machine state: `last_session`,
-  `last_audit`, default `mode`, default `role`, plus the audit
-  `staleness_days` (housekeeping cadence — distinct from the
-  hoard-wide commit cadence covered below, which lives in
-  `.ws-cadence.yaml` at the hoard root).
-- **Body sections**: Preferences, Observations, Concerns, Audit Log
-  (per the Thalamus model — see [thalamus.md](thalamus.md)).
+- **Frontmatter** for per-machine state: `last_session`, `last_audit`, default `mode`, default `role`, plus the audit `staleness_days` (housekeeping cadence — distinct from the hoard-wide commit cadence covered below, which lives in `.ws-cadence.yaml` at the hoard root).
+- **Body sections**: Preferences, Observations, Concerns, Audit Log (per the Thalamus model — see [thalamus.md](thalamus.md)).
 
 Per-machine files also carry an `arcs:` list — short entries (slug, status, next step) that surface as a live cross-host table when the hoard is opened as an Obsidian vault with the Dataview plugin installed. See [the arc dashboard design](../plans/2026-05-07-thalamus-arc-dashboard-design.md) for the schema, lifecycle, and skill integration; see the hoard's own `ArcDashboard.md` for the rendered view.
 
 Why per-machine? Two reasons:
 
-1. **Avoids merge conflicts.** Two machines editing the same file
-   between syncs would collide on every other line. Per-machine files
-   eliminate that class of conflict.
-2. **Reflects reality.** Each machine has its own context (different
-   keyboard, different network, different screen). Preferences that
-   make sense at the desk don't always make sense on the laptop.
-   Per-machine files keep that fidelity.
+1. **Avoids merge conflicts.** Two machines editing the same file between syncs would collide on every other line. Per-machine files eliminate that class of conflict.
+2. **Reflects reality.** Each machine has its own context (different keyboard, different network, different screen). Preferences that make sense at the desk don't always make sense on the laptop. Per-machine files keep that fidelity.
 
-Cross-machine concerns (preferences that genuinely apply everywhere,
-duplicate observations on multiple machines) get reconciled during
-**multi-thalami housekeeping** — see the `gdd-housekeeping` skill's
-"Multi-Thalami Review" section.
+Cross-machine concerns (preferences that genuinely apply everywhere, duplicate observations on multiple machines) get reconciled during **multi-thalami housekeeping** — see the `gdd-housekeeping` skill's "Multi-Thalami Review" section.
 
 ---
 
 ## Cadence config — `.ws-cadence.yaml`
 
-A small file at the hoard root controls when the orientation skill
-nudges you to commit accumulated changes. Default contents (shipped
-in the `templates/hoards/thalami/` template):
+A small file at the hoard root controls when the orientation skill nudges you to commit accumulated changes. Default contents (shipped in the `templates/hoards/thalami/` template):
 
 ```yaml
 staleness_days: 2
 ```
 
-That's the threshold the orientation skill uses: if your per-machine
-thalamus has been dirty for longer than this, surface a "commit your
-thalamus before we start?" nudge at session start.
+That's the threshold the orientation skill uses: if your per-machine thalamus has been dirty for longer than this, surface a "commit your thalamus before we start?" nudge at session start.
 
-The file is committable, hoard-wide, and shared across machines —
-it's a workflow preference, not a per-machine value. Edit
-`staleness_days` to tune; commit and push so other machines pick it
-up. If the file is missing or the field is unset, the cadence script
-defaults to 2 days.
+The file is committable, hoard-wide, and shared across machines — it's a workflow preference, not a per-machine value. Edit `staleness_days` to tune; commit and push so other machines pick it up. If the file is missing or the field is unset, the cadence script defaults to 2 days.
 
-The check itself runs as `ws hoard cadence` and reports a status
-line (`clean`, `dirty-fresh`, `dirty-stale`, `never-committed`,
-`no-active-hoard`, `no-thalamus-file`) plus elapsed-time fields the
-nudge text substitutes in. The orientation skill calls it
-automatically; you can also run it manually any time.
+The check itself runs as `ws hoard cadence` and reports a status line (`clean`, `dirty-fresh`, `dirty-stale`, `never-committed`, `no-active-hoard`, `no-thalamus-file`) plus elapsed-time fields the nudge text substitutes in. The orientation skill calls it automatically; you can also run it manually any time.
 
-**Migrating an existing thalami hoard** (created before yggdrasil
-PR #49 introduced `.ws-cadence.yaml`): copy
-`templates/hoards/thalami/.ws-cadence.yaml` into your hoard root,
-commit, and push. The old per-machine `commit_staleness_days`
-frontmatter field is now ignored; without the new file, the cadence
-script falls back to its 2-day default.
+**Migrating an existing thalami hoard** (created before yggdrasil PR #49 introduced `.ws-cadence.yaml`): copy `templates/hoards/thalami/.ws-cadence.yaml` into your hoard root, commit, and push. The old per-machine `commit_staleness_days` frontmatter field is now ignored; without the new file, the cadence script falls back to its 2-day default.
 
-**Future direction: scope filters.** A `watch:` glob list could
-let other hoard types scope dirty-detection (e.g., a vault hoard
-counting `*.md` but ignoring `_attachments/`). Not implemented in
-v1 — thalami's per-machine-file watching is hardcoded — but the
-extension point is reserved for when a second hoard type needs it.
+**Future direction: scope filters.** A `watch:` glob list could let other hoard types scope dirty-detection (e.g., a vault hoard counting `*.md` but ignoring `_attachments/`). Not implemented in v1 — thalami's per-machine-file watching is hardcoded — but the extension point is reserved for when a second hoard type needs it.
 
 ---
 
@@ -149,35 +84,18 @@ extension point is reserved for when a second hoard type needs it.
 
 The standard pattern with a thalami hoard across machines:
 
-1. **Start a session.** Orientation reads `<machine>-thalamus.md`,
-   may nudge if cadence threshold passed.
-2. **Work.** Agent writes observations / preferences / concerns into
-   the per-machine file as they accumulate.
-3. **Commit when prompted** (or at natural endpoints — end of
-   session, before mode switch, during housekeeping).
+1. **Start a session.** Orientation reads `<machine>-thalamus.md`, may nudge if cadence threshold passed.
+2. **Work.** Agent writes observations / preferences / concerns into the per-machine file as they accumulate.
+3. **Commit when prompted** (or at natural endpoints — end of session, before mode switch, during housekeeping).
 4. **`ws push thalami-<user>`** to sync to the personal remote.
-5. **On the next machine**: `ws pull thalami-<user>` brings down the
-   committed state. Orientation sees the updated audit log, other
-   machines' files (read-only signals about what's happening
-   elsewhere), and any cross-machine preferences from the housekeeping
-   skill's multi-thalami review.
+5. **On the next machine**: `ws pull thalami-<user>` brings down the committed state. Orientation sees the updated audit log, other machines' files (read-only signals about what's happening elsewhere), and any cross-machine preferences from the housekeeping skill's multi-thalami review.
 
 Two coexisting modes that work well:
 
-- **Each machine commits its own per-machine file.** The hoard's
-  history shows alternating commits per machine.
-- **One machine does cross-machine housekeeping** (typically the
-  most-used desktop). It walks all `<machine>-thalamus.md` files,
-  promotes universal preferences, dedups observations, updates each
-  machine's audit log. The other machines pick up the consolidated
-  state on next pull.
+- **Each machine commits its own per-machine file.** The hoard's history shows alternating commits per machine.
+- **One machine does cross-machine housekeeping** (typically the most-used desktop). It walks all `<machine>-thalamus.md` files, promotes universal preferences, dedups observations, updates each machine's audit log. The other machines pick up the consolidated state on next pull.
 
-**Push directly to `main` — no PR ceremony.** Thalami (and other
-personal hoards) are stream-of-consciousness notes; bot review
-adds nothing useful and a PR/review cycle just slows down sync.
-The convention is: `ws commit` → `ws pull` (fetch+rebase) →
-`ws push`, straight to `main`. PRs are a component-and-realm
-pattern.
+**Push directly to `main` — no PR ceremony.** Thalami (and other personal hoards) are stream-of-consciousness notes; bot review adds nothing useful and a PR/review cycle just slows down sync. The convention is: `ws commit` → `ws pull` (fetch+rebase) → `ws push`, straight to `main`. PRs are a component-and-realm pattern.
 
 ---
 
@@ -199,34 +117,21 @@ The `gdd-hoard-upgrade` skill drives the loop: it runs `--plan`, proposes the de
 
 ## Future hoard types
 
-Hoards are intentionally generic; thalami is just the first type
-shipped. Plausible future types:
+Hoards are intentionally generic; thalami is just the first type shipped. Plausible future types:
 
 - **Vault-style knowledgebase** (Obsidian-flavored or similar). `obsidian-vault` is the canonical example: PARA folders, base templates, plugin install + config seeded automatically on init. Users land their knowledge graph as a hoard and get the `ws push/pull` ergonomics + cadence-config for keeping it synced.
-- **Scratch / experiment** spaces — short-lived hoards for spike work
-  that shouldn't pollute components but you want the workspace's
-  CLI ergonomics for.
-- **Cross-tool transcripts** — agent session transcripts, voice
-  memos, anything that's "yours" but not a project.
+- **Scratch / experiment** spaces — short-lived hoards for spike work that shouldn't pollute components but you want the workspace's CLI ergonomics for.
+- **Cross-tool transcripts** — agent session transcripts, voice memos, anything that's "yours" but not a project.
 
-Each new type ships as a `templates/hoards/<type>/` directory with
-its own scaffold. The `ws hoard init <type>` command picks it up
-automatically. If the type wants its own cadence behavior, it ships
-a `.ws-cadence.yaml` (or omits it for the default).
+Each new type ships as a `templates/hoards/<type>/` directory with its own scaffold. The `ws hoard init <type>` command picks it up automatically. If the type wants its own cadence behavior, it ships a `.ws-cadence.yaml` (or omits it for the default).
 
 ---
 
 ## See also
 
-- [GDD Features Tour](features.md) — where hoards fit in the
-  larger feature set.
-- [Thalamus](thalamus.md) — the thinking-space concept the thalami
-  type is built around.
-- [Trust and Safety](trust-and-safety.md) — hoards' trust level
-  (your own content, equivalent to your other instructions).
-- [Roles and Modes](roles-and-modes.md) — the per-machine `mode:`
-  and `role:` defaults that live in thalamus frontmatter.
-- [`gdd-orientation` skill](../../.agent/skills/gdd-orientation/SKILL.md)
-  — how Step 0a uses `ws hoard cadence`.
-- [`gdd-housekeeping` skill](../../.agent/skills/gdd-housekeeping/SKILL.md)
-  — multi-thalami review process.
+- [GDD Features Tour](features.md) — where hoards fit in the larger feature set.
+- [Thalamus](thalamus.md) — the thinking-space concept the thalami type is built around.
+- [Trust and Safety](trust-and-safety.md) — hoards' trust level (your own content, equivalent to your other instructions).
+- [Roles and Modes](roles-and-modes.md) — the per-machine `mode:` and `role:` defaults that live in thalamus frontmatter.
+- [`gdd-orientation` skill](../../.agent/skills/gdd-orientation/SKILL.md) — how Step 0a uses `ws hoard cadence`.
+- [`gdd-housekeeping` skill](../../.agent/skills/gdd-housekeeping/SKILL.md) — multi-thalami review process.

--- a/docs/gdd/index.md
+++ b/docs/gdd/index.md
@@ -22,25 +22,13 @@ This positioning enables a community angle that the other extremes don't natural
 
 ## Key Concepts
 
-- **Filling the gap** — between AI-private memory (invisible to humans) and
-  committed project instructions (formal, policy-level), GDD introduces the
-  [Thalamus](thalamus.md): a shared, co-authored thinking space where
-  observations, concerns, and preferences live while they're being figured out.
+- **Filling the gap** — between AI-private memory (invisible to humans) and committed project instructions (formal, policy-level), GDD introduces the [Thalamus](thalamus.md): a shared, co-authored thinking space where observations, concerns, and preferences live while they're being figured out.
 
-- **Adaptive ceremony** — [roles and modes](roles-and-modes.md) let the
-  framework meet you where you are. 15 minutes on your phone? Quick mode.
-  Saturday deep dive? Zen mode. First time in the codebase? Mentoring mode.
-  Modes compose freely.
+- **Adaptive ceremony** — [roles and modes](roles-and-modes.md) let the framework meet you where you are. 15 minutes on your phone? Quick mode. Saturday deep dive? Zen mode. First time in the codebase? Mentoring mode. Modes compose freely.
 
-- **Trust as a first-class concern** — AI agents read instructions from
-  nested project components, and not all of those are trustworthy. GDD's
-  [trust hierarchy and black-box safety pattern](trust-and-safety.md) ensure
-  the agent logs concerns before they can be overwritten by hostile content.
+- **Trust as a first-class concern** — AI agents read instructions from nested project components, and not all of those are trustworthy. GDD's [trust hierarchy and black-box safety pattern](trust-and-safety.md) ensure the agent logs concerns before they can be overwritten by hostile content.
 
-- **Self-improving through use** — the framework starts minimal and
-  [evolves through audit cycles](self-improving-loop.md). Observations become
-  skills, friction becomes automation, and the capture heuristics themselves
-  get tuned.
+- **Self-improving through use** — the framework starts minimal and [evolves through audit cycles](self-improving-loop.md). Observations become skills, friction becomes automation, and the capture heuristics themselves get tuned.
 
 ## Why "Guardian"?
 
@@ -58,12 +46,9 @@ The last entry relates to the original more amusing "Dad-Driven-Development" nam
 
 1. **Clone the repo** — `git clone` the yggdrasil workspace
 2. **Start a session** — the orientation skill guides you through setup
-3. **Pick a mode** — Quick for a short session, Zen for deep work,
-   Mentoring if you're learning
-4. **Work normally** — the framework adapts, captures observations, and
-   keeps things safe
-5. **Housekeep occasionally** — review what's accumulated, promote the
-   good stuff, prune the rest
+3. **Pick a mode** — Quick for a short session, Zen for deep work, Mentoring if you're learning
+4. **Work normally** — the framework adapts, captures observations, and keeps things safe
+5. **Housekeep occasionally** — review what's accumulated, promote the good stuff, prune the rest
 
 ## Design Principles
 

--- a/docs/gdd/permissions.md
+++ b/docs/gdd/permissions.md
@@ -1,13 +1,8 @@
 # GDD Permissions Reference
 
-How `.claude/settings.json` works in a GDD workspace, what makes a
-pattern safe, and how to verify the safety claims for yourself.
+How `.claude/settings.json` works in a GDD workspace, what makes a pattern safe, and how to verify the safety claims for yourself.
 
-This doc is the source of truth for the permission system's behavior
-and the empirical findings it relies on. The `gdd-permissions`
-skill (`.agent/skills/gdd-permissions/`) is the operational
-companion — agents invoke it for live decisions; this doc is what they
-(and humans, and automated review tools) read for reference.
+This doc is the source of truth for the permission system's behavior and the empirical findings it relies on. The `gdd-permissions` skill (`.agent/skills/gdd-permissions/`) is the operational companion — agents invoke it for live decisions; this doc is what they (and humans, and automated review tools) read for reference.
 
 ---
 
@@ -15,8 +10,7 @@ companion — agents invoke it for live decisions; this doc is what they
 
 Claude Code reads two settings files for each workspace:
 
-- **`.claude/settings.json`** — project-level, committed to the repo.
-  Shared across everyone working in the workspace.
+- **`.claude/settings.json`** — project-level, committed to the repo. Shared across everyone working in the workspace.
 - **`.claude/settings.local.json`** — per-user, gitignored. Not shared.
 
 Both are merged at startup. Where they conflict on a single key, local wins. The relevant top-level structure is:
@@ -103,12 +97,7 @@ Bash(ws status --verbose)
 Bash(git -C * branch --show-current)
 ```
 
-The literal string after the command name must match exactly. The `*`
-inside `git -C * branch --show-current` is a wildcard for the path
-slot only; the trailing `branch --show-current` is a literal. A
-command of `git -C . branch --list` does NOT match — `--list` ≠
-`--show-current`. The matcher is honest about this; non-matches
-produce a permission prompt.
+The literal string after the command name must match exactly. The `*` inside `git -C * branch --show-current` is a wildcard for the path slot only; the trailing `branch --show-current` is a literal. A command of `git -C . branch --list` does NOT match — `--list` ≠ `--show-current`. The matcher is honest about this; non-matches produce a permission prompt.
 
 ### Prefix wildcards
 
@@ -119,11 +108,7 @@ Bash(bash scripts/ws clone *)
 Bash(bash tests/vendor/bats-core/bin/bats tests/*)
 ```
 
-Each `*` is a wildcard slot. The matcher binds each slot to a single
-argument-shaped sequence. The space before `*` matters: `Bash(foo*)`
-without the space matches `foo` followed by anything (including
-`foobar`); `Bash(foo *)` requires a space, then any single argument.
-For prefix matching of arguments, always include the space.
+Each `*` is a wildcard slot. The matcher binds each slot to a single argument-shaped sequence. The space before `*` matters: `Bash(foo*)` without the space matches `foo` followed by anything (including `foobar`); `Bash(foo *)` requires a space, then any single argument. For prefix matching of arguments, always include the space.
 
 ### Colon-prefix (`cmd:*`)
 
@@ -160,29 +145,10 @@ The chosen subcommand for each pattern is read-only at the porcelain level. `git
 
 The matcher scopes wildcards correctly:
 
-- **Compound commands** (`|`, `&&`, `||`, `;`) are validated
-  per-segment. `git -C . show HEAD | xxd` is two segments: the left
-  matches `Bash(git -C * show *)` and is allowed; the right is `xxd`
-  alone and prompts. The wildcards in the left side don't extend
-  across the pipe.
-- **Command substitution** (`$(...)` and backticks) is rejected by the
-  matcher. `git -C $(echo .) show HEAD --stat` does NOT match
-  `Bash(git -C * show *)` — the matcher prompts and offers no
-  "don't ask again" option. Substitution is too dynamic for any
-  static pattern to safely allowlist.
-- **Exact-form pinning is literal.** `git -C . branch --list` does
-  not match `Bash(git -C * branch --show-current)` because the
-  trailing literals differ.
-- **Stdout-redirect-to-file (`> file`, `>> file`) prompts
-  regardless of the LHS.** Even when the producing command is
-  read-only and individually auto-allowed, the redirect-to-file is
-  treated as a side-effect operation because the destination path
-  is opaque to static analysis (could be `/tmp/foo`,
-  `~/.bashrc`, `/etc/...`). The right design path for "save output
-  for later grep" is a wrapper-side `--output <phrase>` flag that
-  validates the destination against a workspace-internal scratch
-  dir like `.outputs/` — see `ws review --output` for the
-  reference implementation.
+- **Compound commands** (`|`, `&&`, `||`, `;`) are validated per-segment. `git -C . show HEAD | xxd` is two segments: the left matches `Bash(git -C * show *)` and is allowed; the right is `xxd` alone and prompts. The wildcards in the left side don't extend across the pipe.
+- **Command substitution** (`$(...)` and backticks) is rejected by the matcher. `git -C $(echo .) show HEAD --stat` does NOT match `Bash(git -C * show *)` — the matcher prompts and offers no "don't ask again" option. Substitution is too dynamic for any static pattern to safely allowlist.
+- **Exact-form pinning is literal.** `git -C . branch --list` does not match `Bash(git -C * branch --show-current)` because the trailing literals differ.
+- **Stdout-redirect-to-file (`> file`, `>> file`) prompts regardless of the LHS.** Even when the producing command is read-only and individually auto-allowed, the redirect-to-file is treated as a side-effect operation because the destination path is opaque to static analysis (could be `/tmp/foo`, `~/.bashrc`, `/etc/...`). The right design path for "save output for later grep" is a wrapper-side `--output <phrase>` flag that validates the destination against a workspace-internal scratch dir like `.outputs/` — see `ws review --output` for the reference implementation.
 
 Both layers must hold. If Claude Code's matcher behavior changes — for instance, if compound commands stopped being per-segment validated — a "safe" pattern could become unsafe. That's the case for automated regression testing tracked at issue #46.
 
@@ -230,40 +196,24 @@ When you add a new allow pattern, also add at least one positive case (matches �
 
 A decision tree for adding a new `Bash(...)` pattern:
 
-1. **Is the command already auto-allowed by Claude Code?** (`cat`, `ls`,
-   `pwd`, `git status`, `git log` without `-C`, `gh pr view`, etc.) If
-   yes, don't add a pattern — it's redundant.
+1. **Is the command already auto-allowed by Claude Code?** (`cat`, `ls`, `pwd`, `git status`, `git log` without `-C`, `gh pr view`, etc.) If yes, don't add a pattern — it's redundant.
 2. **Does the command's subcommand have any mutating flag-form?**
-   - No (e.g. `git show`, `git diff`, `git ls-tree`): a prefix-wildcard
-     pattern (`Bash(<command> <subcommand> *)`) is fine.
-   - Yes (e.g. `git branch -d`, `git remote add`): pin to the exact
-     safe form (`Bash(git -C * branch --show-current)`).
-3. **Is the command an arbitrary-execution shell?** (`bash *`,
-   `python *`, `node *`, `npx *`, `bunx *`, `uvx *`, `make *`,
-   `npm run *`, `bun run *`, `gh api *`.)  Never widen these. An exact
-   `Bash(bash -n some-specific-script.sh)` is fine; wildcards aren't.
-4. **Does the command write to a shared system?** (push, deploy,
-   publish, send). These are Side-effect tier in
-   `docs/ws-cli-guide.md` — never auto-allow; let the user decide
-   case-by-case.
+   - No (e.g. `git show`, `git diff`, `git ls-tree`): a prefix-wildcard pattern (`Bash(<command> <subcommand> *)`) is fine.
+   - Yes (e.g. `git branch -d`, `git remote add`): pin to the exact safe form (`Bash(git -C * branch --show-current)`).
+3. **Is the command an arbitrary-execution shell?** (`bash *`, `python *`, `node *`, `npx *`, `bunx *`, `uvx *`, `make *`, `npm run *`, `bun run *`, `gh api *`.) Never widen these. An exact `Bash(bash -n some-specific-script.sh)` is fine; wildcards aren't.
+4. **Does the command write to a shared system?** (push, deploy, publish, send). These are Side-effect tier in `docs/ws-cli-guide.md` — never auto-allow; let the user decide case-by-case.
 
-When in doubt, narrower wins. You can always widen later. Narrowing
-post-hoc is harder (you've already trained yourself to expect the
-wide form).
+When in doubt, narrower wins. You can always widen later. Narrowing post-hoc is harder (you've already trained yourself to expect the wide form).
 
 ---
 
 ## Cross-reference rule
 
-When you modify `.claude/settings.json`'s `permissions.allow` (or
-`permissions.deny`), also update the **Empirical matcher findings**
-section above to reflect the new pattern with at least one positive
-and one negative case.
+When you modify `.claude/settings.json`'s `permissions.allow` (or `permissions.deny`), also update the **Empirical matcher findings** section above to reflect the new pattern with at least one positive and one negative case.
 
 The two artifacts are paired:
 - `.claude/settings.json` is what Claude Code enforces.
-- `docs/gdd/permissions.md` (this file) is what humans, automated
-  reviewers, and the agent reason against.
+- `docs/gdd/permissions.md` (this file) is what humans, automated reviewers, and the agent reason against.
 
 Drift between them is a real bug — humans trust the doc, agents trust the doc, and a stale doc gives false confidence. PR review for `.claude/settings.json` changes should call out a missing doc update as blocking.
 
@@ -273,25 +223,8 @@ The `gdd-permissions` skill enforces this rule operationally: when an agent adds
 
 ## Future Directions
 
-- **Cross-framework porting.** Other agent frameworks (Codex, Gemini
-  CLI, Cursor, etc.) have their own permission-style configs. The
-  semantics differ — some are tool-name-only, some have richer
-  per-tool argument matching, some have no analogue to the
-  `permissions.deny` override layer. Mapping Claude Code's allowlist
-  to each framework's equivalent is a future arc; the skill points
-  at this thread but doesn't carry the porting guidance in v1.
+- **Cross-framework porting.** Other agent frameworks (Codex, Gemini CLI, Cursor, etc.) have their own permission-style configs. The semantics differ — some are tool-name-only, some have richer per-tool argument matching, some have no analogue to the `permissions.deny` override layer. Mapping Claude Code's allowlist to each framework's equivalent is a future arc; the skill points at this thread but doesn't carry the porting guidance in v1.
 
-- **Automated regression testing** (issue #46). Today the empirical
-  findings table in **Empirical matcher findings** is the source of
-  truth, but there's no test
-  harness that re-asserts those findings against new Claude Code
-  versions. The future regression suite will execute each (pattern,
-  command, expected) triple and flag matcher-behavior changes.
+- **Automated regression testing** (issue #46). Today the empirical findings table in **Empirical matcher findings** is the source of truth, but there's no test harness that re-asserts those findings against new Claude Code versions. The future regression suite will execute each (pattern, command, expected) triple and flag matcher-behavior changes.
 
-- **Sandboxing tooling.** Personal exploration of AI-tooling
-  sandboxing patterns lives in
-  `realms/realm-siliconsaga/docs/agent-security/` (relocated from
-  this repo's `docs/` in the same hygiene PR that introduced this
-  doc). Some of that work — particularly Nvidia's OpenShell /
-  NemoClaw lineage — could inform a future GDD security category
-  that sits next to permissions.
+- **Sandboxing tooling.** Personal exploration of AI-tooling sandboxing patterns lives in `realms/realm-siliconsaga/docs/agent-security/` (relocated from this repo's `docs/` in the same hygiene PR that introduced this doc). Some of that work — particularly Nvidia's OpenShell / NemoClaw lineage — could inform a future GDD security category that sits next to permissions.

--- a/docs/gdd/realms.md
+++ b/docs/gdd/realms.md
@@ -25,18 +25,12 @@ The upstream `realm-template` ships as a tutorial scaffold; communities fork it 
 
 A realm typically carries:
 
-- **`ecosystem.yaml`** — component list, tiers, defaults. The community
-  declaration of "what we work on."
-- **Identity defaults** — agent identity (e.g. `agent-refr`),
-  attribution conventions, fork-org settings.
-- **MCP server overrides** — which MCP servers the community runs and
-  how they're wired.
-- **Adapter commands** — community-specific shell helpers exposed to
-  agents.
-- **`AGENTS.md`** — community-level agent instructions layered on top
-  of the workspace root's.
-- **`.agent/skills/`** — community-scoped skills that ship to every
-  member's sessions.
+- **`ecosystem.yaml`** — component list, tiers, defaults. The community declaration of "what we work on."
+- **Identity defaults** — agent identity (e.g. `agent-refr`), attribution conventions, fork-org settings.
+- **MCP server overrides** — which MCP servers the community runs and how they're wired.
+- **Adapter commands** — community-specific shell helpers exposed to agents.
+- **`AGENTS.md`** — community-level agent instructions layered on top of the workspace root's.
+- **`.agent/skills/`** — community-scoped skills that ship to every member's sessions.
 
 Anything an individual would otherwise have to copy across machines or re-explain to a new contributor is a candidate to live in the realm.
 
@@ -83,11 +77,8 @@ Cloning a realm is a higher-trust act than cloning an arbitrary component — on
 
 You can have multiple realms cloned simultaneously and flip between them with `ws realm use <name>`. This is mostly useful for:
 
-- **Tutorial → real.** Start with `realm-template` to learn the
-  workspace, then switch to your community realm when ready.
-- **Cross-community contribution.** A developer who works in two
-  communities (say, `realm-siliconsaga` and `realm-yourorg`) keeps
-  both cloned and switches when context shifts.
+- **Tutorial → real.** Start with `realm-template` to learn the workspace, then switch to your community realm when ready.
+- **Cross-community contribution.** A developer who works in two communities (say, `realm-siliconsaga` and `realm-yourorg`) keeps both cloned and switches when context shifts.
 
 Components from inactive realms aren't touched — `ws` just reads a different `ecosystem.yaml` for resolution.
 
@@ -101,12 +92,8 @@ The merge generalizes to N layers. The same upstream → realm → local shape e
 
 ## See also
 
-- [GDD Features Tour](features.md) — where realms fit in the larger
-  feature set.
+- [GDD Features Tour](features.md) — where realms fit in the larger feature set.
 - [Hoards](hoards.md) — the personal counterpart to realms.
-- [Ecosystem Architecture](../ecosystem-architecture.md) — the merge
-  semantics and dual-mode source resolution.
-- [Getting Started](../getting-started/index.md) — clone-and-go
-  walkthrough including realm setup.
-- [Trust and Safety](trust-and-safety.md) — realm content's trust
-  level and the broader hierarchy.
+- [Ecosystem Architecture](../ecosystem-architecture.md) — the merge semantics and dual-mode source resolution.
+- [Getting Started](../getting-started/index.md) — clone-and-go walkthrough including realm setup.
+- [Trust and Safety](trust-and-safety.md) — realm content's trust level and the broader hierarchy.

--- a/docs/gdd/roles-and-modes.md
+++ b/docs/gdd/roles-and-modes.md
@@ -1,8 +1,6 @@
 # Roles and Modes
 
-GDD doesn't assign people to fixed categories. Instead, it defines **roles**
-(what you're doing right now) and **modes** (how the framework adapts its
-behavior). A person can switch roles between sessions or even within one.
+GDD doesn't assign people to fixed categories. Instead, it defines **roles** (what you're doing right now) and **modes** (how the framework adapts its behavior). A person can switch roles between sessions or even within one.
 
 ## Roles
 
@@ -14,8 +12,7 @@ behavior). A person can switch roles between sessions or even within one.
 | **Scribe** | Note-taking and vault work — PARA layout, frontmatter, daily notes, capture-process-organize loop |
 | **AI Agent** | Any of the above, bounded by permissions |
 
-Roles aren't skill levels. A first-time contributor and a 20-year veteran
-can both be in the Developer role — they'll just have different modes active.
+Roles aren't skill levels. A first-time contributor and a 20-year veteran can both be in the Developer role — they'll just have different modes active.
 
 Today only the **Scribe** role has a dedicated skill file; the other roles are the assumed default and rely on mode and practice skills rather than a single role file.
 
@@ -25,18 +22,13 @@ Modes modify how the framework behaves. They compose freely.
 
 ### Mentoring
 
-The AI explains decisions, teaches practices in context, and offers more
-scaffolding. Not tied to seniority; anyone can request it. First time
-touching BDD? Ask for Mentoring mode, even if you've been coding for a decade.
+The AI explains decisions, teaches practices in context, and offers more scaffolding. Not tied to seniority; anyone can request it. First time touching BDD? Ask for Mentoring mode, even if you've been coding for a decade.
 
-The AI's job in Mentoring mode is to **grow the human**, not just ship the
-code. Every interaction is an opportunity to transfer understanding.
+The AI's job in Mentoring mode is to **grow the human**, not just ship the code. Every interaction is an opportunity to transfer understanding.
 
 ### Quick
 
-Minimal ceremony for short time windows. You have 15 minutes on your phone
-between responsibilities? Quick mode suggests appropriately-sized tasks,
-recovers context fast, and skips questions it can infer.
+Minimal ceremony for short time windows. You have 15 minutes on your phone between responsibilities? Quick mode suggests appropriately-sized tasks, recovers context fast, and skips questions it can infer.
 
 Session sizing examples:
 - **15 min:** Write one BDD scenario, review one PR comment, fix one small bug
@@ -45,21 +37,12 @@ Session sizing examples:
 
 ### Zen
 
-Full ceremony for deep focus sessions. Saturday morning deep dive? Zen mode
-leans into thorough brainstorming, comprehensive reviews, auditing accumulated
-concerns, and completing large chunks of work end-to-end.
+Full ceremony for deep focus sessions. Saturday morning deep dive? Zen mode leans into thorough brainstorming, comprehensive reviews, auditing accumulated concerns, and completing large chunks of work end-to-end.
 
-Zen mode may proactively suggest housekeeping if observations have accumulated
-in the Thalamus.
+Zen mode may proactively suggest housekeeping if observations have accumulated in the Thalamus.
 
 ### Flow
 
-Adaptive ceremony for sessions that drift productively across multiple topics.
-The agent matches the human's rhythm, incorporates tangents naturally, and
-treats the Thalamus as a live collaboration surface rather than a
-session-bookend artifact. Often the natural default when no mode is set.
+Adaptive ceremony for sessions that drift productively across multiple topics. The agent matches the human's rhythm, incorporates tangents naturally, and treats the Thalamus as a live collaboration surface rather than a session-bookend artifact. Often the natural default when no mode is set.
 
-Modes compose freely — a learning contributor might run Mentoring + Quick on
-a busy day, or Zen + Mentoring for a deep teaching session. The per-mode
-skills under `.agent/skills/gdd-<mode>/SKILL.md` describe the specific
-behavior modifiers each mode applies.
+Modes compose freely — a learning contributor might run Mentoring + Quick on a busy day, or Zen + Mentoring for a deep teaching session. The per-mode skills under `.agent/skills/gdd-<mode>/SKILL.md` describe the specific behavior modifiers each mode applies.

--- a/docs/gdd/self-improving-loop.md
+++ b/docs/gdd/self-improving-loop.md
@@ -1,7 +1,6 @@
 # The Self-Improving Loop
 
-GDD is designed to evolve through use, not just through upfront design. The
-framework starts minimal and grows through a continuous feedback cycle.
+GDD is designed to evolve through use, not just through upfront design. The framework starts minimal and grows through a continuous feedback cycle.
 
 ## The Cycle
 
@@ -21,8 +20,7 @@ Each housekeeping audit is an opportunity to refine the framework:
 - **Recurring friction** becomes a new skill or `ws` subcommand
 - **Validated preferences** become committed instructions
 - **Stale concerns** get pruned
-- **Capture heuristics** get tuned — "we're capturing too much noise about
-  formatting, let's stop noting those"
+- **Capture heuristics** get tuned — "we're capturing too much noise about formatting, let's stop noting those"
 
 ## Co-Evolving Artifacts
 
@@ -34,18 +32,13 @@ Three artifacts evolve together:
 | **Orientation skill** | Governs capture behavior | Heuristics tuned by housekeeping feedback |
 | **Housekeeping skill** | Audits and promotes | Process refined as we learn what promotions are valuable |
 
-None of these is "done." Each audit cycle refines the template, adjusts
-capture heuristics, or adds new sections to the file.
+None of these is "done." Each audit cycle refines the template, adjusts capture heuristics, or adds new sections to the file.
 
 ## The Principle
 
 > **Evolve through use** — the framework refines itself through audit cycles;
 > no part of it is final.
 
-This is GDD's 6th design principle. It means the initial implementation is
-deliberately minimal. Rather than trying to design the perfect framework
-upfront, GDD provides just enough structure to start capturing observations,
-then lets real usage reveal what's worth formalizing.
+This is GDD's 6th design principle. It means the initial implementation is deliberately minimal. Rather than trying to design the perfect framework upfront, GDD provides just enough structure to start capturing observations, then lets real usage reveal what's worth formalizing.
 
-A framework that can't change is a framework that will be abandoned. GDD
-is designed to be the opposite — it gets better the more you use it.
+A framework that can't change is a framework that will be abandoned. GDD is designed to be the opposite — it gets better the more you use it.

--- a/docs/gdd/skills-reference.md
+++ b/docs/gdd/skills-reference.md
@@ -85,10 +85,6 @@ To read a skill: open the file. To author a new skill or change an existing one:
 
 ## See also
 
-- [Roles and Modes](roles-and-modes.md) — the model the mode and
-  role skills implement.
-- [Self-Improving Loop](self-improving-loop.md) — how observations
-  in the thalamus become new or revised skills over time.
-- [`AGENTS.md`](https://github.com/SiliconSaga/yggdrasil/blob/main/AGENTS.md)
-  — the workspace-root pointer that names the skills agents read at
-  orientation.
+- [Roles and Modes](roles-and-modes.md) — the model the mode and role skills implement.
+- [Self-Improving Loop](self-improving-loop.md) — how observations in the thalamus become new or revised skills over time.
+- [`AGENTS.md`](https://github.com/SiliconSaga/yggdrasil/blob/main/AGENTS.md) — the workspace-root pointer that names the skills agents read at orientation.

--- a/docs/gdd/thalamus.md
+++ b/docs/gdd/thalamus.md
@@ -1,20 +1,12 @@
 # The Thalamus
 
-*Named after the brain's relay station — it receives input, processes it, and
-routes it to the right destination. Like the thalamus, this file doesn't store
-things permanently; it processes and forwards.*
+*Named after the brain's relay station — it receives input, processes it, and routes it to the right destination. Like the thalamus, this file doesn't store things permanently; it processes and forwards.*
 
-Between "private AI memory" (invisible to humans) and "committed project
-instructions" (formal, policy-level) there's a gap: where do observations,
-half-formed ideas, and session-to-session context live?
+Between "private AI memory" (invisible to humans) and "committed project instructions" (formal, policy-level) there's a gap: where do observations, half-formed ideas, and session-to-session context live?
 
 ## What It Is
 
-The Thalamus is a shared, gitignored markdown file — a thinking space
-co-authored by one human and one local AI agent (at a time). It's not a
-knowledge base, not a project management tool, and not a replacement for
-committed instructions. It's the place where things live while they're
-being figured out.
+The Thalamus is a shared, gitignored markdown file — a thinking space co-authored by one human and one local AI agent (at a time). It's not a knowledge base, not a project management tool, and not a replacement for committed instructions. It's the place where things live while they're being figured out.
 
 ## Where It Sits
 
@@ -29,8 +21,7 @@ being figured out.
 
 - **Preferences** — mode defaults, interaction style, session habits
 - **Observations** — patterns noticed, friction points, things that worked well
-- **Concerns** — trust issues, suspicious instructions, safety flags (written
-  **immediately** as part of the black-box safety pattern)
+- **Concerns** — trust issues, suspicious instructions, safety flags (written **immediately** as part of the black-box safety pattern)
 - **Audit Log** — when was content last reviewed, what was promoted or pruned
 
 ## The Lifecycle
@@ -39,17 +30,14 @@ Content flows through the Thalamus, not into it permanently:
 
 1. **Capture** — observations accumulate during sessions
 2. **Review** — housekeeping audits process items with the human
-3. **Graduate** — actionable items move to permanent homes (issues, skills,
-   instructions, `ws` subcommands)
+3. **Graduate** — actionable items move to permanent homes (issues, skills, instructions, `ws` subcommands)
 4. **Prune** — resolved or stale items are removed
 
-The file is workspace-local and gitignored — accepted risk of loss, mitigated
-by the fact that highest-value content should have been promoted elsewhere.
+The file is workspace-local and gitignored — accepted risk of loss, mitigated by the fact that highest-value content should have been promoted elsewhere.
 
 ## Frontmatter
 
-The template includes YAML frontmatter that the orientation skill reads on
-session start:
+The template includes YAML frontmatter that the orientation skill reads on session start:
 
 ```yaml
 last_session: 2026-03-20
@@ -59,8 +47,7 @@ role: developer
 staleness_days: 14
 ```
 
-This enables session continuity — the AI knows when you last worked, whether
-an audit is overdue, and what mode to default to.
+This enables session continuity — the AI knows when you last worked, whether an audit is overdue, and what mode to default to.
 
 ## Cross-machine sync — the thalami hoard
 
@@ -78,14 +65,12 @@ See the [Arc Dashboard design doc](../plans/2026-05-07-thalamus-arc-dashboard-de
 
 ## Housekeeping
 
-When the staleness threshold is reached (or the human asks), the housekeeping
-skill walks through accumulated content:
+When the staleness threshold is reached (or the human asks), the housekeeping skill walks through accumulated content:
 
 - **Promote** — move to a permanent home
 - **Keep** — still relevant, not yet actionable
 - **Prune** — resolved or stale
 
-Housekeeping also reflects on its own process: "Did we capture useful things?
-Too much noise?" This feedback tunes the capture behavior for next time.
+Housekeeping also reflects on its own process: "Did we capture useful things? Too much noise?" This feedback tunes the capture behavior for next time.
 
 For the full spec, see the [Thalamus Design](../plans/2026-03-22-secondbrain-design.md) (the concept began as "SecondBrain").

--- a/docs/gdd/trust-and-safety.md
+++ b/docs/gdd/trust-and-safety.md
@@ -23,10 +23,8 @@ graph BT
 
 When the orientation skill encounters instructions from an untrusted or suspicious source, it follows a specific sequence:
 
-1. **Read just enough** to identify the file as an instruction file from an
-   untrusted source (filename, location, first few lines)
-2. **Log a concern to Thalamus immediately** — before reading the full
-   content. This is the safety breadcrumb.
+1. **Read just enough** to identify the file as an instruction file from an untrusted source (filename, location, first few lines)
+2. **Log a concern to Thalamus immediately** — before reading the full content. This is the safety breadcrumb.
 3. **Continue reading** the full file
 4. **Surface the concern** to the human in conversation
 5. **Do not follow** the instruction until the human explicitly approves

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -13,11 +13,7 @@ Note that this currently assumes a variety of prerequisites:
 
 ## Templates, instances, and tutorials
 
-The yggdrasil workspace ships templates in two shapes: in-repo
-`templates/<kind>/<flavor>/` directories that an `init` command copies
-out (hoards, components), and external git repos that an `init` command
-clones (realms — referenced via `defaults.templateRealm` URL in the
-ecosystem config).
+The yggdrasil workspace ships templates in two shapes: in-repo `templates/<kind>/<flavor>/` directories that an `init` command copies out (hoards, components), and external git repos that an `init` command clones (realms — referenced via `defaults.templateRealm` URL in the ecosystem config).
 
 | Kind | Source | Instance dir | Init command |
 |------|--------|--------------|--------------|
@@ -25,58 +21,32 @@ ecosystem config).
 | **Hoard** | `templates/hoards/<type>/` | `hoards/<type>-<username>/` | `ws hoard init <type>` (copies + git-inits) |
 | **Component** | `templates/components/<flavor>/` | `components/<name>/` | `ws component init <flavor> <name>` (copies + git-inits) |
 
-A *template* is a forkable scaffold. An *instance* is the on-disk
-result of running its `init` command. A *tutorial* is an instance
-deliberately suitable for newcomers — the `gh-pages` component
-template produces a tutorial instance with a comprehensive README and
-a designed-to-be-edited home page. Other flavors may not be tutorial-
-friendly (they're production scaffolds).
+A *template* is a forkable scaffold. An *instance* is the on-disk result of running its `init` command. A *tutorial* is an instance deliberately suitable for newcomers — the `gh-pages` component template produces a tutorial instance with a comprehensive README and a designed-to-be-edited home page. Other flavors may not be tutorial-friendly (they're production scaffolds).
 
 ## Setup
 
 ### Before you start: bootstrap
 
-Two foundational pieces have to be in place before any of the rest
-of the walkthrough works. Skim these and skip whichever you already
-have.
+Two foundational pieces have to be in place before any of the rest of the walkthrough works. Skim these and skip whichever you already have.
 
 #### Install Git
 
-You need Git to clone the workspace, and on Windows it's also how
-you get bash (the shell `ws` runs in).
+You need Git to clone the workspace, and on Windows it's also how you get bash (the shell `ws` runs in).
 
-- **macOS:** `xcode-select --install` to get Git via Xcode Command
-  Line Tools, OR `brew install git` if you already use Homebrew.
-  Bash is built-in.
-- **Windows:** Download Git for Windows from
-  https://git-scm.com/download/win — this bundles **Git Bash**, the
-  shell you'll use for everything else. Accept the installer's
-  default to add Git to your PATH (the "Git from the command line
-  and also from 3rd-party software" option). After install, **open
-  Git Bash** (Start menu → Git Bash). Run all subsequent commands
-  from Git Bash, not cmd.exe or PowerShell.
-- **Linux:** `sudo apt install git` (Debian/Ubuntu) or
-  `sudo dnf install git` (Fedora). Bash is built-in.
+- **macOS:** `xcode-select --install` to get Git via Xcode Command Line Tools, OR `brew install git` if you already use Homebrew. Bash is built-in.
+- **Windows:** Download Git for Windows from https://git-scm.com/download/win — this bundles **Git Bash**, the shell you'll use for everything else. Accept the installer's default to add Git to your PATH (the "Git from the command line and also from 3rd-party software" option). After install, **open Git Bash** (Start menu → Git Bash). Run all subsequent commands from Git Bash, not cmd.exe or PowerShell.
+- **Linux:** `sudo apt install git` (Debian/Ubuntu) or `sudo dnf install git` (Fedora). Bash is built-in.
 
-You don't need Python for the workspace itself. Python and `uv` are
-optional, only required for components or MCP servers that
-explicitly use them.
+You don't need Python for the workspace itself. Python and `uv` are optional, only required for components or MCP servers that explicitly use them.
 
 #### Get a GitHub or GitLab account
 
-GDD assumes you have a hosting account — agents push, open PRs, and
-file issues on your behalf, and there has to be an account those
-operations belong to. **If you don't have one yet:**
+GDD assumes you have a hosting account — agents push, open PRs, and file issues on your behalf, and there has to be an account those operations belong to. **If you don't have one yet:**
 
-- **GitHub:** sign up at https://github.com/signup (free). Pick a
-  username — that's your `identity.human_account` in the workspace
-  config below. Verify your email so you can create repos.
-- **GitLab:** sign up at https://gitlab.com/users/sign_up (free).
-  Same shape — username becomes your config identity.
+- **GitHub:** sign up at https://github.com/signup (free). Pick a username — that's your `identity.human_account` in the workspace config below. Verify your email so you can create repos.
+- **GitLab:** sign up at https://gitlab.com/users/sign_up (free). Same shape — username becomes your config identity.
 
-That's enough to get through this walkthrough. The token + CLI
-setup (Step 3 below) needs your account to exist; everything else
-is stand-alone. If you already have an account, skip ahead.
+That's enough to get through this walkthrough. The token + CLI setup (Step 3 below) needs your account to exist; everything else is stand-alone. If you already have an account, skip ahead.
 
 ### Walkthrough
 
@@ -93,10 +63,7 @@ is stand-alone. If you already have an account, skip ahead.
    bash scripts/ws preflight
    ```
 
-   It verifies bash, git, `yq` (v4+ — Mike Farah's, not the
-   Python yq), `jq`, and a provider CLI (`gh` or `glab`). Anything
-   missing prints a per-OS install hint. Re-run after installing
-   to confirm.
+   It verifies bash, git, `yq` (v4+ — Mike Farah's, not the Python yq), `jq`, and a provider CLI (`gh` or `glab`). Anything missing prints a per-OS install hint. Re-run after installing to confirm.
 
 2. **Configure your identity** — copy the example config and fill in your details:
 
@@ -110,11 +77,7 @@ is stand-alone. If you already have an account, skip ahead.
 
 3. **Set up auth** — follow the [Git Provider Setup](../git-provider-setup.md) guide to configure your provider token in `.env` and install the CLI tools (`gh` for GitHub, `glab` for GitLab). This enables the `ws` CLI to push, file issues, and manage PRs/MRs.
 
-4. **Add `ws` to your PATH** — all workspace operations go through the `ws` CLI.
-   Adding `scripts/` to your PATH lets you run `ws <command>` directly instead
-   of the longer `bash scripts/ws <command>` form. It also means `ws` always
-   resolves paths relative to the workspace root, so it works correctly no matter
-   which directory you (or an AI agent) run it from:
+4. **Add `ws` to your PATH** — all workspace operations go through the `ws` CLI. Adding `scripts/` to your PATH lets you run `ws <command>` directly instead of the longer `bash scripts/ws <command>` form. It also means `ws` always resolves paths relative to the workspace root, so it works correctly no matter which directory you (or an AI agent) run it from:
 
    ```bash
    echo "export PATH=\"$(pwd)/scripts:\$PATH\"" >> ~/.zshrc   # zsh (macOS default)
@@ -122,8 +85,7 @@ is stand-alone. If you already have an account, skip ahead.
    echo "export PATH=\"$(pwd)/scripts:\$PATH\"" >> ~/.bashrc  # bash
    ```
 
-   Then reload your shell (`source ~/.zshrc` / `source ~/.bashrc`) or open a new terminal.
-   Run `ws help` to verify.
+   Then reload your shell (`source ~/.zshrc` / `source ~/.bashrc`) or open a new terminal. Run `ws help` to verify.
 
 5. **Clone a component to work on:**
 
@@ -150,18 +112,13 @@ is stand-alone. If you already have an account, skip ahead.
 
 ### Recommended first scaffold
 
-If you're new to GDD and want to feel the full workflow on a tiny live
-target, scaffold the GitHub Pages tutorial:
+If you're new to GDD and want to feel the full workflow on a tiny live target, scaffold the GitHub Pages tutorial:
 
 ```bash
 ws component init gh-pages my-page
 ```
 
-Then follow the printed instructions and `components/my-page/README.md`.
-The tutorial walks you through creating the GitHub repo, enabling
-Pages, making a first edit on a topic branch, opening a PR, watching
-CodeRabbit and Copilot review, and seeing it deploy live — the whole
-GDD loop on something small enough to feel in 15 minutes.
+Then follow the printed instructions and `components/my-page/README.md`. The tutorial walks you through creating the GitHub repo, enabling Pages, making a first edit on a topic branch, opening a PR, watching CodeRabbit and Copilot review, and seeing it deploy live — the whole GDD loop on something small enough to feel in 15 minutes.
 
 ## Your First Session
 

--- a/docs/git-provider-setup.md
+++ b/docs/git-provider-setup.md
@@ -1,17 +1,12 @@
 # Git Provider Setup
 
-One-time setup for using the workspace CLI (`ws`) with GitHub and/or GitLab.
-The workspace auto-detects your provider from remote URLs — no config needed
-for `github.com` or `gitlab.com`. Self-hosted instances need a config entry
-(see Provider Detection below).
+One-time setup for using the workspace CLI (`ws`) with GitHub and/or GitLab. The workspace auto-detects your provider from remote URLs — no config needed for `github.com` or `gitlab.com`. Self-hosted instances need a config entry (see Provider Detection below).
 
 ---
 
 ## Env var quick reference
 
-All workspace credentials live in `.env` at the yggdrasil root
-(gitignored). The shell scripts source it automatically — there's no
-manual `source .env` step required during normal `ws` use.
+All workspace credentials live in `.env` at the yggdrasil root (gitignored). The shell scripts source it automatically — there's no manual `source .env` step required during normal `ws` use.
 
 | Variable | Purpose | Required when |
 |---|---|---|
@@ -22,11 +17,7 @@ manual `source .env` step required during normal `ws` use.
 | `GITLAB_HOST` | Self-hosted GitLab hostname | Self-hosted GitLab only |
 | `GITLAB_<scope>_<owner>_<role>` | Per-fork / per-group GitLab tokens | Multi-token GitLab setups (see GitLab section) |
 
-For GitLab multi-token setups, individual env vars are mapped to URL
-prefixes via `defaults.gitTokens` in `ecosystem.yaml` (longest-prefix
-match). The script `gp_set_token_for_url` exports the right
-`GITLAB_TOKEN` for each operation. The full naming pattern and
-examples live in the [GitLab](#gitlab) section below.
+For GitLab multi-token setups, individual env vars are mapped to URL prefixes via `defaults.gitTokens` in `ecosystem.yaml` (longest-prefix match). The script `gp_set_token_for_url` exports the right `GITLAB_TOKEN` for each operation. The full naming pattern and examples live in the [GitLab](#gitlab) section below.
 
 Verify what's currently set without changing anything:
 
@@ -50,15 +41,13 @@ brew install gh
 ```bash
 winget install GitHub.cli
 ```
-After install, open a fresh Git Bash session so the updated `PATH` is picked up.
-Alternatively, download the MSI directly from https://cli.github.com.
+After install, open a fresh Git Bash session so the updated `PATH` is picked up. Alternatively, download the MSI directly from https://cli.github.com.
 
 **Linux:** See https://github.com/cli/cli/blob/trunk/docs/install_linux.md
 
 ### Create a classic Personal Access Token
 
-Go to **GitHub → Settings → Developer settings → Personal access tokens →
-Tokens (classic) → Generate new token (classic)**.
+Go to **GitHub → Settings → Developer settings → Personal access tokens → Tokens (classic) → Generate new token (classic)**.
 
 Settings:
 - **Note**: descriptive name, e.g. `yggdrasil-workspace`
@@ -73,19 +62,9 @@ Settings:
 | `read:project` | Read GitHub Projects — checked by `gh pr edit --body-file` |
 | `workflow` | Only if you modify `.github/workflows` files |
 
-The three `read:*` scopes are the recommended baseline alongside
-`repo`. They don't grant any mutation power — they just remove
-recurring papercuts where `gh pr edit`-shaped operations would
-otherwise fail with a scopes error and need the `gh api PATCH`
-workaround documented in [`docs/gdd/access.md`](gdd/access.md) § 4.
-If org policy or token-issuance rules block adding them, the
-strict-minimum (`repo` alone) still works — you'll just hit the
-fallback path more often.
+The three `read:*` scopes are the recommended baseline alongside `repo`. They don't grant any mutation power — they just remove recurring papercuts where `gh pr edit`-shaped operations would otherwise fail with a scopes error and need the `gh api PATCH` workaround documented in [`docs/gdd/access.md`](gdd/access.md) § 4. If org policy or token-issuance rules block adding them, the strict-minimum (`repo` alone) still works — you'll just hit the fallback path more often.
 
-> **Why classic and not fine-grained?** Fine-grained PATs have known
-> limitations with cross-org pull requests and workflow file access.
-> Classic PATs are simpler and more reliable for GDD workspaces that span
-> multiple orgs or forks.
+> **Why classic and not fine-grained?** Fine-grained PATs have known limitations with cross-org pull requests and workflow file access. Classic PATs are simpler and more reliable for GDD workspaces that span multiple orgs or forks.
 
 ### Store the token
 
@@ -134,8 +113,7 @@ After install, open a fresh Git Bash session so the updated `PATH` is picked up.
 
 ### Create a Token
 
-GitLab offers three token types with increasing scope. Use the narrowest one
-that covers your use case:
+GitLab offers three token types with increasing scope. Use the narrowest one that covers your use case:
 
 | Token type | Scope | How to create |
 |------------|-------|---------------|
@@ -143,16 +121,9 @@ that covers your use case:
 | **Group Access Token** | All repos in a group | Group → Settings → Access Tokens |
 | **Personal Access Token** | Entire account | User Settings → Access Tokens |
 
-**Recommended:** use a **Project Access Token** for a single test repo, or a
-**Group Access Token** if your workspace components all live under one group.
-Personal Access Tokens with `api` scope work but give broader access than needed.
+**Recommended:** use a **Project Access Token** for a single test repo, or a **Group Access Token** if your workspace components all live under one group. Personal Access Tokens with `api` scope work but give broader access than needed.
 
-> **gitlab.com free tier:** Group and Project Access Tokens require a paid
-> subscription (Premium+). Use a **Personal Access Token** with `api` scope
-> instead. For the multi-token setup (fork → upstream), you can point multiple
-> env vars at the same PAT (see `.env.example` for variable names) — the token
-> routing logic still works, you just don't get the access-level separation
-> that scoped tokens provide.
+> **gitlab.com free tier:** Group and Project Access Tokens require a paid subscription (Premium+). Use a **Personal Access Token** with `api` scope instead. For the multi-token setup (fork → upstream), you can point multiple env vars at the same PAT (see `.env.example` for variable names) — the token routing logic still works, you just don't get the access-level separation that scoped tokens provide.
 
 Choose the narrowest role that matches the token's job:
 - **Developer** for fork/write tokens that must push branches or create MRs.
@@ -162,9 +133,7 @@ Choose the narrowest role that matches the token's job:
 
 **GitLab display name** (what appears as the MR/issue author bot):
 
-Pattern: `<scope>-<owner>-<role>` where scope is the group or project slug,
-owner is your username, and role is the GitLab role level. For personal
-namespaces (no shared scope), omit the scope prefix and use `<owner>-<role>`.
+Pattern: `<scope>-<owner>-<role>` where scope is the group or project slug, owner is your username, and role is the GitLab role level. For personal namespaces (no shared scope), omit the scope prefix and use `<owner>-<role>`.
 
 | Token's job | GitLab display name | Why |
 |---|---|---|
@@ -173,10 +142,7 @@ namespaces (no shared scope), omit the scope prefix and use `<owner>-<role>`.
 | Personal namespace write | `rpraestholm-developer` | Namespace + role |
 | Single-project write | `aws-ops-wheel-rpraestholm-developer` | Project + owner + role |
 
-With a well-named token, an MR opened by the agent shows as authored by
-e.g. `gdd-rpraestholm-developer` — the human connection is clear even though
-it's a bot account. Combined with `@HUMAN_ACCOUNT` in the MR body, this is
-the primary attribution mechanism on GitLab (see `docs/gdd/cr-internals.md`).
+With a well-named token, an MR opened by the agent shows as authored by e.g. `gdd-rpraestholm-developer` — the human connection is clear even though it's a bot account. Combined with `@HUMAN_ACCOUNT` in the MR body, this is the primary attribution mechanism on GitLab (see `docs/gdd/cr-internals.md`).
 
 **Env var name** (used in `.env` and referenced in `gitTokens`):
 
@@ -227,8 +193,7 @@ export GITLAB_HOST=git.mycompany.com
 
 ### Load and verify
 
-For self-hosted instances, register the hostname with `glab` once after
-setting `GITLAB_HOST`:
+For self-hosted instances, register the hostname with `glab` once after setting `GITLAB_HOST`:
 
 ```bash
 source .env
@@ -244,10 +209,7 @@ Verify with:
 glab auth status
 ```
 
-> **Note:** `glab auth status` exits non-zero if *any* configured GitLab host
-> fails authentication — including `gitlab.com` if you have no token for it.
-> Check that your self-hosted instance shows `✓ Logged in to <your-host>`.
-> The `gitlab.com` failure is harmless if you only use the self-hosted instance.
+> **Note:** `glab auth status` exits non-zero if *any* configured GitLab host fails authentication — including `gitlab.com` if you have no token for it. Check that your self-hosted instance shows `✓ Logged in to <your-host>`. The `gitlab.com` failure is harmless if you only use the self-hosted instance.
 
 ### Test
 
@@ -269,9 +231,7 @@ ws gitlab-auth --status   # shows all configured token slots and set/unset statu
 ws diagnose <comp>        # shows which token covers each remote for a specific component
 ```
 
-`ws diagnose` is the fastest way to confirm auth is wired up correctly for a
-new component — it shows the ecosystem entry, clone status, remotes, provider
-detection, and whether the covering token env var is set or missing.
+`ws diagnose` is the fastest way to confirm auth is wired up correctly for a new component — it shows the ecosystem entry, clone status, remotes, provider detection, and whether the covering token env var is set or missing.
 
 ---
 
@@ -289,8 +249,7 @@ defaults:
     git.mycompany.com: gitlab
 ```
 
-See `ecosystem.local.yaml.example` for more options (workspace-wide defaults,
-per-component overrides).
+See `ecosystem.local.yaml.example` for more options (workspace-wide defaults, per-component overrides).
 
 ---
 
@@ -298,8 +257,7 @@ per-component overrides).
 
 ### yq (YAML processor)
 
-The workspace scripts require [yq](https://github.com/mikefarah/yq) v4+
-to parse `ecosystem.yaml`.
+The workspace scripts require [yq](https://github.com/mikefarah/yq) v4+ to parse `ecosystem.yaml`.
 
 **macOS:**
 ```bash
@@ -326,8 +284,7 @@ Verify: `yq --version` should report v4.x.
 
 ### jq (JSON processor)
 
-The GitLab provider uses [jq](https://jqlang.github.io/jq/) to parse API
-responses. GitHub uses `gh --jq` natively, so jq is only required for GitLab.
+The GitLab provider uses [jq](https://jqlang.github.io/jq/) to parse API responses. GitHub uses `gh --jq` natively, so jq is only required for GitLab.
 
 **macOS:**
 ```bash
@@ -343,8 +300,7 @@ winget install jqlang.jq
 choco install jq
 ```
 
-After installing via chocolatey on Windows, jq may not be on PATH in Git Bash.
-Add it to `~/.bashrc`:
+After installing via chocolatey on Windows, jq may not be on PATH in Git Bash. Add it to `~/.bashrc`:
 ```bash
 export PATH="/c/ProgramData/chocolatey/bin:$PATH"
 ```
@@ -353,8 +309,7 @@ Verify: `jq --version` should report 1.6+.
 
 ### Running Shell Scripts on Windows
 
-All workspace scripts are Bash scripts. Windows needs Git Bash (installed
-with Git for Windows).
+All workspace scripts are Bash scripts. Windows needs Git Bash (installed with Git for Windows).
 
 | From | How to run |
 |------|------------|
@@ -362,9 +317,7 @@ with Git for Windows).
 | cmd / PowerShell | `bash scripts/ws help` (Git Bash must be on PATH) |
 | VS Code terminal | Set default shell to Git Bash, or prefix with `bash` |
 
-A `.gitattributes` in the repo root forces LF line endings on `.sh` files,
-preventing `\r: command not found` errors. If you hit this on existing checkouts:
-`git checkout -- scripts/*.sh`
+A `.gitattributes` in the repo root forces LF line endings on `.sh` files, preventing `\r: command not found` errors. If you hit this on existing checkouts: `git checkout -- scripts/*.sh`
 
 ---
 
@@ -379,11 +332,9 @@ Name remotes after the org or service — never use the generic `origin`.
 | `local-gitea` | Homelab Gitea instance |
 | `<orgname>` | Any org — name the remote after it |
 
-The rule: the remote name should answer "where does this push go?" without
-running `git remote -v`.
+The rule: the remote name should answer "where does this push go?" without running `git remote -v`.
 
-Bootstrap scripts may add an internal Gitea remote during cluster setup. That
-remote is ephemeral and should not be given a permanent name like `origin`.
+Bootstrap scripts may add an internal Gitea remote during cluster setup. That remote is ephemeral and should not be given a permanent name like `origin`.
 
 ---
 
@@ -391,13 +342,11 @@ remote is ephemeral and should not be given a permanent name like `origin`.
 
 ### `gh`/`glab` not found after install
 
-Open a fresh terminal session. The installer updates PATH, but existing
-sessions don't pick it up.
+Open a fresh terminal session. The installer updates PATH, but existing sessions don't pick it up.
 
 ### "Bad credentials" or 401 errors (GitHub)
 
-- Token may be expired — check at GitHub → Settings → Developer settings →
-  Personal access tokens.
+- Token may be expired — check at GitHub → Settings → Developer settings → Personal access tokens.
 - Classic PAT: ensure the `repo` scope is selected.
 - Org-scoped fine-grained PAT: the org owner may need to approve it first.
 
@@ -409,11 +358,8 @@ sessions don't pick it up.
 
 ### Push fails with "remote: Permission denied" or "Write access not granted"
 
-- Credential helper may not have your token stored. Run
-  `gh auth status` (GitHub) or `glab auth status` (GitLab) to check.
-- **Stale cached credential (Windows):** Git Credential Manager caches tokens
-  and won't pick up a new `GH_TOKEN` from `.env` automatically. If you rotated
-  your PAT, erase the stale entry and let the next push re-cache:
+- Credential helper may not have your token stored. Run `gh auth status` (GitHub) or `glab auth status` (GitLab) to check.
+- **Stale cached credential (Windows):** Git Credential Manager caches tokens and won't pick up a new `GH_TOKEN` from `.env` automatically. If you rotated your PAT, erase the stale entry and let the next push re-cache:
 
   ```bash
   # Erase the cached credential for github.com
@@ -433,15 +379,11 @@ sessions don't pick it up.
     "$GH_TOKEN" | git credential-manager store
   ```
 
-- GitKraken users: check `~/.gitconfig` for `url.insteadOf` entries that
-  redirect HTTPS to SSH. Remove or scope them if they interfere with CLI auth.
-  GitKraken manages its own credentials separately from the system credential
-  helper, so it is unaffected by the erase/store steps above.
+- GitKraken users: check `~/.gitconfig` for `url.insteadOf` entries that redirect HTTPS to SSH. Remove or scope them if they interfere with CLI auth. GitKraken manages its own credentials separately from the system credential helper, so it is unaffected by the erase/store steps above.
 
 ### "Cannot detect git provider for URL"
 
-Self-hosted domain not recognized. Add it to `defaults.gitProviders` in
-`ecosystem.local.yaml`:
+Self-hosted domain not recognized. Add it to `defaults.gitProviders` in `ecosystem.local.yaml`:
 
 ```yaml
 defaults:

--- a/docs/ide-setup.md
+++ b/docs/ide-setup.md
@@ -1,19 +1,15 @@
 # IDE Setup
 
-IDE workspace files are NOT tracked in Git — they vary per developer and
-per set of cloned components.
+IDE workspace files are NOT tracked in Git — they vary per developer and per set of cloned components.
 
 ## VS Code
 
-Run `bash scripts/ws vscode` to generate `yggdrasil.code-workspace` from your
-currently cloned components. Re-run after cloning more components.
+Run `bash scripts/ws vscode` to generate `yggdrasil.code-workspace` from your currently cloned components. Re-run after cloning more components.
 
 ## JetBrains
 
-Open the `yggdrasil/` directory, then attach component directories as modules
-via File > Project Structure.
+Open the `yggdrasil/` directory, then attach component directories as modules via File > Project Structure.
 
 ## Terminal / Neovim / other editors
 
-`cd` into `yggdrasil/` or any component under `components/`. The scripts work
-from anywhere.
+`cd` into `yggdrasil/` or any component under `components/`. The scripts work from anywhere.

--- a/docs/mcp-setup.md
+++ b/docs/mcp-setup.md
@@ -1,10 +1,6 @@
 # MCP Setup
 
-[Model Context Protocol](https://modelcontextprotocol.io) servers extend
-agent sessions with additional tools and data sources. The yggdrasil
-workspace declares MCP servers in the active realm's `ecosystem.yaml`,
-and `ws mcp-setup` generates the `.mcp.json` Claude Code reads at
-startup.
+[Model Context Protocol](https://modelcontextprotocol.io) servers extend agent sessions with additional tools and data sources. The yggdrasil workspace declares MCP servers in the active realm's `ecosystem.yaml`, and `ws mcp-setup` generates the `.mcp.json` Claude Code reads at startup.
 
 ---
 
@@ -27,15 +23,11 @@ mcp:
 Each server entry must declare:
 
 - **`url`** — the MCP server endpoint
-- **`transport`** — the transport type (`http` is typical for MaaS-style
-  remote servers)
+- **`transport`** — the transport type (`http` is typical for MaaS-style remote servers)
 
-Both are required; `ws mcp-setup` errors if either is missing rather
-than writing a `.mcp.json` Claude Code would reject.
+Both are required; `ws mcp-setup` errors if either is missing rather than writing a `.mcp.json` Claude Code would reject.
 
-The optional `mcp.doc` field points at a realm-side reference doc
-(server descriptions, who owns each, auth caveats). The setup command
-prints the resolved path so users can find it.
+The optional `mcp.doc` field points at a realm-side reference doc (server descriptions, who owns each, auth caveats). The setup command prints the resolved path so users can find it.
 
 ---
 
@@ -47,36 +39,23 @@ ws mcp-setup --dry-run    # preview without touching .mcp.json
 ws mcp-status             # show currently configured servers
 ```
 
-`ws mcp-setup` reads the merged ecosystem config (upstream + realm +
-local), builds `.mcp.json` at the workspace root, and prints the
-resulting server map. The write is atomic — the file is staged to a
-sibling temp file and `mv`d into place, so an interrupted run never
-leaves a truncated `.mcp.json`.
+`ws mcp-setup` reads the merged ecosystem config (upstream + realm + local), builds `.mcp.json` at the workspace root, and prints the resulting server map. The write is atomic — the file is staged to a sibling temp file and `mv`d into place, so an interrupted run never leaves a truncated `.mcp.json`.
 
-`ws mcp-status` reads the existing `.mcp.json` and lists each server's
-name and URL. Useful to confirm a regeneration produced what you
-expected, or to check what an existing checkout is currently wired up
-for.
+`ws mcp-status` reads the existing `.mcp.json` and lists each server's name and URL. Useful to confirm a regeneration produced what you expected, or to check what an existing checkout is currently wired up for.
 
 ---
 
 ## Authenticating
 
-After `.mcp.json` exists, **restart Claude Code** so it picks up the
-new server list, then run `/mcp` inside the session to authenticate
-each server. Claude Code handles the browser OAuth flow — don't
-paste auth URLs manually.
+After `.mcp.json` exists, **restart Claude Code** so it picks up the new server list, then run `/mcp` inside the session to authenticate each server. Claude Code handles the browser OAuth flow — don't paste auth URLs manually.
 
-Cursor users: MaaS servers must be added to `~/.cursor/mcp.json`
-manually; the workspace's `.mcp.json` is Claude Code-shaped.
+Cursor users: MaaS servers must be added to `~/.cursor/mcp.json` manually; the workspace's `.mcp.json` is Claude Code-shaped.
 
 ---
 
 ## See also
 
 - [`ws help mcp-setup`](ws-cli-guide.md) — CLI flags and behavior
-- [Ecosystem Architecture](ecosystem-architecture.md) — the
-  three-layer config merge `ws mcp-setup` reads from
+- [Ecosystem Architecture](ecosystem-architecture.md) — the three-layer config merge `ws mcp-setup` reads from
 - [Realms](gdd/realms.md) — where the `mcp.servers` declaration lives
-- [`gdd-mcp` skill](gdd/skills-reference.md#workspace-operations) —
-  agent conventions around calling MCP tools and surfacing setup nudges
+- [`gdd-mcp` skill](gdd/skills-reference.md#workspace-operations) — agent conventions around calling MCP tools and surfacing setup nudges

--- a/docs/ws-cli-guide.md
+++ b/docs/ws-cli-guide.md
@@ -99,10 +99,7 @@ Every subcommand falls into one of three tiers:
 }
 ```
 
-> **Note:** Deny patterns shown above are truncated. The actual
-> `.claude/settings.json` includes patterns for all supported arities
-> (up to 7 wildcards). Always check the repo's committed file for the
-> full set.
+> **Note:** Deny patterns shown above are truncated. The actual `.claude/settings.json` includes patterns for all supported arities (up to 7 wildcards). Always check the repo's committed file for the full set.
 
 ### 5. Update docs
 
@@ -135,13 +132,11 @@ Component names pass through `yq` expressions via bracket-quoted lookups (`.comp
 
 ### Forking and renaming
 
-The workspace name `yggdrasil` appears as a special case in `ws_resolve_target`
-(one string comparison) and throughout documentation. To fork and rename:
+The workspace name `yggdrasil` appears as a special case in `ws_resolve_target` (one string comparison) and throughout documentation. To fork and rename:
 
 1. Change the `"yggdrasil"` check in `scripts/ws` → `ws_resolve_target()`
 2. Search docs for `yggdrasil` and update narrative references
-3. Update remote names and org prefixes in `scripts/git-push.sh` and
-   `scripts/git-cr.sh` to match your fork's remote naming
+3. Update remote names and org prefixes in `scripts/git-push.sh` and `scripts/git-cr.sh` to match your fork's remote naming
 4. Update the domain in `ecosystem.yaml`
 5. Update `.mcp.json` if you change component names that host MCP servers
 
@@ -235,8 +230,7 @@ The flag value is a bare name (no angle brackets), so it passes the hook and nee
 
 ## ws component init
 
-Scaffolds a new component into `components/<name>/` from a template
-shipped at `templates/components/<flavor>/`.
+Scaffolds a new component into `components/<name>/` from a template shipped at `templates/components/<flavor>/`.
 
 Usage:
 
@@ -247,31 +241,19 @@ ws component list
 
 Behavior:
 
-1. Validates the flavor exists. Errors with the available-flavors list
-   if not.
+1. Validates the flavor exists. Errors with the available-flavors list if not.
 2. Resolves the component name. Required; prompted on a tty if omitted.
-3. Pre-flight checks: `components/<name>/` doesn't exist, `<name>`
-   isn't already in `ecosystem.local.yaml`. Warns + confirms if `<name>`
-   shadows a realm-catalog entry.
+3. Pre-flight checks: `components/<name>/` doesn't exist, `<name>` isn't already in `ecosystem.local.yaml`. Warns + confirms if `<name>` shadows a realm-catalog entry.
 4. Copies the template directory into `components/<name>/`.
-5. `git init -b main`, initial commit using the user's git config —
-   `git config user.name` for the author name (fallback to
-   `identity.human_account`) and `git config user.email` for the email
-   (fallback to `<human_account>@local`).
-6. Adds an entry to `ecosystem.local.yaml` under `components.<name>.repo`
-   (matches the field `ws-clone.sh` reads). The URL is inferred from
-   `identity.human_account` and the component name, in canonical
-   `https://github.com/<user>/<name>.git` form.
-7. Prints educational output explaining the local-first → upstream-when-
-   ready flow plus a flavor-appropriate `gh repo create` suggestion.
+5. `git init -b main`, initial commit using the user's git config — `git config user.name` for the author name (fallback to `identity.human_account`) and `git config user.email` for the email (fallback to `<human_account>@local`).
+6. Adds an entry to `ecosystem.local.yaml` under `components.<name>.repo` (matches the field `ws-clone.sh` reads). The URL is inferred from `identity.human_account` and the component name, in canonical `https://github.com/<user>/<name>.git` form.
+7. Prints educational output explaining the local-first → upstream-when-ready flow plus a flavor-appropriate `gh repo create` suggestion.
 
 `ecosystem.local.yaml` is the per-developer (gitignored) layer of the three-layer merge. The new component is immediately usable from this workspace; when ready to share with the community, move the entry into the realm's `ecosystem.yaml` with realm-appropriate fields (tier, chartVersion, etc.) and push the realm.
 
 Currently shipped flavors:
 
-- `gh-pages` — tutorial-friendly GitHub Pages site, bare markdown +
-  default GitHub Jekyll theme. Comprehensive README walks the user
-  through the edit → PR → bot-review → merge → see-it-live demo loop.
+- `gh-pages` — tutorial-friendly GitHub Pages site, bare markdown + default GitHub Jekyll theme. Comprehensive README walks the user through the edit → PR → bot-review → merge → see-it-live demo loop.
 
 Per-flavor flag handling is hardcoded in `scripts/ws-component.sh` for v1.
 


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @Cervator via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

Apply the no-hard-wrap convention across the GitHub-rendered reference docs: prose paragraphs and list items become single physical lines (the renderer handles wrap). This is a **purely cosmetic line-joining** change — no wording, punctuation, or content was altered.

- 20 files: `CLAUDE.md`, the top-level `docs/*.md`, and `docs/gdd/*.md`.
- Untouched by rule: fenced code blocks (incl. mermaid/yaml/bash/text), tables, YAML frontmatter, HTML blocks, link-reference definitions, headings.
- **Excluded** (by design): `docs/plans/*` (historical design records — to be reprocessed into a historic format separately) and `docs/gdd/samples/*` (intentional example formatting).

## How it was done

A fan-out of per-file-group agents did the mechanical de-wrap; each verified its own output (structure intact, no code/table/frontmatter joins, exactly-one-blank-line separation). I spot-reviewed the highest-risk file (`docs/gdd/permissions.md`) at the line level — clean joins, code fences intact, no content loss. The big line-count reductions (e.g. access.md, hoards.md) are expected: heavily-wrapped legacy docs collapse a lot when de-wrapped.

## Test plan

- [x] Mechanical change only; no scripts/tests touched.
- [ ] Skim the rendered diff on GitHub — confirm no paragraph lost text and no code block/table got joined. (The diff is large but uniform: each hunk is `multi-line → single-line` with identical text.)

## Related

- Convention: `.agent/skills/gdd-doc-writing/SKILL.md` ("Prose Line Wrapping") + the `feedback_no_hard_wrap` note.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

**Documentation**
- Improved readability and consistency across setup, access control, permissions, Git provider configuration, IDE/editor setup, and workspace CLI guidance.
- Clarified token routing and scope expectations, including practical GitHub/GitLab differences and fallback behavior.
- Expanded guidance on AI agent authentication and local auto-approve patterns.
- Strengthened troubleshooting/diagnostics recommendations and refined permission pattern matching rules (including wildcard behavior and decision guidance).
- Updated workflow explanations for cross-fork CR/MR flows and general reflowed content for easier scanning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->