### PR TITLE
docs(k8s): guarded Kubernetes tutorial improvements

### DIFF
--- a/.agent/skills/gdd-k8s/SKILL.md
+++ b/.agent/skills/gdd-k8s/SKILL.md
@@ -23,7 +23,7 @@ When the skill fires for the first time in a session (no scope set yet), walk th
 
 1. **Explain what's about to happen and why** — the guard will intercept raw `kubectl`, redirect it through `ws k8s`, and block any write that targets a namespace outside the captured scope.
 2. **Offer context discovery** — run `kubectl config get-contexts` to list available contexts and invite the user to pick one. (`ws k8s config get-contexts` works equivalently once a scope is armed.)
-3. **Confirm the target namespace(s)** — for multiple namespaces, confirm each individually so the user understands what is and is not in scope. A namespace need not already exist: arming a scope on namespaces you intend to create (e.g. one per environment) is supported — `ws k8s create namespace <ns>` is in-scope and can create them.
+3. **Confirm the target namespace(s)** — for multiple namespaces, confirm each individually so the user understands what is and is not in scope. A namespace need not already exist: arming a scope on namespaces you intend to create (e.g. one per environment) is supported — `ws k8s create namespace <ns>` is in-scope and can create them. Also ask the user to name a second namespace they expect writes to be rejected from — using a real namespace they know makes the rejection demonstrations concrete rather than arbitrary (e.g. `default` carries no meaning to most users). This secondary namespace can later serve as the target for the scope-widening exercise.
 4. **Arm the scope** — run `ws k8s scope set --context <ctx> --namespace <ns[,ns]>`. The command requires the context to exist (you can't create a context through the guard) but only WARNS on a namespace that doesn't exist yet — surfacing a likely typo without blocking the pre-create workflow.
 5. **Confirm the guard is armed** — run `ws k8s scope show` and echo the result. Explain what the user will see when a command is allowed, prompted, or blocked.
 
@@ -54,15 +54,15 @@ Read verbs auto-approved by the guard: `get`, `describe`, `logs`, `top`, `explai
 
 ## Surfacing Output to the User
 
-**The user cannot see tool output in Claude Code.** When a Bash tool call completes, the harness shows the user only the command name and a pass/fail indicator — not the actual stdout or stderr delivered to the agent. A user clicking on a rejected command sees `Bash(ws k8s delete pod probe -n default)` and a red dot, nothing more.
+Tool output visibility varies by harness, version, and user preferences. In some configurations the user sees full stdout/stderr inline; in others they see only the command name and a pass/fail indicator. When uncertain, **check with the user early** — for example, after the first guard rejection, ask whether they can see the rejection message or only the result dot. Their answer should calibrate how much the agent needs to repeat for the rest of the session.
 
-This has direct consequences for this skill:
+When the agent cannot confirm the user is seeing output:
 
-- **Always quote guard rejection messages verbatim** when a command is blocked. Do not paraphrase or summarize — the guard's messages are written to be read, and the user cannot read them without the agent repeating them.
-- **Echo `ws k8s scope show` output** after arming the scope, rather than just saying "the scope is armed." The user cannot see the confirmation line the command produced.
-- **Quote the output of any diagnostic command** (`kubectl config get-contexts`, `kubectl get namespace`, etc.) when the result is relevant to a decision the user is being asked to make.
+- **Quote guard rejection messages verbatim** when a command is blocked. The guard's messages are written to be informative; a paraphrase loses the specific remedies they name.
+- **Echo `ws k8s scope show` output** after arming, rather than just asserting "the scope is armed."
+- **Surface any command output the user needs in order to make a decision** — context lists, namespace lookups, etc.
 
-The general rule: if the output of a tool call is the point — a rejection reason, a confirmation, a list the user must choose from — repeat it in plain text before moving on. Silence after a blocked command, when the user has no way to see why it was blocked, is a significant UX failure.
+The general rule: if the output of a tool call is the point — a rejection reason, a confirmation, a list — and the agent is not certain the user is seeing it, repeat it in plain text before moving on.
 
 ## Hook Availability
 

--- a/.agent/skills/gdd-k8s/SKILL.md
+++ b/.agent/skills/gdd-k8s/SKILL.md
@@ -37,7 +37,9 @@ Once a scope is armed, the hook's scoped-redirect tier intercepts every Bash too
 | `ws k8s <write verb>` targeting in-scope namespace | Prompts normally — user sees the command and approves |
 | `ws k8s <write verb>` targeting out-of-scope namespace | Denied with a class-aware explanation: a namespace-scoped write says to add that namespace to the scope; a cluster-scoped/unbounded write says widening cannot help — run outside the guard or clear it |
 | `ws k8s create`/`delete namespace <ns>` where `<ns>` is in scope | Allowed — you may create (or delete and recreate) your own scoped namespace(s). An out-of-scope namespace name is denied like any out-of-scope write |
-| Raw `kubectl` command | Redirected to `ws k8s`; user sees the denial message |
+| Raw `kubectl` read verb | Auto-approved silently — reads are free even via raw kubectl when a scope is armed. The hook does not redirect harmless reads. |
+| Raw `kubectl` write (in-scope namespace) | Denied with a message instructing use of `ws k8s` — the wrapper injects `--context`, preventing writes from hitting the wrong cluster by force of habit |
+| Raw `kubectl` write (out-of-scope namespace or unbounded) | Denied with the same class-aware message the `ws k8s` wrapper emits |
 | Temp script (bash/sh/source) whose file contains raw `kubectl` | Denied with a message pointing to `ws k8s` or `ws hook-bypass k8s` |
 | `kubectl --context <other-ctx>` where other-ctx ≠ practice context | Blocked — explicit cross-context write is out of scope |
 | `--all-namespaces` on a write | Blocked — unbounded writes are never scope-bounded |
@@ -49,6 +51,10 @@ Read verbs auto-approved by the guard: `get`, `describe`, `logs`, `top`, `explai
 - **Widen the scope** — re-run `ws k8s scope set --context <ctx> --namespace <ns1,ns2>` with a broader namespace list. The previous scope is overwritten.
 - **Remove the scope entirely** — `ws k8s scope clear`. The guard deactivates for the session; raw `kubectl` is no longer intercepted.
 - **Lift the redirect for the session** — `ws hook-bypass k8s`. This writes a session-scoped bypass marker so the raw-kubectl redirect does not fire, but scope-set vars remain in place. Useful for running a one-off automation script that calls `kubectl` directly.
+
+## Hook Availability
+
+The raw-kubectl intercept (Tier 2b) is implemented as a **Claude Code PreToolUse hook** registered in `.claude/settings.json`. Without an equivalent hook in another harness (Codex, Cursor, etc.), raw `kubectl` commands are not intercepted — the `ws k8s` wrapper still enforces scope when called directly, but the safety net against accidental bare `kubectl` use only fires inside Claude Code. When running in a different harness, treat `ws k8s` as the required form; do not assume raw `kubectl` will be caught.
 
 ## Composability
 

--- a/.agent/skills/gdd-k8s/SKILL.md
+++ b/.agent/skills/gdd-k8s/SKILL.md
@@ -52,6 +52,18 @@ Read verbs auto-approved by the guard: `get`, `describe`, `logs`, `top`, `explai
 - **Remove the scope entirely** — `ws k8s scope clear`. The guard deactivates for the session; raw `kubectl` is no longer intercepted.
 - **Lift the redirect for the session** — `ws hook-bypass k8s`. This writes a session-scoped bypass marker so the raw-kubectl redirect does not fire, but scope-set vars remain in place. Useful for running a one-off automation script that calls `kubectl` directly.
 
+## Surfacing Output to the User
+
+**The user cannot see tool output in Claude Code.** When a Bash tool call completes, the harness shows the user only the command name and a pass/fail indicator — not the actual stdout or stderr delivered to the agent. A user clicking on a rejected command sees `Bash(ws k8s delete pod probe -n default)` and a red dot, nothing more.
+
+This has direct consequences for this skill:
+
+- **Always quote guard rejection messages verbatim** when a command is blocked. Do not paraphrase or summarize — the guard's messages are written to be read, and the user cannot read them without the agent repeating them.
+- **Echo `ws k8s scope show` output** after arming the scope, rather than just saying "the scope is armed." The user cannot see the confirmation line the command produced.
+- **Quote the output of any diagnostic command** (`kubectl config get-contexts`, `kubectl get namespace`, etc.) when the result is relevant to a decision the user is being asked to make.
+
+The general rule: if the output of a tool call is the point — a rejection reason, a confirmation, a list the user must choose from — repeat it in plain text before moving on. Silence after a blocked command, when the user has no way to see why it was blocked, is a significant UX failure.
+
 ## Hook Availability
 
 The raw-kubectl intercept (Tier 2b) is implemented as a **Claude Code PreToolUse hook** registered in `.claude/settings.json`. Without an equivalent hook in another harness (Codex, Cursor, etc.), raw `kubectl` commands are not intercepted — the `ws k8s` wrapper still enforces scope when called directly, but the safety net against accidental bare `kubectl` use only fires inside Claude Code. When running in a different harness, treat `ws k8s` as the required form; do not assume raw `kubectl` will be caught.

--- a/.agent/skills/gdd-mentoring/SKILL.md
+++ b/.agent/skills/gdd-mentoring/SKILL.md
@@ -42,6 +42,16 @@ When the mentoring overlay is active and a k8s-practice signal fires — the use
 
 With mentoring active, narrate each step of the scope-capture flow before running it: explain what the guard is, why each namespace confirmation matters, and what the user will see when a command is blocked. The goal is internalization, not just arming the guard.
 
+## Tone and Register
+
+Mentoring mode calls for a **moderately formal, professional register** — the voice of a senior colleague explaining something carefully, not a casual guide improvising aloud. Calibrate to the documentation the user is learning from: if the docs are measured and precise, the narration should match that register.
+
+Specifically:
+- **Avoid loose or casual language.** Phrases like "make a mess in", "try it out and see what happens", "pretty straightforward", or "don't worry about it" lower the register below what a formal mentor context warrants. Use "a namespace you can freely write to" rather than "one you can wreck"; "observe the guard in action" rather than "see what blows up".
+- **Be direct and precise.** A mentor names what is happening and why, without hedging or breezy reassurance. Precision is more respectful of the learner than friendliness at the cost of accuracy.
+- **Do not over-correct into stiffness.** The goal is professional clarity, not formality for its own sake. Conversational contractions ("you'll", "it's") are fine; throwaway slang is not.
+- **Match the weight of the subject.** Kubernetes cluster operations carry real consequences even with the guard in place. Narration should reflect that — not alarmism, but appropriate seriousness.
+
 ## What This Overlay Does NOT Do
 
 - Condescend or assume the user knows nothing

--- a/docs/tutorials/guarded-kubernetes.md
+++ b/docs/tutorials/guarded-kubernetes.md
@@ -69,7 +69,7 @@ ws k8s scope show
 
 The scope lives in your session, not your kubeconfig — `ws k8s scope clear` removes it, and it's gone when the session ends. It changes nothing on the cluster.
 
-> **Scope changes must go through your agent.** `ws k8s scope set` requires the agent session ID and will not work in a standalone terminal — the error message will tell you to ask your agent to run it instead.
+> **Scope changes require a session ID.** `ws k8s scope set` writes to a session-scoped file and will fail without one. In a standalone terminal this means asking your agent to run the command — the error message will say so. Advanced users can export `GDD_SESSION_ID` directly to run scope commands outside the harness.
 
 **That's the setup.** From here on, every `ws k8s …` command is checked against this scope.
 
@@ -218,7 +218,7 @@ For the rare case where the agent genuinely needs raw kubectl (a one-off automat
 
 ### The human path (ambient guard)
 
-Open a separate plain terminal — no agent, no session id — while an agent session's scope is armed, and `ws k8s` is *still* guarded there: it aggregates the active session's scope. A read works; an out-of-scope write is rejected even though this terminal has no session of its own. The human terminal cannot reconfigure the guard — `ws k8s scope set` and `scope clear` require the agent session ID and will not work outside the harness. To change the scope, ask your agent to run the command. The human terminal's escape from a rejection is plain `kubectl`.
+Open a separate plain terminal — no agent, no session id — while an agent session's scope is armed, and `ws k8s` is *still* guarded there: it aggregates the active session's scope. A read works; an out-of-scope write is rejected even though this terminal has no session of its own. The human terminal cannot reconfigure the guard — `ws k8s scope set` and `scope clear` require a session ID, which a plain terminal does not have. To change the scope, ask your agent to run the command (or export `GDD_SESSION_ID` manually for advanced use). The human terminal's escape from a rejection is plain `kubectl`.
 
 ### What the guard does NOT do
 

--- a/docs/tutorials/guarded-kubernetes.md
+++ b/docs/tutorials/guarded-kubernetes.md
@@ -12,9 +12,9 @@ The walkthrough is chaptered so you can stop after Chapter 2 with the guard in m
 
 ## Prerequisites
 
-- **A Kubernetes cluster context you can write to**, and a namespace you can freely create and destroy. This is the one hard requirement — the guard guards *real* kubectl against a *real* cluster.
+- **A Kubernetes cluster context you can write to**, and a namespace within it that you have write access to. Creating or destroying namespaces is not required for Chapters 1–2; that is covered as optional material in Chapter 3. This is the one hard requirement — the guard operates against a real cluster.
 
-  Don't have a cluster? Spin up a throwaway local one (any of these gives you a context you can wreck safely):
+  Don't have a cluster? Spin up a local one (any of these gives you a disposable context):
 
   | Tool | Start it | Context name |
   |---|---|---|
@@ -27,7 +27,7 @@ The walkthrough is chaptered so you can stop after Chapter 2 with the guard in m
 - **The workspace prerequisites.** From the workspace root, `ws preflight` should pass — it verifies bash, git, `yq` (the guard parses `-f` manifests with it), `jq`, and a provider CLI (`gh` or `glab`).
 - **The `ws k8s` feature present.** `ws orient` should list the `gdd-k8s` skill and a `k8s` subcommand.
 
-Throughout, substitute `<ctx>` for your chosen context and `<ns>` for a throwaway namespace (e.g. `practice`). Run everything from the workspace root.
+Throughout, substitute `<ctx>` for your chosen context and `<ns>` for the namespace you will use (e.g. `practice`). Run everything from the workspace root.
 
 ---
 
@@ -43,13 +43,15 @@ List what you can reach:
 kubectl config get-contexts
 ```
 
-Pick one you're comfortable making a mess in (`<ctx>`). You need a namespace too. You can create it first:
+Pick a context you have write access to (`<ctx>`). You need a namespace too — use one that already exists and that you can write to freely (`<ns>`).
+
+If you are working in a disposable environment and prefer to start with a fresh namespace, you can create one:
 
 ```bash
 kubectl --context <ctx> create namespace <ns>
 ```
 
-Or skip that — arming a scope does **not** require the namespace to exist yet (Chapter 3 creates it through the guard). Either path is fine.
+This is not required — the guard arms equally well against an existing namespace. Namespace creation and deletion are covered as optional steps in Chapter 3.
 
 ### 2. Arm the scope
 
@@ -122,7 +124,7 @@ All three block **before** kubectl runs, so they're safe to type while you're le
 
 ## Chapter 3: Real practice
 
-Goal: the workflows you'll actually use — manifests, namespace lifecycle, widening, cleanup.
+Goal: the workflows you'll actually use — manifests, widening, cleanup. Namespace lifecycle (create and delete) is covered as an optional step for disposable environments.
 
 ### 1. Apply a manifest
 
@@ -148,16 +150,18 @@ It applies — the namespace in the manifest is in scope. Each document is scope
 
 > **Windows note:** quote the path or use forward slashes. An unquoted backslash path (`ws k8s apply -f C:\dir\pod.yaml`) is mangled by the shell into `C:dirpod.yaml` *before* `ws` ever sees it — use `"C:\dir\pod.yaml"` or `C:/dir/pod.yaml`.
 
-### 2. Namespace lifecycle — create and recreate your own
+### 2. Namespace lifecycle — create and recreate your own *(optional — disposable environments only)*
 
-Because `<ns>` is in your scope, you may create and delete *that* namespace through the guard:
+Skip this step if you are working in a shared or production-adjacent cluster. It requires a namespace you can freely delete and recreate without affecting other workloads.
+
+Because `<ns>` is in your scope, the guard permits creating and deleting *that* namespace:
 
 ```bash
 ws k8s delete namespace <ns>     # allowed — it's in scope
 ws k8s create namespace <ns>     # allowed — recreated
 ```
 
-A namespace *not* in your scope (`ws k8s delete namespace kube-public`) is still rejected. This is what makes the "arm a not-yet-existing namespace, then create it" workflow from Chapter 1 work — handy when you're setting up the same sandbox across several environments.
+A namespace *not* in your scope (`ws k8s delete namespace kube-public`) is still rejected. This is what makes the "arm a not-yet-existing namespace, then create it" workflow from Chapter 1 useful — handy when provisioning the same sandbox across several environments.
 
 ### 3. Widen, then narrow
 
@@ -178,9 +182,14 @@ ws k8s scope clear
 ```bash
 ws k8s delete pod practice-pod -n <ns>
 ws k8s delete pod probe -n <ns>
-ws k8s delete namespace <ns>          # in-scope; or raw: kubectl --context <ctx> delete namespace <ns>
 ws k8s scope clear
 rm pod.yaml
+```
+
+If you created a namespace specifically for this tutorial (Chapter 1 or the optional step above), delete it:
+
+```bash
+ws k8s delete namespace <ns>
 ```
 
 If you spun up a local cluster just for this, tear it down too (`kind delete cluster`, `k3d cluster delete practice`, `minikube delete`, or disable Docker Desktop's Kubernetes).

--- a/docs/tutorials/guarded-kubernetes.md
+++ b/docs/tutorials/guarded-kubernetes.md
@@ -69,6 +69,8 @@ ws k8s scope show
 
 The scope lives in your session, not your kubeconfig — `ws k8s scope clear` removes it, and it's gone when the session ends. It changes nothing on the cluster.
 
+> **Scope changes must go through your agent.** `ws k8s scope set` requires the agent session ID and will not work in a standalone terminal — the error message will tell you to ask your agent to run it instead.
+
 **That's the setup.** From here on, every `ws k8s …` command is checked against this scope.
 
 ---
@@ -165,7 +167,7 @@ A namespace *not* in your scope (`ws k8s delete namespace kube-public`) is still
 
 ### 3. Widen, then narrow
 
-Want a second namespace in scope? Re-arm with the broader list (it overwrites):
+Want a second namespace in scope? Re-arm with the broader list (it overwrites). Run this through your agent — `ws k8s scope set` will not work in a standalone terminal:
 
 ```bash
 ws k8s scope set --context <ctx> --namespace <ns>,another-ns
@@ -211,7 +213,7 @@ For the rare case where the agent genuinely needs raw kubectl (a one-off automat
 
 ### The human path (ambient guard)
 
-Open a separate plain terminal — no agent, no session id — while an agent session's scope is armed, and `ws k8s` is *still* guarded there: it aggregates the active session's scope. A read works; an out-of-scope write is rejected even though this terminal has no session of its own. The human terminal can't reconfigure the guard (scope set/clear are session-bound); its escape from a rejection is plain `kubectl`.
+Open a separate plain terminal — no agent, no session id — while an agent session's scope is armed, and `ws k8s` is *still* guarded there: it aggregates the active session's scope. A read works; an out-of-scope write is rejected even though this terminal has no session of its own. The human terminal cannot reconfigure the guard — `ws k8s scope set` and `scope clear` require the agent session ID and will not work outside the harness. To change the scope, ask your agent to run the command. The human terminal's escape from a rejection is plain `kubectl`.
 
 ### What the guard does NOT do
 

--- a/docs/tutorials/guarded-kubernetes.md
+++ b/docs/tutorials/guarded-kubernetes.md
@@ -184,14 +184,19 @@ ws k8s scope clear
 ```bash
 ws k8s delete pod practice-pod -n <ns>
 ws k8s delete pod probe -n <ns>
-ws k8s scope clear
-rm pod.yaml
 ```
 
-If you created a namespace specifically for this tutorial (Chapter 1 or the optional step above), delete it:
+If you created a namespace specifically for this tutorial (Chapter 1 or the optional step above), delete it before clearing the scope — the guard only allows the delete while `<ns>` is still in scope:
 
 ```bash
 ws k8s delete namespace <ns>
+```
+
+Then clear the scope and remove the manifest:
+
+```bash
+ws k8s scope clear
+rm pod.yaml
 ```
 
 If you spun up a local cluster just for this, tear it down too (`kind delete cluster`, `k3d cluster delete practice`, `minikube delete`, or disable Docker Desktop's Kubernetes).

--- a/scripts/git-push.sh
+++ b/scripts/git-push.sh
@@ -94,15 +94,15 @@ elif [[ -n "${GIT_PUSH_REMOTE:-}" ]]; then
     fi
   done
   if [[ -z "$REMOTE_NAME" ]]; then
-    echo "ERROR: No remote matching '$GIT_PUSH_REMOTE' (from identity.forkRemote)." >&2
+    echo "ERROR: No remote matching '$GIT_PUSH_REMOTE' (from --remote flag or identity.forkRemote)." >&2
     echo "  Available remotes: ${REMOTES[*]}" >&2
-    echo "  Set identity.forkRemote in ecosystem.local.yaml or GIT_PUSH_REMOTE." >&2
+    echo "  Pass --remote <name> to ws push, or set identity.forkRemote in ecosystem.local.yaml." >&2
     exit 1
   fi
 else
   echo "ERROR: Multiple remotes found — cannot determine which to push to." >&2
   echo "  Available remotes: ${REMOTES[*]}" >&2
-  echo "  Set identity.forkRemote in ecosystem.local.yaml or GIT_PUSH_REMOTE." >&2
+  echo "  Pass --remote <name> to ws push, or set identity.forkRemote in ecosystem.local.yaml." >&2
   exit 1
 fi
 

--- a/scripts/ws
+++ b/scripts/ws
@@ -165,11 +165,11 @@ HELP
             return 0
         fi
     done
-    local comp="${1:-yggdrasil}"
+    local comp="yggdrasil"
+    local comp_set=0
     local branch=""
     local force=""
     local push_remote_override=""
-    shift 2>/dev/null || true
     while [[ $# -gt 0 ]]; do
         case "$1" in
             --force) force="--force" ;;
@@ -189,7 +189,16 @@ HELP
                 fi
                 ;;
             -*) echo "ERROR: Unknown option '$1'" >&2; exit 1 ;;
-            *) branch="$1" ;;
+            *)
+                if [[ $comp_set -eq 0 ]]; then
+                    comp="$1"
+                    comp_set=1
+                elif [[ -z "$branch" ]]; then
+                    branch="$1"
+                else
+                    echo "ERROR: Too many positional arguments" >&2; exit 1
+                fi
+                ;;
         esac
         shift
     done

--- a/scripts/ws
+++ b/scripts/ws
@@ -149,40 +149,60 @@ ws_push() {
     for _arg in "$@"; do
         if [[ "$_arg" == "--help" || "$_arg" == "-h" ]]; then
             cat <<'HELP'
-Usage: ws push [component] [branch|tag] [--force]
+Usage: ws push [component] [--remote <remote>] [branch|tag] [--force]
 
-  component  Component to push (default: yggdrasil)
-  branch|tag Component branch or local tag to push (default: current branch)
-  --force    Force push a branch (use with care; refused for tags)
+  component        Component to push (default: yggdrasil)
+  --remote <name>  Push to this git remote instead of identity.forkRemote
+  branch|tag       Component branch or local tag to push (default: current branch)
+  --force          Force push a branch (use with care; refused for tags)
 
 Pushes to the component's per-developer fork remote (resolved via
 identity.forkRemote in ecosystem config). For repos you own directly,
-pushes to the configured remote.
+pushes to the configured remote. Use --remote to target a specific remote
+(e.g. `ws push yggdrasil --remote siliconsaga` to push to GitHub when
+identity.forkRemote points at a GitLab fork).
 HELP
             return 0
         fi
     done
-    if [[ $# -gt 3 ]]; then
-        echo "Usage: ws push [component] [branch|tag] [--force]" >&2
-        exit 1
-    fi
     local comp="${1:-yggdrasil}"
     local branch=""
     local force=""
+    local push_remote_override=""
     shift 2>/dev/null || true
-    for arg in "$@"; do
-        case "$arg" in
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
             --force) force="--force" ;;
-            -*) echo "ERROR: Unknown option '$arg'" >&2; exit 1 ;;
-            *) branch="$arg" ;;
+            --remote)
+                if [[ $# -lt 2 || -z "${2:-}" || "${2:-}" == -* ]]; then
+                    echo "ERROR: --remote requires a git remote name" >&2
+                    exit 1
+                fi
+                push_remote_override="$2"
+                shift
+                ;;
+            --remote=*)
+                push_remote_override="${1#--remote=}"
+                if [[ -z "$push_remote_override" ]]; then
+                    echo "ERROR: --remote requires a git remote name" >&2
+                    exit 1
+                fi
+                ;;
+            -*) echo "ERROR: Unknown option '$1'" >&2; exit 1 ;;
+            *) branch="$1" ;;
         esac
+        shift
     done
     ws_resolve_target "$comp"
-    # Pass forkRemote as push remote hint (only if set and not already overridden)
-    local fork_remote
-    fork_remote=$(ws_resolve_fork_remote)
-    if [[ -n "$fork_remote" && -z "${GIT_PUSH_REMOTE:-}" ]]; then
-        export GIT_PUSH_REMOTE="$fork_remote"
+    # --remote flag takes precedence; otherwise fall back to identity.forkRemote
+    if [[ -n "$push_remote_override" ]]; then
+        export GIT_PUSH_REMOTE="$push_remote_override"
+    else
+        local fork_remote
+        fork_remote=$(ws_resolve_fork_remote)
+        if [[ -n "$fork_remote" && -z "${GIT_PUSH_REMOTE:-}" ]]; then
+            export GIT_PUSH_REMOTE="$fork_remote"
+        fi
     fi
     cd "$COMPONENT_DIR" && bash "$SCRIPT_DIR/git-push.sh" ${force:+"$force"} ${branch:+"$branch"}
 }

--- a/scripts/ws-session.sh
+++ b/scripts/ws-session.sh
@@ -56,6 +56,7 @@ ws_session_set() {
     local key="${1:-}" value="${2:-}" path; path="$(ws_session_identity_path)"
     if [[ -z "$path" ]]; then
         echo "ERROR: No session id (GDD_SESSION_ID / CLAUDE_CODE_SESSION_ID / CODEX_THREAD_ID) — cannot write session config." >&2
+        echo "  Running in a plain terminal? Ask your agent to run this command instead — scope changes require the agent session." >&2
         return 1
     fi
     [[ -n "$key" ]] || { echo "ERROR: ws_session_set requires a KEY." >&2; return 1; }


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @rpraestholm via [GDD](docs/gdd/index.md).

## Summary

- Fix `gdd-k8s` skill behavior table: split the "Raw kubectl" row to accurately reflect that reads are auto-approved and only writes are denied/redirected; add a Hook Availability note that the raw-kubectl intercept is a Claude Code PreToolUse hook and is not active in other harnesses
- Add a Tone and Register section to `gdd-mentoring` skill, giving future agents explicit guidance on professional register and patterns to avoid
- Restructure guarded-kubernetes tutorial to make namespace create/destroy optional rather than the primary path — the hard requirement is now write access to an existing namespace
- Add a "Surfacing Output to the User" section to `gdd-k8s` skill noting that tool output visibility varies by harness and instructing agents to confirm with the user and quote guard messages when uncertain
- Update scope-capture flow step 3 to ask the user for a secondary namespace to use for rejection demonstrations
- Improve `ws_session_set` error message to tell the user to ask their agent when scope changes fail outside the harness

## Test plan

- [ ] `ws orient` lists `gdd-k8s` and `gdd-mentoring` skills as before
- [ ] `ws k8s scope set` in a standalone terminal prints the new agent-guidance line
- [ ] Tutorial reads cleanly end-to-end with a prod cluster (no namespace create/destroy required for Chapters 1–2)

## Related

- Closes #115 (if a tracking issue exists — remove if not)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Refined the Guarded Kubernetes tutorial with clearer prerequisites, safer namespace/lifecycle instructions, and guidance on using agent sessions for scope changes.
  * Updated practice workflow docs to better explain out-of-scope write rejection, tool-output surfacing, and guard interception expectations.
  * Added mentoring “Tone and Register” guidance for a more professional style.
* **New Features**
  * Enhanced `ws push` with an explicit `--remote <name>` override and improved remote selection behavior.
* **Bug Fixes**
  * Improved `ws push` help detection and `ws-session`/push error messaging to clarify when scope changes require an agent session.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->