### PR TITLE
chore(ws): surface ws test yggdrasil + ws review reply for agent discoverability

### DIFF
--- a/scripts/ws-orient.sh
+++ b/scripts/ws-orient.sh
@@ -311,6 +311,18 @@ emit_component_adapters() {
     fi
 }
 
+# Surface the workspace-root self-test. yggdrasil itself is treated as a
+# "component" by ws-test.sh, whose suite is the vendored-bats files under
+# tests/ (excluding tests/vendor/). It has no realm adapter, so it never
+# shows up in emit_component_adapters — surface it here so `ws test
+# yggdrasil` is discoverable from orient, the lowest-effort entry point.
+emit_workspace_selftest() {
+    [[ -n "$(LC_ALL=C find "$ROOT_DIR/tests" -path "$ROOT_DIR/tests/vendor" -prune -o -type f -name '*.bats' -print -quit 2>/dev/null)" ]] || return 0
+    printf '\nWorkspace root — self-test:\n'
+    printf '  yggdrasil\n'
+    printf '    ws test yggdrasil [runs: bats tests/**/*.bats]\n'
+}
+
 # Render one component's adapter wiring. Walks the three plan-named
 # verbs explicitly (test/lint/build) so a typo in the YAML doesn't
 # silently swallow a missing slot — the diagnostic message stays
@@ -445,4 +457,5 @@ _resolve_orient_realm
 emit_subcommand_survey
 emit_active_realm
 emit_component_adapters
+emit_workspace_selftest
 emit_skill_index

--- a/scripts/ws-realm.sh
+++ b/scripts/ws-realm.sh
@@ -440,6 +440,20 @@ HELP
         exit 1
     fi
 
+    # Workspace root is not an ecosystem component, but ws-test.sh treats
+    # `yggdrasil` as one whose suite is the vendored-bats files under tests/.
+    # Surface that self-test instead of erroring on "not declared in config".
+    if [[ "$comp" == "yggdrasil" ]]; then
+        echo "=== yggdrasil (workspace root) ==="
+        if [[ -n "$(LC_ALL=C find "$ROOT_DIR/tests" -path "$ROOT_DIR/tests/vendor" -prune -o -type f -name '*.bats' -print -quit 2>/dev/null)" ]]; then
+            echo "Self-test (vendored bats):"
+            echo "  test    ws test yggdrasil   [bats tests/**/*.bats]"
+        else
+            echo "  (no .bats files under tests/)"
+        fi
+        return 0
+    fi
+
     local eco
     eco="$(ws_resolve_ecosystem)"
     local exists

--- a/scripts/ws-review.sh
+++ b/scripts/ws-review.sh
@@ -556,6 +556,15 @@ review_comments() {
         trap - EXIT
         echo "Saved: $output_path"
     fi
+
+    # Reply nudge — to stderr so it never lands in --output snapshots or
+    # downstream greps of stdout. Replies are the exception, not the rule:
+    # addressing a finding normally lets CodeRabbit self-resolve, so only reach
+    # for `reply` when rejecting a comment or explaining a non-obvious fix.
+    if (( n_comments > 0 )); then
+        echo "" >&2
+        echo "↪ Reply to a thread: ws review <comp> reply <cr#> <thread-id> <msg> [--resolve] — only when rejecting a comment or explaining an unexpected fix; just addressing it usually lets the bot self-resolve." >&2
+    fi
 }
 
 review_notes() {


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @Cervator via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

- Small agent-ergonomics nudges so the best `ws` command is the lowest-effort one to discover. Surfaced while reviewing the mentoring/k8s design (PR #107).
- **`ws review`** prints a stderr reminder (only when there are inline comments) that `ws review <comp> reply <cr#> <thread-id> <msg> [--resolve]` exists — framed as the exception, for rejecting a comment or explaining a non-obvious fix; addressing a finding normally lets the bot self-resolve. Stderr so it never pollutes `--output` snapshots or downstream greps.
- **`ws orient`** surfaces the workspace-root self-test ("Workspace root — self-test: `ws test yggdrasil` [runs: bats tests/**/*.bats]") when `tests/**/*.bats` exist. `ws test yggdrasil` already worked, but nothing advertised it on the agent's lowest-effort discovery path (orient at session start).
- **`ws actions yggdrasil`** surfaces the same self-test instead of hard-erroring with "not declared in ecosystem config".

## Test plan

- [ ] `bash scripts/ws test yggdrasil` — full bats suite green (393 tests).
- [ ] `bash scripts/ws orient` shows the new "Workspace root — self-test" section.
- [ ] `bash scripts/ws actions yggdrasil` prints the self-test instead of erroring.

## Related

- Follow-on to the mentoring/k8s training-wheels design (PR #107, merged) — these ergonomics tweaks rode out of that review session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a workspace root self-test section to the orientation output, including a ready-to-run test command when applicable.
  * Workspace actions now recognize the root workspace self-test and report when no matching tests are present.
  * Review output now includes an extra hint for replying to inline comments, with guidance for resolving or explaining changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->