### PR TITLE
feat(hook): redirect git mv to the plain-mv + bodyfile pattern

### DIFF
--- a/.claude/hooks/hook-rules
+++ b/.claude/hooks/hook-rules
@@ -50,7 +50,7 @@ ws review * threads * --resolve*
 git-commit   | git commit*    | Use `ws commit <comp> <bodyfile>` — handles Co-Authored-By trailer + bodyfile-driven staging. See `ws help commit`. If `ws commit` doesn't fit (rare), run `ws hook-bypass git-commit` to request a session-scoped bypass.
 git-push     | git push*      | Use `ws push <comp> [branch]` — handles fork-remote selection from identity.forkRemote and sets upstream on first push. `ws hook-bypass git-push` for a session-scoped bypass.
 gh-pr-create | gh pr create*  | Use `ws cr <comp> <title> <bodyfile>` — bodyfile-driven, applies identity substitutions, picks the right token + remote. `ws hook-bypass gh-pr-create` for a session-scoped bypass.
-git-mv       | git* mv*       | Don't `git mv` — it pre-stages the rename and breaks `ws commit`'s bodyfile staging. Instead `mv <src> <dst>` (plain), then list BOTH the old and new paths under `add:` in your `ws commit` bodyfile; git still records a clean rename. `ws hook-bypass git-mv` for a session-scoped bypass.
+git-mv       | git mv*        | Don't `git mv` — it pre-stages the rename and breaks `ws commit`'s bodyfile staging. Instead `mv <src> <dst>` (plain), then list BOTH the old and new paths under `add:` in your `ws commit` bodyfile; git still records a clean rename. `ws hook-bypass git-mv` for a session-scoped bypass.
 
 [adapter-redirect-commands]
 # Tier 3 — raw test/lint/build runners with a ws equivalent. The hook

--- a/.claude/hooks/hook-rules
+++ b/.claude/hooks/hook-rules
@@ -50,6 +50,7 @@ ws review * threads * --resolve*
 git-commit   | git commit*    | Use `ws commit <comp> <bodyfile>` — handles Co-Authored-By trailer + bodyfile-driven staging. See `ws help commit`. If `ws commit` doesn't fit (rare), run `ws hook-bypass git-commit` to request a session-scoped bypass.
 git-push     | git push*      | Use `ws push <comp> [branch]` — handles fork-remote selection from identity.forkRemote and sets upstream on first push. `ws hook-bypass git-push` for a session-scoped bypass.
 gh-pr-create | gh pr create*  | Use `ws cr <comp> <title> <bodyfile>` — bodyfile-driven, applies identity substitutions, picks the right token + remote. `ws hook-bypass gh-pr-create` for a session-scoped bypass.
+git-mv       | git* mv*       | Don't `git mv` — it pre-stages the rename and breaks `ws commit`'s bodyfile staging. Instead `mv <src> <dst>` (plain), then list BOTH the old and new paths under `add:` in your `ws commit` bodyfile; git still records a clean rename. `ws hook-bypass git-mv` for a session-scoped bypass.
 
 [adapter-redirect-commands]
 # Tier 3 — raw test/lint/build runners with a ws equivalent. The hook

--- a/docs/gdd/permissions.md
+++ b/docs/gdd/permissions.md
@@ -50,7 +50,7 @@ See [`.claude/hooks/README.md`](../../.claude/hooks/README.md) for the full hook
 
 ### Redirect tier and bypass
 
-Tier 2 of the PreToolUse hook denies a curated list of raw commands (`git commit`, `git push`, `gh pr create`) that have a `ws` wrapper equivalent. The deny carries a corrective message pointing at the right `ws` subcommand.
+Tier 2 of the PreToolUse hook denies a curated list of raw commands (`git commit`, `git push`, `gh pr create`, `git mv`) that have a friendlier equivalent. The deny carries a corrective message pointing at the right `ws` subcommand — or, for `git mv`, at the plain-`mv`-then-list-both-paths-in-the-bodyfile pattern, since `git mv` pre-stages the rename and breaks `ws commit`'s bodyfile-driven staging.
 
 This is a *training* layer, not a safety floor — the `ws` wrappers add attribution, remote selection, and bodyfile flows that AGENTS.md documents but training-data reflex drifts away from. A legitimate edge case (the `ws` subcommand doesn't yet support what's needed) escapes via `ws hook-bypass <slug>`, which writes a marker file keyed to the Claude Code session id (`$CLAUDE_CODE_SESSION_ID`). The marker is honored for the rest of the session.
 
@@ -191,6 +191,7 @@ Verified in interactive testing. Each row is a (pattern, attempted command, expe
 | `Bash(ws commit:*)` | `ws commit --co-author-file sess--sub yggdrasil .commits/x.md` | Allowed without prompt | The flag tail matches the start-anchored `ws commit:*` prefix; no env prefix, no angle brackets |
 | (any allow) | `LD_PRELOAD=/tmp/evil.so ws status` | Prompted | An env-assignment prefix stays in the match string and fails every allow glob |
 | `Bash(git commit *)` redirect-deny | `git commit -m y` | Denied (redirected to `ws commit`) | A bare denied command still hits its redirect-deny |
+| `git* mv*` redirect-deny | `git -C x mv a b` | Denied (redirect to plain `mv` + bodyfile) | The `git*…*` shape catches the `git -C <dir> mv` hoard form, not just bare `git mv` |
 | `Bash(ws test:*)` | `ws test mimir` | Allowed without prompt | `ws test` allowlisted under the realm trust model |
 | `Bash(ws lint:*)` | `ws lint mimir` | Allowed without prompt | `ws lint` allowlisted under the realm trust model |
 

--- a/docs/gdd/permissions.md
+++ b/docs/gdd/permissions.md
@@ -191,7 +191,7 @@ Verified in interactive testing. Each row is a (pattern, attempted command, expe
 | `Bash(ws commit:*)` | `ws commit --co-author-file sess--sub yggdrasil .commits/x.md` | Allowed without prompt | The flag tail matches the start-anchored `ws commit:*` prefix; no env prefix, no angle brackets |
 | (any allow) | `LD_PRELOAD=/tmp/evil.so ws status` | Prompted | An env-assignment prefix stays in the match string and fails every allow glob |
 | `Bash(git commit *)` redirect-deny | `git commit -m y` | Denied (redirected to `ws commit`) | A bare denied command still hits its redirect-deny |
-| `git* mv*` redirect-deny | `git -C x mv a b` | Denied (redirect to plain `mv` + bodyfile) | The `git*…*` shape catches the `git -C <dir> mv` hoard form, not just bare `git mv` |
+| `git mv*` redirect-deny | `git mv a b` | Denied (redirect to plain `mv` + bodyfile) | Start-anchored bare-form match (like `git commit*`); a `git -C <dir> mv` form isn't caught — same accepted gap as the other git redirects, and avoids over-matching `mv` in unrelated git args |
 | `Bash(ws test:*)` | `ws test mimir` | Allowed without prompt | `ws test` allowlisted under the realm trust model |
 | `Bash(ws lint:*)` | `ws lint mimir` | Allowed without prompt | `ws lint` allowlisted under the realm trust model |
 

--- a/tests/hook/gdd-permission-hook.bats
+++ b/tests/hook/gdd-permission-hook.bats
@@ -857,7 +857,7 @@ EOF
     write_project_hook_rules "$(cat <<'EOF'
 [redirect-commands]
 git-commit | git commit* | Use ws commit
-git-mv | git* mv* | Use plain mv then list both paths in the ws commit bodyfile
+git-mv | git mv* | Use plain mv then list both paths in the ws commit bodyfile
 EOF
 )"
     run_hook "git mv old.md new.md"
@@ -866,24 +866,25 @@ EOF
     [[ "$output" == *"list both paths"* ]]
 }
 
-@test "redirect: git -C <dir> mv is caught by git-mv too" {
+@test "redirect: git-mv glob does not over-match 'mv' in other git args" {
     write_project_hook_rules "$(cat <<'EOF'
 [redirect-commands]
 git-commit | git commit* | Use ws commit
-git-mv | git* mv* | Use plain mv then list both paths in the ws commit bodyfile
+git-mv | git mv* | Use plain mv then list both paths in the ws commit bodyfile
 EOF
 )"
-    run_hook 'git -C hoards/borgr mv "a b.md" "40_Archive/Bills/a b.md"'
+    # A non-mv subcommand whose args merely contain " mv " must NOT be denied
+    # as git-mv (the bare `git mv*` pattern is start-anchored, not a catch-all).
+    run_hook 'git tag -a v1 -m "drop the old mv helper"'
     [ "$status" -eq 0 ]
-    [[ "$output" == *"\"permissionDecision\":\"deny\""* ]]
-    [[ "$output" == *"list both paths"* ]]
+    [[ "$output" != *"list both paths"* ]]
 }
 
 @test "redirect: 'mv' in a commit message routes to git-commit, not git-mv" {
     write_project_hook_rules "$(cat <<'EOF'
 [redirect-commands]
 git-commit | git commit* | Use ws commit
-git-mv | git* mv* | Use plain mv then list both paths
+git-mv | git mv* | Use plain mv then list both paths
 EOF
 )"
     run_hook 'git commit -m "remove old mv helper"'

--- a/tests/hook/gdd-permission-hook.bats
+++ b/tests/hook/gdd-permission-hook.bats
@@ -853,6 +853,46 @@ EOF
     [[ "$output" != *"Use ws commit"* ]]
 }
 
+@test "redirect: git mv denies with plain-mv + bodyfile guidance" {
+    write_project_hook_rules "$(cat <<'EOF'
+[redirect-commands]
+git-commit | git commit* | Use ws commit
+git-mv | git* mv* | Use plain mv then list both paths in the ws commit bodyfile
+EOF
+)"
+    run_hook "git mv old.md new.md"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"\"permissionDecision\":\"deny\""* ]]
+    [[ "$output" == *"list both paths"* ]]
+}
+
+@test "redirect: git -C <dir> mv is caught by git-mv too" {
+    write_project_hook_rules "$(cat <<'EOF'
+[redirect-commands]
+git-commit | git commit* | Use ws commit
+git-mv | git* mv* | Use plain mv then list both paths in the ws commit bodyfile
+EOF
+)"
+    run_hook 'git -C hoards/borgr mv "a b.md" "40_Archive/Bills/a b.md"'
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"\"permissionDecision\":\"deny\""* ]]
+    [[ "$output" == *"list both paths"* ]]
+}
+
+@test "redirect: 'mv' in a commit message routes to git-commit, not git-mv" {
+    write_project_hook_rules "$(cat <<'EOF'
+[redirect-commands]
+git-commit | git commit* | Use ws commit
+git-mv | git* mv* | Use plain mv then list both paths
+EOF
+)"
+    run_hook 'git commit -m "remove old mv helper"'
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"\"permissionDecision\":\"deny\""* ]]
+    [[ "$output" == *"Use ws commit"* ]]
+    [[ "$output" != *"list both paths"* ]]
+}
+
 # ─── Tier 3 — adapter-aware test/lint redirects ─────────────────────
 
 # When `[adapter-redirect-commands]` matches (pytest, ruff, etc.) and


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @Cervator via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

- Add a `[redirect-commands]` hook rule that denies `git mv` (and the `git -C <dir> mv` form) with a corrective message: use plain `mv` then list both old and new paths under `add:` in the `ws commit` bodyfile.
- Why: `git mv` pre-stages the rename and removes the old path, which breaks `ws commit`'s bodyfile staging — a recurring snag when moving a tracked file (e.g. archiving a vault note). Plain `mv` + both paths lets `ws commit` stage the rename cleanly, and git still records a 100% rename.
- Pattern `git* mv*` also catches the `-C` hoard form (matching the existing `git*reset --hard*` convention); ordered after `git commit` so a "mv"-in-message commit still routes to `git-commit`.
- Pure config: no hook code change (the section is data-driven). Slug `git-mv` doubles as the `ws hook-bypass git-mv` escape hatch.

## Test plan

- [ ] `ws test yggdrasil` passes, including three new `redirect:` bats cases (bare `git mv` denies; `git -C … mv` denies; "mv" in a commit message still routes to `git-commit`).
- [ ] Manual: a `git mv a b` Bash call is denied with the plain-mv + bodyfile message; `ws hook-bypass git-mv` lifts it for the session.

## Related

- Follow-up idea (not in this PR): a `ws hoard mv` helper the redirect could point at instead of inline instructions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Tier 2 redirect-deny guidance to include `git mv`, with recommended replacement workflow using plain `mv` and preserving clean rename tracking via listing both old and new paths.
  * Expanded matcher notes to clarify when `git mv` is denied vs not caught (including directory-scoped command forms).

* **Tests**
  * Added Bats coverage for `git mv` redirect-deny behavior, verifying correct guidance text and ensuring it doesn’t over-match unrelated `mv` strings or route incorrectly through `git commit -m`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->