### PR TITLE
docs(tutorials): Tutorials section + Guarded Kubernetes walkthrough

### DIFF
--- a/.agent/skills/gdd-k8s/SKILL.md
+++ b/.agent/skills/gdd-k8s/SKILL.md
@@ -3,13 +3,13 @@ name: gdd-k8s
 description: Use when a guarded kubectl practice is requested ("practice kubectl", "test cluster access", "nervous about prod") or when GDD_K8S_CONTEXT is set for the session.
 ---
 
-# GDD K8s Training Wheels
+# GDD K8s Guard
 
 A practice workflow that arms a small scope — a kube context plus allowed namespaces — so accidental `kubectl` commands against the wrong cluster or namespace are blocked before they execute.
 
 ## What This Is (and Is Not)
 
-Training wheels: accident-prevention for nervous practitioners, not a security boundary. A determined agent or human can bypass the guard via `ws hook-bypass k8s` (session-level lift) or by running `kubectl` entirely outside the harness (e.g. in a terminal not running Claude Code). Real authorization lives server-side in RBAC. The guard's job is to catch the command that slips out of habit, not to enforce cluster access control.
+A safety scope, not a security boundary: accident-prevention for anyone who wants writes bounded to a known context + namespace — a newcomer learning the ropes, or an expert who wants a guardrail while working near production. A determined agent or human can bypass the guard via `ws hook-bypass k8s` (session-level lift) or by running `kubectl` entirely outside the harness (e.g. in a terminal not running Claude Code). Real authorization lives server-side in RBAC. The guard's job is to catch the command that slips out of habit, not to enforce cluster access control.
 
 ## When to Load
 

--- a/docs/gdd/features.md
+++ b/docs/gdd/features.md
@@ -123,7 +123,7 @@ Per-machine extras (opt-in): if a command you trust keeps getting denied, copy `
 
 ## Kubernetes practice guard — `ws k8s`
 
-"Training wheels" for kubectl: arm a scope (a context + one or more namespaces) and the workspace blocks accidental *writes* to anything outside it — before kubectl runs. Reads stay free cluster-wide; the guard is accident-prevention against destructive out-of-scope writes, **not** a security or confidentiality boundary (real authorization is server-side RBAC).
+A safety scope for kubectl — training wheels while you learn, a guardrail near production: arm a scope (a context + one or more namespaces) and the workspace blocks accidental *writes* to anything outside it — before kubectl runs. Reads stay free cluster-wide; the guard is accident-prevention against destructive out-of-scope writes, **not** a security or confidentiality boundary (real authorization is server-side RBAC).
 
 - `ws k8s scope set --context <ctx> --namespace <ns[,ns]>` arms the guard for the session; `ws k8s scope show` / `ws k8s scope clear` inspect and disarm. The context must exist; a namespace that doesn't exist yet only warns, so you can arm across environments and create the namespaces afterward.
 - `ws k8s <kubectl args>` runs guarded: in-scope reads and writes go through (writes inject `--context`); out-of-scope, cluster-scoped, or malformed-input writes are REJECTED with a **class-aware** message that names the right next step (widen the scope, lift the guard, or fix the input). You may create/delete the very namespaces your scope covers.

--- a/docs/gdd/features.md
+++ b/docs/gdd/features.md
@@ -130,7 +130,7 @@ Per-machine extras (opt-in): if a command you trust keeps getting denied, copy `
 - For AI agents, the PreToolUse hook extends the guard to *raw* `kubectl`: an in-scope read auto-allows, an out-of-scope write is denied with the same message, and a script that shells out to `kubectl` is caught too. `ws hook-bypass k8s` lifts the redirect for a session (human-approved, audited).
 - A plain human terminal with no session id is still guarded by an active session's scope (ambient aggregation), so the protection holds when you step in by hand.
 
-The `gdd-k8s` skill drives the scope-capture flow; the mentoring overlay narrates each guard decision so a nervous practitioner learns the pattern, not just the commands. See [skills-reference.md](skills-reference.md) and [agent-training.md](agent-training.md).
+The `gdd-k8s` skill drives the scope-capture flow; the mentoring overlay narrates each guard decision so a nervous practitioner learns the pattern, not just the commands. Hands-on: the [Guarded Kubernetes tutorial](../tutorials/guarded-kubernetes.md) (needs a cluster). Reference: [skills-reference.md](skills-reference.md) and [agent-training.md](agent-training.md).
 
 ---
 

--- a/docs/gdd/roles-and-stances.md
+++ b/docs/gdd/roles-and-stances.md
@@ -53,7 +53,7 @@ When mentoring is on, the AI explains decisions, teaches practices in context, a
 
 The AI's job with mentoring active is to **grow the human**, not just ship the code. Every interaction is an opportunity to transfer understanding.
 
-Mentoring is also the overlay that arms tool-practice workflows. For example, `gdd-k8s` (the Kubernetes training-wheels practice skill) activates when mentoring is on and the session involves Kubernetes — it guides the contributor through safe, explained cluster interactions rather than handing them raw `kubectl` commands to run without context.
+Mentoring is also the overlay that arms tool-practice workflows. For example, `gdd-k8s` (the guarded-Kubernetes practice skill) activates when mentoring is on and the session involves Kubernetes — it guides the contributor through safe, explained cluster interactions rather than handing them raw `kubectl` commands to run without context.
 
 ## See also
 

--- a/docs/tutorials/guarded-kubernetes.md
+++ b/docs/tutorials/guarded-kubernetes.md
@@ -1,0 +1,216 @@
+# Guarded Kubernetes
+
+> **You can ask your AI agent to walk you through any step below, or follow this guide directly. Both paths arrive at the same place** — the agent is non-deterministic, this guide is the deterministic version.
+>
+> **First time through? Turn on mentoring.** Ask your agent: *"let's turn on mentoring while I work through the guarded Kubernetes tutorial."* The mentoring overlay narrates each guard decision — *why* a command was allowed, prompted, or blocked — which is exactly what you want while the verdicts are still new. The `gdd-k8s` skill drives the flow; mentoring adds the teaching.
+
+The `ws k8s` guard is **training wheels for kubectl**: you arm a small scope — one kube context plus one or more namespaces — and the workspace blocks accidental *writes* to anything outside it, before kubectl runs. Reads stay free cluster-wide. It is **accident-prevention, not a security boundary**: a determined human or agent can always step around it (plain `kubectl`, or `ws hook-bypass k8s`), and real authorization lives in your cluster's RBAC. The guard's job is to catch the destructive command that slips out of habit — a `delete` against prod when you meant your sandbox — not to enforce access control.
+
+The walkthrough is chaptered so you can stop after Chapter 2 with the guard in muscle memory, and come back for the agent/human paths and real workflows later.
+
+---
+
+## Prerequisites
+
+- **A Kubernetes cluster context you can write to**, and a namespace you can freely create and destroy. This is the one hard requirement — the guard guards *real* kubectl against a *real* cluster.
+
+  Don't have a cluster? Spin up a throwaway local one (any of these gives you a context you can wreck safely):
+
+  | Tool | Start it | Context name |
+  |---|---|---|
+  | Docker Desktop | enable Kubernetes in Settings → Kubernetes | `docker-desktop` |
+  | [kind](https://kind.sigs.k8s.io/) | `kind create cluster` | `kind-kind` |
+  | [k3d](https://k3d.io/) | `k3d cluster create practice` | `k3d-practice` |
+  | [minikube](https://minikube.sigs.k8s.io/) | `minikube start` | `minikube` |
+
+- **The workspace prerequisites.** From the workspace root, `ws preflight` should pass — you specifically need `kubectl` on PATH plus `yq` (the guard parses `-f` manifests with it) and `jq`.
+- **The `ws k8s` feature present.** `ws orient` should list the `gdd-k8s` skill and a `k8s` subcommand.
+
+Throughout, substitute `<ctx>` for your chosen context and `<ns>` for a throwaway namespace (e.g. `practice`). Run everything from the workspace root.
+
+---
+
+# Chapter 1: Arm the training wheels
+
+Goal: a guard scope armed and understood. Nothing is blocked yet — you're setting the boundary.
+
+## 1. Pick a context and a namespace
+
+List what you can reach:
+
+```bash
+kubectl config get-contexts
+```
+
+Pick one you're comfortable making a mess in (`<ctx>`). You need a namespace too. You can create it first:
+
+```bash
+kubectl --context <ctx> create namespace <ns>
+```
+
+Or skip that — arming a scope does **not** require the namespace to exist yet (Chapter 3 creates it through the guard). Either path is fine.
+
+## 2. Arm the scope
+
+```bash
+ws k8s scope set --context <ctx> --namespace <ns>
+```
+
+You'll see `guard scope armed: context=<ctx> namespaces=<ns>`. The context must exist — a bogus `--context nope` errors. A namespace that doesn't exist yet only *warns* ("not found … arming anyway") and arms regardless, so you can arm across several environments up front and create the namespaces later.
+
+Confirm it:
+
+```bash
+ws k8s scope show
+```
+
+The scope lives in your session, not your kubeconfig — `ws k8s scope clear` removes it, and it's gone when the session ends. It changes nothing on the cluster.
+
+**That's the setup.** From here on, every `ws k8s …` command is checked against this scope.
+
+---
+
+# Chapter 2: Feel the guard
+
+Goal: build intuition for what's allowed, what's blocked, and — most importantly — how to *read the rejection messages*, which tell you the right next step.
+
+## 1. Reads are free
+
+```bash
+ws k8s get pods                     # your scoped context, injected automatically
+ws k8s get pods -n kube-system      # a different namespace — still fine
+```
+
+Both run. Reads are never namespace-bounded — the guard only cares about writes. Notice the wrapper injects `--context <ctx>` for you, so you can't accidentally read (or later write) against the wrong cluster.
+
+## 2. An in-scope write runs
+
+```bash
+ws k8s run probe --image=pause --restart=Never -n <ns>
+```
+
+The pod is created. A write that lands inside your scope behaves like normal kubectl.
+
+## 3. An out-of-scope write is blocked
+
+```bash
+ws k8s delete pod probe -n default
+```
+
+REJECTED — and kubectl is never called. Read the message: it tells you the namespace is outside the scope and that you can **add that namespace to the scope** to allow it just there, or run plain `kubectl` outside the guard. This is the common case the guard exists for: you meant `<ns>`, you typed `default`, nothing happened.
+
+## 4. The three kinds of rejection
+
+The guard tailors its advice to *why* something is blocked. Trigger each once so you recognise them:
+
+```bash
+ws k8s delete pod probe -n default                          # SCOPE: a namespace you could add
+ws k8s create clusterrole demo --verb=get --resource=pods   # UNBOUNDED: not namespace-bound at all
+ws k8s apply -f ./nope.yaml                                  # PRECONDITION: the guard can't read the input
+```
+
+- **Scope** — the target namespace is outside the scope. Remedy: add it to the scope, or go around the guard. Widening *helps*.
+- **Unbounded** — the resource isn't bound to any namespace (a `clusterrole`, a node `cordon`, `--all-namespaces`). Widening the namespace scope **cannot** help; the message points you at plain `kubectl` or dropping the guard with `ws k8s scope clear`.
+- **Precondition** — the guard couldn't evaluate the command (a `-f` file that doesn't exist or won't parse). It fails closed and tells you to fix the input — this is *not* a scope decision, so it doesn't mention widening.
+
+All three block **before** kubectl runs, so they're safe to type while you're learning.
+
+**That's Chapter 2.** You can stop here — you've got the core: reads free, in-scope writes run, out-of-scope writes blocked, and you can read the three rejection styles. Come back for the real workflows and the agent/human paths.
+
+---
+
+# Chapter 3: Real practice
+
+Goal: the workflows you'll actually use — manifests, namespace lifecycle, widening, cleanup.
+
+## 1. Apply a manifest
+
+Write a Pod manifest into your scoped namespace:
+
+```bash
+cat > pod.yaml <<'EOF'
+apiVersion: v1
+kind: Pod
+metadata:
+  name: practice-pod
+  namespace: <ns>
+spec:
+  containers:
+    - name: pause
+      image: pause
+EOF
+
+ws k8s apply -f pod.yaml
+```
+
+It applies — the namespace in the manifest is in scope. Each document is scope-checked individually: a `kind: List` (or a multi-doc file) with one item in `<ns>` and one in `prod` is blocked on the `prod` item, before anything is applied.
+
+> **Windows note:** quote the path or use forward slashes. An unquoted backslash path (`ws k8s apply -f C:\dir\pod.yaml`) is mangled by the shell into `C:dirpod.yaml` *before* `ws` ever sees it — use `"C:\dir\pod.yaml"` or `C:/dir/pod.yaml`.
+
+## 2. Namespace lifecycle — create and recreate your own
+
+Because `<ns>` is in your scope, you may create and delete *that* namespace through the guard:
+
+```bash
+ws k8s delete namespace <ns>     # allowed — it's in scope
+ws k8s create namespace <ns>     # allowed — recreated
+```
+
+A namespace *not* in your scope (`ws k8s delete namespace kube-public`) is still rejected. This is what makes the "arm a not-yet-existing namespace, then create it" workflow from Chapter 1 work — handy when you're setting up the same sandbox across several environments.
+
+## 3. Widen, then narrow
+
+Want a second namespace in scope? Re-arm with the broader list (it overwrites):
+
+```bash
+ws k8s scope set --context <ctx> --namespace <ns>,another-ns
+```
+
+When you're done, clear it:
+
+```bash
+ws k8s scope clear
+```
+
+## 4. Clean up
+
+```bash
+ws k8s delete pod practice-pod -n <ns>
+ws k8s delete pod probe -n <ns>
+ws k8s delete namespace <ns>          # in-scope; or raw: kubectl --context <ctx> delete namespace <ns>
+ws k8s scope clear
+rm pod.yaml
+```
+
+If you spun up a local cluster just for this, tear it down too (`kind delete cluster`, `k3d cluster delete practice`, `minikube delete`, or disable Docker Desktop's Kubernetes).
+
+---
+
+# Chapter 4+: The agent path, the human path, and going further
+
+## The agent path (Tier 2b)
+
+When an AI agent has a scope armed, the guard extends to *raw* `kubectl`, not just `ws k8s`:
+
+- A raw in-scope **read** (`kubectl get pods`) auto-allows — no redirect, no prompt.
+- A raw out-of-scope **write** is denied with the same class-aware message the wrapper emits.
+- A raw in-scope **write** is redirected to `ws k8s` so the wrapper can inject `--context`.
+- A temp script that shells out to `kubectl` is caught too (the hook scans script bodies).
+
+For the rare case where the agent genuinely needs raw kubectl (a one-off automation script), `ws hook-bypass k8s` lifts the raw-kubectl redirect for that session — human-approved and audited. It does **not** disable the `ws k8s` wrapper guard.
+
+## The human path (ambient guard)
+
+Open a separate plain terminal — no agent, no session id — while an agent session's scope is armed, and `ws k8s` is *still* guarded there: it aggregates the active session's scope. A read works; an out-of-scope write is rejected even though this terminal has no session of its own. The human terminal can't reconfigure the guard (scope set/clear are session-bound); its escape from a rejection is plain `kubectl`.
+
+## What the guard does NOT do
+
+- Replace RBAC. The bypass is always one command away by design — server-side RBAC is the real authorization boundary.
+- Guard kubectl run entirely outside the workspace (a terminal not running the agent, CI, etc.).
+- Persist across sessions — the scope is per-session and clears when the session ends.
+
+## Going further
+
+- **Multiple namespaces / environments.** Arm a comma-separated list; pre-arm namespaces that don't exist yet and create them in-scope.
+- **Use it for real.** The same guard protects real work — arm your sandbox namespace before a session where you'll be near production, and let the training wheels catch the slip.
+- **Validate the feature end-to-end.** If you're testing the guard itself rather than learning it, the maintainer's primer (a pass/fail checklist) lives in the thalami hoard — the [`gdd-k8s` skill](../gdd/skills-reference.md) and [Features Tour § Kubernetes practice guard](../gdd/features.md) are the reference.

--- a/docs/tutorials/guarded-kubernetes.md
+++ b/docs/tutorials/guarded-kubernetes.md
@@ -23,18 +23,19 @@ The walkthrough is chaptered so you can stop after Chapter 2 with the guard in m
   | [k3d](https://k3d.io/) | `k3d cluster create practice` | `k3d-practice` |
   | [minikube](https://minikube.sigs.k8s.io/) | `minikube start` | `minikube` |
 
-- **The workspace prerequisites.** From the workspace root, `ws preflight` should pass — you specifically need `kubectl` on PATH plus `yq` (the guard parses `-f` manifests with it) and `jq`.
+- **`kubectl` on your PATH**, pointed at that cluster. Note `kubectl` is the one tool `ws preflight` does *not* check (it isn't a general workspace prerequisite) — this tutorial needs it specifically, so confirm `kubectl version` works before you start.
+- **The workspace prerequisites.** From the workspace root, `ws preflight` should pass — it verifies bash, git, `yq` (the guard parses `-f` manifests with it), `jq`, and a provider CLI (`gh` or `glab`).
 - **The `ws k8s` feature present.** `ws orient` should list the `gdd-k8s` skill and a `k8s` subcommand.
 
 Throughout, substitute `<ctx>` for your chosen context and `<ns>` for a throwaway namespace (e.g. `practice`). Run everything from the workspace root.
 
 ---
 
-# Chapter 1: Arm the training wheels
+## Chapter 1: Arm the training wheels
 
 Goal: a guard scope armed and understood. Nothing is blocked yet — you're setting the boundary.
 
-## 1. Pick a context and a namespace
+### 1. Pick a context and a namespace
 
 List what you can reach:
 
@@ -50,7 +51,7 @@ kubectl --context <ctx> create namespace <ns>
 
 Or skip that — arming a scope does **not** require the namespace to exist yet (Chapter 3 creates it through the guard). Either path is fine.
 
-## 2. Arm the scope
+### 2. Arm the scope
 
 ```bash
 ws k8s scope set --context <ctx> --namespace <ns>
@@ -70,11 +71,11 @@ The scope lives in your session, not your kubeconfig — `ws k8s scope clear` re
 
 ---
 
-# Chapter 2: Feel the guard
+## Chapter 2: Feel the guard
 
 Goal: build intuition for what's allowed, what's blocked, and — most importantly — how to *read the rejection messages*, which tell you the right next step.
 
-## 1. Reads are free
+### 1. Reads are free
 
 ```bash
 ws k8s get pods                     # your scoped context, injected automatically
@@ -83,7 +84,7 @@ ws k8s get pods -n kube-system      # a different namespace — still fine
 
 Both run. Reads are never namespace-bounded — the guard only cares about writes. Notice the wrapper injects `--context <ctx>` for you, so you can't accidentally read (or later write) against the wrong cluster.
 
-## 2. An in-scope write runs
+### 2. An in-scope write runs
 
 ```bash
 ws k8s run probe --image=pause --restart=Never -n <ns>
@@ -91,7 +92,7 @@ ws k8s run probe --image=pause --restart=Never -n <ns>
 
 The pod is created. A write that lands inside your scope behaves like normal kubectl.
 
-## 3. An out-of-scope write is blocked
+### 3. An out-of-scope write is blocked
 
 ```bash
 ws k8s delete pod probe -n default
@@ -99,7 +100,7 @@ ws k8s delete pod probe -n default
 
 REJECTED — and kubectl is never called. Read the message: it tells you the namespace is outside the scope and that you can **add that namespace to the scope** to allow it just there, or run plain `kubectl` outside the guard. This is the common case the guard exists for: you meant `<ns>`, you typed `default`, nothing happened.
 
-## 4. The three kinds of rejection
+### 4. The three kinds of rejection
 
 The guard tailors its advice to *why* something is blocked. Trigger each once so you recognise them:
 
@@ -119,11 +120,11 @@ All three block **before** kubectl runs, so they're safe to type while you're le
 
 ---
 
-# Chapter 3: Real practice
+## Chapter 3: Real practice
 
 Goal: the workflows you'll actually use — manifests, namespace lifecycle, widening, cleanup.
 
-## 1. Apply a manifest
+### 1. Apply a manifest
 
 Write a Pod manifest into your scoped namespace:
 
@@ -147,7 +148,7 @@ It applies — the namespace in the manifest is in scope. Each document is scope
 
 > **Windows note:** quote the path or use forward slashes. An unquoted backslash path (`ws k8s apply -f C:\dir\pod.yaml`) is mangled by the shell into `C:dirpod.yaml` *before* `ws` ever sees it — use `"C:\dir\pod.yaml"` or `C:/dir/pod.yaml`.
 
-## 2. Namespace lifecycle — create and recreate your own
+### 2. Namespace lifecycle — create and recreate your own
 
 Because `<ns>` is in your scope, you may create and delete *that* namespace through the guard:
 
@@ -158,7 +159,7 @@ ws k8s create namespace <ns>     # allowed — recreated
 
 A namespace *not* in your scope (`ws k8s delete namespace kube-public`) is still rejected. This is what makes the "arm a not-yet-existing namespace, then create it" workflow from Chapter 1 work — handy when you're setting up the same sandbox across several environments.
 
-## 3. Widen, then narrow
+### 3. Widen, then narrow
 
 Want a second namespace in scope? Re-arm with the broader list (it overwrites):
 
@@ -172,7 +173,7 @@ When you're done, clear it:
 ws k8s scope clear
 ```
 
-## 4. Clean up
+### 4. Clean up
 
 ```bash
 ws k8s delete pod practice-pod -n <ns>
@@ -186,9 +187,9 @@ If you spun up a local cluster just for this, tear it down too (`kind delete clu
 
 ---
 
-# Chapter 4+: The agent path, the human path, and going further
+## Chapter 4+: The agent path, the human path, and going further
 
-## The agent path (Tier 2b)
+### The agent path (Tier 2b)
 
 When an AI agent has a scope armed, the guard extends to *raw* `kubectl`, not just `ws k8s`:
 
@@ -199,18 +200,18 @@ When an AI agent has a scope armed, the guard extends to *raw* `kubectl`, not ju
 
 For the rare case where the agent genuinely needs raw kubectl (a one-off automation script), `ws hook-bypass k8s` lifts the raw-kubectl redirect for that session — human-approved and audited. It does **not** disable the `ws k8s` wrapper guard.
 
-## The human path (ambient guard)
+### The human path (ambient guard)
 
 Open a separate plain terminal — no agent, no session id — while an agent session's scope is armed, and `ws k8s` is *still* guarded there: it aggregates the active session's scope. A read works; an out-of-scope write is rejected even though this terminal has no session of its own. The human terminal can't reconfigure the guard (scope set/clear are session-bound); its escape from a rejection is plain `kubectl`.
 
-## What the guard does NOT do
+### What the guard does NOT do
 
 - Replace RBAC. The bypass is always one command away by design — server-side RBAC is the real authorization boundary.
 - Guard kubectl run entirely outside the workspace (a terminal not running the agent, CI, etc.).
 - Persist across sessions — the scope is per-session and clears when the session ends.
 
-## Going further
+### Going further
 
 - **Multiple namespaces / environments.** Arm a comma-separated list; pre-arm namespaces that don't exist yet and create them in-scope.
 - **Use it for real.** The same guard protects real work — arm your sandbox namespace before a session where you'll be near production, and let the training wheels catch the slip.
-- **Validate the feature end-to-end.** If you're testing the guard itself rather than learning it, the maintainer's primer (a pass/fail checklist) lives in the thalami hoard — the [`gdd-k8s` skill](../gdd/skills-reference.md) and [Features Tour § Kubernetes practice guard](../gdd/features.md) are the reference.
+- **Validate the feature end-to-end.** If you're testing the guard itself rather than learning it, the [`gdd-k8s` skill](../gdd/skills-reference.md) and [Features Tour § Kubernetes practice guard](../gdd/features.md) are the reference.

--- a/docs/tutorials/guarded-kubernetes.md
+++ b/docs/tutorials/guarded-kubernetes.md
@@ -4,7 +4,7 @@
 >
 > **First time through? Turn on mentoring.** Ask your agent: *"let's turn on mentoring while I work through the guarded Kubernetes tutorial."* The mentoring overlay narrates each guard decision — *why* a command was allowed, prompted, or blocked — which is exactly what you want while the verdicts are still new. The `gdd-k8s` skill drives the flow; mentoring adds the teaching.
 
-The `ws k8s` guard is **training wheels for kubectl**: you arm a small scope — one kube context plus one or more namespaces — and the workspace blocks accidental *writes* to anything outside it, before kubectl runs. Reads stay free cluster-wide. It is **accident-prevention, not a security boundary**: a determined human or agent can always step around it (plain `kubectl`, or `ws hook-bypass k8s`), and real authorization lives in your cluster's RBAC. The guard's job is to catch the destructive command that slips out of habit — a `delete` against prod when you meant your sandbox — not to enforce access control.
+The `ws k8s` guard is a **safety scope for kubectl** — training wheels while you're learning, a guardrail the rest of the time. You arm a small scope (one kube context plus one or more namespaces) and the workspace blocks accidental *writes* to anything outside it, before kubectl runs. Reads stay free cluster-wide. It's as useful to an expert who wants a boundary while working near production as to someone on their first cluster session. It is **accident-prevention, not a security boundary**: a determined human or agent can always step around it (plain `kubectl`, or `ws hook-bypass k8s`), and real authorization lives in your cluster's RBAC. The guard's job is to catch the destructive command that slips out of habit — a `delete` against prod when you meant your sandbox — not to enforce access control.
 
 The walkthrough is chaptered so you can stop after Chapter 2 with the guard in muscle memory, and come back for the agent/human paths and real workflows later.
 
@@ -31,7 +31,7 @@ Throughout, substitute `<ctx>` for your chosen context and `<ns>` for a throwawa
 
 ---
 
-## Chapter 1: Arm the training wheels
+## Chapter 1: Arm a guard scope
 
 Goal: a guard scope armed and understood. Nothing is blocked yet — you're setting the boundary.
 
@@ -213,5 +213,5 @@ Open a separate plain terminal — no agent, no session id — while an agent se
 ### Going further
 
 - **Multiple namespaces / environments.** Arm a comma-separated list; pre-arm namespaces that don't exist yet and create them in-scope.
-- **Use it for real.** The same guard protects real work — arm your sandbox namespace before a session where you'll be near production, and let the training wheels catch the slip.
+- **Use it for real.** The same guard protects real work — arm your sandbox namespace before a session where you'll be near production, and let it catch the slip.
 - **Validate the feature end-to-end.** If you're testing the guard itself rather than learning it, the [`gdd-k8s` skill](../gdd/skills-reference.md) and [Features Tour § Kubernetes practice guard](../gdd/features.md) are the reference.

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -1,0 +1,17 @@
+# Tutorials
+
+Hands-on, chaptered walkthroughs of individual GDD features. Each one is followable solo — just read and run the commands — or alongside your AI agent. Turn on the mentoring overlay for your first pass through any of them and the agent explains each command and decision as you go rather than just running it.
+
+These differ from the [Getting Started](../getting-started/index.md) walkthrough, which onboards you to the workspace as a whole. A tutorial here goes deep on one feature.
+
+## Available tutorials
+
+| Tutorial | What you practice | Prerequisite |
+|---|---|---|
+| [Guarded Kubernetes](guarded-kubernetes.md) | Practising `kubectl` safely behind the `ws k8s` training-wheels guard — armed scopes, the allow/block verdicts, and the agent + human paths. | A Kubernetes cluster context you can write to (a throwaway local cluster is fine). |
+
+## A note on shapes
+
+Most tutorials in this section are **docs pages** like the ones above — read-and-run walkthroughs of a feature.
+
+One tutorial is a **scaffold** instead: the `gh-pages` component template. Running `ws component init gh-pages <name>` drops a tutorial *instance* into `components/<name>/` whose own `README.md` is a chaptered walkthrough — from scaffold to a live GitHub Pages site through the full edit → PR → bot-review → merge loop, in about 15 minutes. It lives with the template rather than here because the thing you learn on is a real repo you create. See [Getting Started → Recommended first scaffold](../getting-started/index.md#recommended-first-scaffold).

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -6,12 +6,13 @@ These differ from the [Getting Started](../getting-started/index.md) walkthrough
 
 ## Available tutorials
 
-| Tutorial | What you practice | Prerequisite |
-|---|---|---|
-| [Guarded Kubernetes](guarded-kubernetes.md) | Practising `kubectl` safely behind the `ws k8s` training-wheels guard — armed scopes, the allow/block verdicts, and the agent + human paths. | A Kubernetes cluster context you can write to (a throwaway local cluster is fine). |
+| Tutorial | Shape | What you practice | Prerequisite |
+|---|---|---|---|
+| [Guarded Kubernetes](guarded-kubernetes.md) | docs page | `kubectl` safely behind the `ws k8s` guard — armed scopes, the allow/block verdicts, and the agent + human paths. | A Kubernetes cluster context you can write to (a throwaway local cluster is fine). |
+| [GitHub Pages site](https://github.com/SiliconSaga/yggdrasil/blob/main/templates/components/gh-pages/README.md) | scaffold | The full GDD loop on a tiny live target — scaffold, deploy, edit, open a PR, watch the bots review, merge. | A GitHub account (a public repo gives free Pages). |
 
 ## A note on shapes
 
-Most tutorials in this section are **docs pages** like the ones above — read-and-run walkthroughs of a feature.
+Most tutorials here are **docs pages** like Guarded Kubernetes — read-and-run walkthroughs of a feature.
 
-One tutorial is a **scaffold** instead: the `gh-pages` component template. Running `ws component init gh-pages <name>` drops a tutorial *instance* into `components/<name>/` whose own `README.md` is a chaptered walkthrough — from scaffold to a live GitHub Pages site through the full edit → PR → bot-review → merge loop, in about 15 minutes. It lives with the template rather than here because the thing you learn on is a real repo you create. See [Getting Started → Recommended first scaffold](../getting-started/index.md#recommended-first-scaffold).
+The **GitHub Pages** one is a **scaffold** instead: run `ws component init gh-pages <name>` and the walkthrough is the generated `components/<name>/README.md` (the table links to the template version). It lives with its template rather than as a docs page because the thing you learn on is a real repo you create and deploy. See [Getting Started → Recommended first scaffold](../getting-started/index.md#recommended-first-scaffold) for where it fits in onboarding.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,3 +83,4 @@ nav:
   - Tutorials:
     - tutorials/index.md
     - Guarded Kubernetes: tutorials/guarded-kubernetes.md
+    - GitHub Pages Site: https://github.com/SiliconSaga/yggdrasil/blob/main/templates/components/gh-pages/README.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -80,3 +80,6 @@ nav:
       - "Thalamus: Parallel": gdd/samples/thalamus-parallel.md
   - Getting Started:
     - getting-started/index.md
+  - Tutorials:
+    - tutorials/index.md
+    - Guarded Kubernetes: tutorials/guarded-kubernetes.md

--- a/scripts/ws-k8s.sh
+++ b/scripts/ws-k8s.sh
@@ -96,10 +96,11 @@ _k8s_help() {
 Usage: ws k8s scope set|show|clear        # manage the practice guard scope
        ws k8s <kubectl args...>           # guarded kubectl passthrough
 
-A practice guard ("training wheels") that bounds accidental kubectl WRITES to
-an armed context + namespace(s). Reads are free cluster-wide; out-of-scope or
-cluster-scoped writes are blocked before kubectl runs. Accident-prevention,
-not a security boundary — see the gdd-k8s skill.
+A safety scope that bounds accidental kubectl WRITES to an armed context +
+namespace(s) — training wheels while learning, a guardrail near production.
+Reads are free cluster-wide; out-of-scope or cluster-scoped writes are blocked
+before kubectl runs. Accident-prevention, not a security boundary — see the
+gdd-k8s skill.
 
 Scope management:
   ws k8s scope set --context <ctx> --namespace <ns[,ns]>   arm the guard


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @Cervator via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

- Adds a docs **Tutorials** section (`docs/tutorials/`) — the home for a growing suite of chaptered, read-and-run (or agent-guided) per-feature walkthroughs, distinct from the workspace-wide Getting Started onboarding.
- First tutorial: **Guarded Kubernetes** — a hands-on walkthrough of the `ws k8s` training-wheels guard, gated on the one hard prerequisite (a writable cluster context) with throwaway-local-cluster pointers. Mirrors the gh-pages tutorial's voice/chapters: arm a scope → feel the guard and read the three rejection classes → real workflows → the agent + human paths + what it is not (RBAC).
- Wires both pages into the mkdocs nav; cross-links the tutorial from the Features Tour's k8s section; cross-links the gh-pages scaffold tutorial from the new index.

## Test plan

- [ ] mkdocs builds with both pages in nav and no broken internal links (`validation.links.not_found: info`).
- [ ] Optional human pass: follow the tutorial end-to-end against a throwaway local cluster and confirm each chapter's commands behave as written.

## Related

- Follows PR #112 (the `ws k8s` guard UX work this tutorial teaches).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Tutorials landing page with an optional AI-mentored “mentoring overlay” walkthrough style.
  * Introduced a complete Guarded Kubernetes tutorial covering scoped apply behavior, namespace lifecycle handling, cleanup, and how different rejection outcomes guide next steps.
* **Documentation**
  * Clarified that `gdd-k8s` drives the guarded Kubernetes scope-capture, with mentoring narration of guard decisions.
  * Updated `ws k8s` help text and refreshed the `gdd-k8s` skill framing to emphasize “not a security boundary” and RBAC caveats.
* **Chores**
  * Updated site navigation to include the new Tutorials section and links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->