### PR TITLE
test(ws-push) + fix(gitlab): push arg parser tests and glab auth per-host fix

### DIFF
--- a/scripts/providers/gitlab.sh
+++ b/scripts/providers/gitlab.sh
@@ -25,7 +25,7 @@ gp_check_cli() {
     # No token in env — fall back to checking per-host if host is known
     local host="${GITLAB_HOST:-}"
     if [[ -n "$host" ]]; then
-        if ! glab auth status -h "$host" 2>&1 | grep -q "Logged in to $host"; then
+        if ! glab auth status --hostname "$host" 2>&1 | grep -qF "Logged in to $host"; then
             echo "ERROR: glab is not authenticated for $host." >&2
             echo "  Run 'ws gitlab-auth' to set up credentials." >&2
             return 1

--- a/scripts/providers/gitlab.sh
+++ b/scripts/providers/gitlab.sh
@@ -19,15 +19,13 @@ gp_check_cli() {
     fi
 
     # GITLAB_TOKEN set in env is sufficient — glab uses it directly.
-    # Avoid bare `glab auth status` which exits non-zero if any configured
-    # host (e.g. gitlab.com) lacks credentials, even if ours works.
     if [[ -n "${GITLAB_TOKEN:-}" ]]; then
         return 0
     fi
     # No token in env — fall back to checking per-host if host is known
     local host="${GITLAB_HOST:-}"
     if [[ -n "$host" ]]; then
-        if ! glab auth status 2>&1 | grep -q "Logged in to $host"; then
+        if ! glab auth status -h "$host" 2>&1 | grep -q "Logged in to $host"; then
             echo "ERROR: glab is not authenticated for $host." >&2
             echo "  Run 'ws gitlab-auth' to set up credentials." >&2
             return 1

--- a/tests/ws-cr/gp-check-cli.bats
+++ b/tests/ws-cr/gp-check-cli.bats
@@ -23,22 +23,32 @@ setup() {
 
 # Configurable glab stub.
 #
-#   ok               — exits 0, prints "Logged in to <GITLAB_HOST>" (default)
-#   fail-bare-pass-h — bare auth status exits 1 (simulates stale second host);
-#                      -h <host> exits 0 — the pipefail regression fixture
-#   fail             — exits 1, no "Logged in" output (not authenticated)
+#   ok                    — exits 0, prints multi-line auth info (default)
+#   fail-bare-pass-hostname — bare auth status exits 1 (simulates stale second
+#                           host); --hostname <host> exits 0 — pipefail fixture
+#   fail                  — exits 1, no "Logged in" output (not authenticated)
 glab() {
     printf 'glab: %s\n' "$*" >> "$GLAB_LOG"
-    local with_h=0
-    for a; do [[ "$a" == "-h" ]] && { with_h=1; break; }; done
+    local with_hostname=0
+    local i=0
+    for a; do
+        if [[ "$a" == "--hostname" ]]; then
+            with_hostname=1; break
+        fi
+    done
     case "${GLAB_BEHAVIOR:-ok}" in
         ok)
             printf '✓ Logged in to %s as testuser\n' "${GITLAB_HOST:-}"
+            printf '  Token: ***\n'
             return 0
             ;;
-        fail-bare-pass-h)
+        fail-bare-pass-hostname)
+            # Simulate: target host is authenticated but a stale second host
+            # (e.g. gitlab.com) makes bare 'glab auth status' exit 1.
+            # --hostname scopes to just our host and exits 0.
             printf '✓ Logged in to %s as testuser\n' "${GITLAB_HOST:-}"
-            [[ "$with_h" -eq 1 ]] && return 0 || return 1
+            printf '  Token: ***\n'
+            [[ "$with_hostname" -eq 1 ]] && return 0 || return 1
             ;;
         fail)
             printf 'x Not logged in to %s: 401 Unauthorized\n' "${GITLAB_HOST:-}"
@@ -64,19 +74,19 @@ glab() {
     [ "$status" -eq 0 ]
 }
 
-@test "gp_check_cli: -h scoping passes when bare glab auth status exits non-zero (pipefail regression)" {
+@test "gp_check_cli: --hostname scoping passes when bare glab auth status exits non-zero (pipefail regression)" {
     # Regression: bare 'glab auth status' exits 1 when any configured host
     # (e.g. a stale gitlab.com entry) fails, even if our target host is fine.
     # Under set -o pipefail, that non-zero propagates through the pipe even when
     # grep finds the "Logged in to <host>" string. The fix uses 'glab auth status
-    # -h "$host"' to scope the check to just our host so stale hosts don't
-    # pollute the exit code.
-    export GLAB_BEHAVIOR="fail-bare-pass-h"
+    # --hostname "$host"' to scope the check to just our host so stale hosts
+    # don't pollute the exit code.
+    export GLAB_BEHAVIOR="fail-bare-pass-hostname"
 
     run gp_check_cli
 
     [ "$status" -eq 0 ]
-    [[ "$(cat "$GLAB_LOG")" == *"auth status -h gitlab.example.com"* ]]
+    [[ "$(cat "$GLAB_LOG")" == *"auth status --hostname gitlab.example.com"* ]]
 }
 
 @test "gp_check_cli: unauthenticated host returns 1 with error" {

--- a/tests/ws-cr/gp-check-cli.bats
+++ b/tests/ws-cr/gp-check-cli.bats
@@ -1,0 +1,98 @@
+#!/usr/bin/env bats
+
+# Tests for gp_check_cli in scripts/providers/gitlab.sh.
+#
+# Covers the GITLAB_TOKEN fast-path and the 'glab auth status -h <host>'
+# fallback used when no token is in env (ws cr, ws issue, ws review).
+# The regression case verifies that a stale second host in glab's config
+# (which makes bare 'glab auth status' exit non-zero under pipefail) does
+# not falsely fail the check when -h scoping is used.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    GLAB_LOG="$BATS_TEST_TMPDIR/glab.log"
+    export GLAB_LOG
+
+    # shellcheck source=../../scripts/providers/gitlab.sh
+    source "$REPO_ROOT/scripts/providers/gitlab.sh"
+
+    unset GITLAB_TOKEN
+    export GITLAB_HOST="gitlab.example.com"
+    export GLAB_BEHAVIOR="ok"
+}
+
+# Configurable glab stub.
+#
+#   ok               — exits 0, prints "Logged in to <GITLAB_HOST>" (default)
+#   fail-bare-pass-h — bare auth status exits 1 (simulates stale second host);
+#                      -h <host> exits 0 — the pipefail regression fixture
+#   fail             — exits 1, no "Logged in" output (not authenticated)
+glab() {
+    printf 'glab: %s\n' "$*" >> "$GLAB_LOG"
+    local with_h=0
+    for a; do [[ "$a" == "-h" ]] && { with_h=1; break; }; done
+    case "${GLAB_BEHAVIOR:-ok}" in
+        ok)
+            printf '✓ Logged in to %s as testuser\n' "${GITLAB_HOST:-}"
+            return 0
+            ;;
+        fail-bare-pass-h)
+            printf '✓ Logged in to %s as testuser\n' "${GITLAB_HOST:-}"
+            [[ "$with_h" -eq 1 ]] && return 0 || return 1
+            ;;
+        fail)
+            printf 'x Not logged in to %s: 401 Unauthorized\n' "${GITLAB_HOST:-}"
+            return 1
+            ;;
+    esac
+}
+
+@test "gp_check_cli: GITLAB_TOKEN set returns 0 without calling glab" {
+    export GITLAB_TOKEN="glpat_testtoken"
+
+    run gp_check_cli
+
+    [ "$status" -eq 0 ]
+    [ ! -s "$GLAB_LOG" ]
+}
+
+@test "gp_check_cli: authenticated host with no token in env returns 0" {
+    export GLAB_BEHAVIOR="ok"
+
+    run gp_check_cli
+
+    [ "$status" -eq 0 ]
+}
+
+@test "gp_check_cli: -h scoping passes when bare glab auth status exits non-zero (pipefail regression)" {
+    # Regression: bare 'glab auth status' exits 1 when any configured host
+    # (e.g. a stale gitlab.com entry) fails, even if our target host is fine.
+    # Under set -o pipefail, that non-zero propagates through the pipe even when
+    # grep finds the "Logged in to <host>" string. The fix uses 'glab auth status
+    # -h "$host"' to scope the check to just our host so stale hosts don't
+    # pollute the exit code.
+    export GLAB_BEHAVIOR="fail-bare-pass-h"
+
+    run gp_check_cli
+
+    [ "$status" -eq 0 ]
+    [[ "$(cat "$GLAB_LOG")" == *"auth status -h gitlab.example.com"* ]]
+}
+
+@test "gp_check_cli: unauthenticated host returns 1 with error" {
+    export GLAB_BEHAVIOR="fail"
+
+    run gp_check_cli
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"glab is not authenticated for gitlab.example.com"* ]]
+}
+
+@test "gp_check_cli: no token and no GITLAB_HOST returns 1 with error" {
+    unset GITLAB_HOST
+
+    run gp_check_cli
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"GITLAB_TOKEN is not set and GITLAB_HOST is unknown"* ]]
+}

--- a/tests/ws-push/ws-push-args.bats
+++ b/tests/ws-push/ws-push-args.bats
@@ -1,0 +1,124 @@
+#!/usr/bin/env bats
+
+# Tests for `ws push` argument parsing — the --remote flag and the
+# comp_set sentinel parser (both added in PR #115).
+#
+# The adjacent push.bats tests exercise git-push.sh directly (HTTPS
+# auth, tag behavior, upstream-tracking). This file covers the ws
+# push arg parser: --remote flag in every position, equal-sign form,
+# forkRemote fallback, and error paths.
+
+REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+WS_BIN="$REPO_ROOT/scripts/ws"
+
+setup() {
+    WORK="$BATS_TEST_TMPDIR/work"
+    FORK_DIR="$BATS_TEST_TMPDIR/fork.git"
+    ALT_DIR="$BATS_TEST_TMPDIR/siliconsaga.git"
+
+    git init -q --bare "$FORK_DIR"
+    git init -q --bare "$ALT_DIR"
+
+    git init -q "$WORK"
+    git -C "$WORK" config user.name "Test User"
+    git -C "$WORK" config user.email "test@example.local"
+    echo "seed" > "$WORK/file.txt"
+    git -C "$WORK" add file.txt
+    git -C "$WORK" commit -q -m "seed"
+    git -C "$WORK" branch -M main
+    git -C "$WORK" remote add fork "$FORK_DIR"
+    git -C "$WORK" remote add siliconsaga "$ALT_DIR"
+
+    cat > "$WORK/ecosystem.yaml" <<'YAML'
+identity:
+  human_account: testuser
+  forkRemote: fork
+components: {}
+YAML
+    cat > "$WORK/ecosystem.local.yaml" <<'YAML'
+identity:
+  human_account: testuser
+YAML
+
+    export ROOT_DIR="$WORK"
+    export ECOSYSTEM="$WORK/ecosystem.yaml"
+    export ECOSYSTEM_LOCAL="$WORK/ecosystem.local.yaml"
+}
+
+run_ws_push() {
+    run env WS_FOOTER_DISABLE=1 bash "$WS_BIN" push "$@"
+}
+
+remote_has_ref() {   # $1=bare-dir $2=full-ref (e.g. refs/heads/main)
+    git --git-dir="$1" show-ref --verify --quiet "$2"
+}
+
+# ─── --remote flag routing ──────────────────────────────────────────
+
+@test "ws push --remote: option-first form overrides identity.forkRemote" {
+    # Regression for the original parsing bug: comp was assigned the
+    # flag name ("--remote") before the loop ran, so option-first
+    # invocations silently used the wrong component.
+    run_ws_push --remote siliconsaga
+    [ "$status" -eq 0 ]
+    remote_has_ref "$ALT_DIR" refs/heads/main
+    ! remote_has_ref "$FORK_DIR" refs/heads/main
+}
+
+@test "ws push --remote: flag accepted between component and explicit branch" {
+    run_ws_push yggdrasil --remote siliconsaga main
+    [ "$status" -eq 0 ]
+    remote_has_ref "$ALT_DIR" refs/heads/main
+    ! remote_has_ref "$FORK_DIR" refs/heads/main
+}
+
+@test "ws push --remote=name: equal-sign form overrides forkRemote" {
+    run_ws_push --remote=siliconsaga
+    [ "$status" -eq 0 ]
+    remote_has_ref "$ALT_DIR" refs/heads/main
+}
+
+@test "ws push: identity.forkRemote used when --remote not specified" {
+    run_ws_push
+    [ "$status" -eq 0 ]
+    remote_has_ref "$FORK_DIR" refs/heads/main
+    ! remote_has_ref "$ALT_DIR" refs/heads/main
+}
+
+@test "ws push yggdrasil main: explicit component + branch without --remote uses forkRemote" {
+    run_ws_push yggdrasil main
+    [ "$status" -eq 0 ]
+    remote_has_ref "$FORK_DIR" refs/heads/main
+    ! remote_has_ref "$ALT_DIR" refs/heads/main
+}
+
+# ─── --remote error paths ──────────────────────────────────────────
+
+@test "ws push --remote: rejects next arg that starts with a dash" {
+    # --force, --upstream, etc. are not remote names; the parser
+    # checks that the following arg doesn't start with -.
+    run_ws_push --remote --force
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"--remote requires a git remote name"* ]]
+}
+
+@test "ws push --remote=: empty value errors before any git call" {
+    run_ws_push --remote=
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"--remote requires a git remote name"* ]]
+}
+
+# ─── positional arg error paths ────────────────────────────────────
+
+@test "ws push with three positional args errors" {
+    # comp, branch, extra — three positionals trip the sentinel guard.
+    run_ws_push comp branch extra
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Too many positional arguments"* ]]
+}
+
+@test "ws push with unknown option errors" {
+    run_ws_push --unknown
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Unknown option '--unknown'"* ]]
+}


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @rpraestholm via [GDD](docs/gdd/index.md).

## Summary

- Add `tests/ws-push/ws-push-args.bats` (9 tests) covering the `ws push` arg parser introduced in PR #115: `--remote` in option-first position, between positionals, equal-sign form, `identity.forkRemote` fallback, and four error paths (dash-after-flag, empty value, too many positionals, unknown option). Deferred from #115; the adjacent `push.bats` tests `git-push.sh` directly and does not cover this layer.
- Fix `gp_check_cli` in `scripts/providers/gitlab.sh`: scope the `glab auth status` check to `-h "$host"` (per-host) so a stale second host in glab's config (e.g. an expired `gitlab.com` entry) does not propagate its non-zero exit through `set -o pipefail` and falsely fail the auth check for `ws cr` / `ws issue` / `ws review`.
- Add `tests/ws-cr/gp-check-cli.bats` (5 tests): GITLAB_TOKEN fast-path, per-host auth success, the pipefail regression fixture (bare glab exits 1 but `-h <host>` exits 0 — must pass with the fix), auth failure, and missing `GITLAB_HOST`. The regression test confirms glab is called with `-h`.

## Test plan

- [ ] `ws test yggdrasil` passes (554 tests total, up from 549)
- [ ] `gp_check_cli` regression: run `ws cr` on a machine with a stale `gitlab.com` entry in glab config — no longer falsely reports "not authenticated for <host>"

## Related

- Deferred from #115 (`ws push --remote` + `comp_set` parser)
- Thalamus FG4WWY622F observation 2026-06-06 (glab auth status pipefail bug)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GitLab authentication verification when no token is provided by scoping the check to the configured host, with more reliable success/failure behavior.

* **Tests**
  * Added GitLab provider test coverage for token-based auth, host-based auth, unauthenticated host errors, and the “hostname-scoped” command behavior.
  * Added `ws push` argument-parsing tests for `--remote` override formats and multiple error paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->