### PR TITLE
fix: onboarding hardening — bash 3.2 auth guard, token setup UX, realm/tutorial docs

### DIFF
--- a/.agent/skills/gdd-orientation/SKILL.md
+++ b/.agent/skills/gdd-orientation/SKILL.md
@@ -222,7 +222,7 @@ Already `GDD_ROLE=scribe` → skip; the scribe skill runs its own binding sub-fl
 
 Brief the human based on stance, role, active concerns, and post-orient signals:
 
-- **Newcomer (post-orient signals strong):** walk through what orient surfaced. Name the wired verbs, name the active realm if any, ask what they're trying to learn or build.
+- **Newcomer (post-orient signals strong):** walk through what orient surfaced. Name the wired verbs, name the active realm if any, ask what they're trying to learn or build. If the active realm is the shared `realm-template` starter, prompt them to make it their own — fork it on GitHub and rename to `realm-<their-community>`, then adopt the fork with `ws realm <fork-url>` — rather than living long-term inside `realm-template`. Point first-timers at the light `ws component init gh-pages` loop before the heavier example-project clones (`ws clone --all`).
 - **Mid-session pickup:** *"Picking up in Developer/Zen stance. Last session noted X. Open concerns: Y. What's the session about?"*
 
 ### Active arcs (when a thalami hoard is active)

--- a/.env.example
+++ b/.env.example
@@ -4,11 +4,12 @@
 
 # ── GitHub ───────────────────────────────────────────────────
 # Create a classic personal access token (scopes pre-selected) at:
-#   https://github.com/settings/tokens/new?scopes=repo&description=GDD%20agent%20write%20token
+#   https://github.com/settings/tokens/new?scopes=repo,read:org,read:discussion,read:project&description=GDD%20agent%20write%20token
 #
-# Required scopes:
-#   repo           (full repo access — PRs, issues, code, cross-org forks)
-#   workflow        (if you need to touch .github/workflows files)
+# Scopes:
+#   repo                                      (push, PRs, issues, code, cross-org forks)
+#   read:org, read:discussion, read:project   (baseline — lets 'gh pr edit'-shaped ops work)
+#   workflow                                  (only if you touch .github/workflows files)
 #
 # A classic PAT is the simple path this base setup targets:
 #   + one token; works across every org/fork your account can access

--- a/.env.example
+++ b/.env.example
@@ -3,19 +3,22 @@
 # Only uncomment the sections for providers you use.
 
 # ── GitHub ───────────────────────────────────────────────────
-# Create a classic personal access token at:
-#   https://github.com/settings/tokens/new
+# Create a classic personal access token (scopes pre-selected) at:
+#   https://github.com/settings/tokens/new?scopes=repo&description=GDD%20agent%20write%20token
 #
 # Required scopes:
 #   repo           (full repo access — PRs, issues, code, cross-org forks)
 #   workflow        (if you need to touch .github/workflows files)
 #
-# Note: Fine-grained PATs exist but have known limitations with cross-org
-# PRs and workflow files. Classic PATs are recommended for GDD workspaces.
+# A classic PAT is the simple path this base setup targets:
+#   + one token; works across every org/fork your account can access
+#   + no per-repo wiring to maintain
+#   − account-wide (it can reach everything your account can) and you renew it by hand at expiry
+# For least-privilege (fine-grained PATs) or a shared, team-managed bot
+# identity (a separate machine account), see docs/git-provider-setup.md.
 #
 # The gh CLI reads GH_TOKEN automatically — no 'gh auth login' needed.
 export GH_TOKEN=ghp_xxxxxxxxxxxx
-export GH_USER=your-github-username
 
 # ── Commit attribution ───────────────────────────────────────
 # Commit identity is per-session, not configured here: an agent establishes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,11 +36,14 @@ A fresh agent's instinct is to reach for raw `git`, `gh`, `glab`, or test runner
 | `git add` + `git commit -m "…"` | `ws commit <comp> <bodyfile>` |
 | `git push` | `ws push <comp> [branch]` |
 | `gh pr create` / `glab mr create` | `ws cr <comp> <title> <bodyfile>` |
+| `gh pr view` / `gh pr checks` / `glab mr note` (reading or replying to review) | `ws review <comp> [cr#]` |
 | `gh issue create` / `glab issue create` | `ws issue <comp> [remote] <title> <label> <bodyfile>` |
 | `git clone <fork>` + manual remote-wiring | `ws clone <comp>` (or `ws clone-fork <comp>` for fork-as-origin) |
 | One-off command inside a component dir | `ws exec <comp> <cmd…>` |
 
 The PreToolUse hook denies `git commit` / `git push` / `gh pr create` at Tier 2 with a corrective pointer to the `ws` wrapper. Don't bypass — use the wrapper.
+
+**Review phase — prefer `ws review`.** Now that `ws` injects tokens, the `ws gh` / `ws glab` one-off wrappers make raw `gh pr` / `glab mr` API calls easy to reach for — but for reading or triaging code-review feedback, start with `ws review <comp> [cr#]`. It handles thread resolution, `--since <ref>` filtering, and attribution that the raw provider calls (and their `ws gh` / `ws glab` wrappers) don't. Drop to `ws gh` / `ws glab` only for something `ws review` genuinely can't express.
 
 Subcommands that take a target (commit, push, cr, issue, review, log, diagnose, test, lint) also accept realm and hoard names, not just components.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,7 @@ Reference forms in skill bodies:
 4. **One command at a time.** Don't bundle with `;` `&&` `|`. The PreToolUse hook denies shell composition — use separate tool calls and native `ws` flags (`--compact`, `--limit N`, `--output <phrase>`) instead of pipes.
 5. **No raw `git`/`gh`/`glab`** for the unconditional verbs above. Wrappers handle attribution, auth, remote selection — raw tools won't.
 6. **No hard-wrapped prose.** Write each paragraph as a single line and let editors / renderers handle wrap. Code blocks, tables, lists, and YAML frontmatter are exempt.
+7. **Prefer native file tools over shelling out.** Use your harness's file read / write / edit tools to inspect or change files rather than `cat` / `echo` / `sed` / `tee` — clearer, and it sidesteps the shell-composition and redirection hooks. When you genuinely need a throwaway helper script (a poll loop, a one-off probe), put it under the workspace `.tmp/` (gitignored, swept by `ws clean`), never `/tmp`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 **Yggdrasil** is the meta-workspace where [Guardian Driven Development (GDD)](docs/gdd/index.md) lives. It isn't just a wrapper around the ecosystem's repos — it's the home of the methodology itself: the `ws` workspace CLI, the GDD skills, the shared-thinking Thalamus, the components/realms/hoards model, and the documentation, commit, and branch conventions that bind everything together. Components, realms, and hoards are what Yggdrasil *orchestrates*; GDD is what Yggdrasil *is*.
 
+**How you actually work here:** you direct an AI coding agent to get real work done in the ecosystem's components, and GDD is the methodology that keeps that work safe, attributable, and legible. The `ws` CLI and the git / commit / branch conventions are mostly **guardrails the agent operates within** — attribution, auth, safe git and review flows — rather than commands you run by hand. Day to day you mostly steer and review; the agent drives `ws`. New to the idea? Start with [Guardian Driven Development](docs/gdd/index.md).
+
 ## Start here
 
 - **New here (human)?** The human-facing docs live in [`docs/gdd/`](docs/gdd/index.md): start with the [features tour](docs/gdd/features.md) — what's in the box — and the [GDD index](docs/gdd/index.md) for the methodology behind it.
@@ -18,7 +20,7 @@
 - **`scripts/ws`** — the unified CLI: clone, status, commit, push, cr, review, test, plus realm / hoard / component management.
 - **`.agent/skills/`** — agent-facing workspace skills (GDD orchestration, orientation, housekeeping, the documentation conventions, and more). These are operational guidance the agent reads directly, not human reading material — humans get the higher-level concepts from `docs/`. Some practice flows also lean on the optional [Obra Superpowers](https://github.com/obra/superpowers) plugin.
 - **`docs/`** — ecosystem architecture, the GDD methodology, and design / plan docs. Component docs follow the **Component Documentation Convention** — a four-Shape graduation ladder, described human-side in [the organization stack](docs/gdd/organization-stack.md); the operational rules for agents writing docs live in the `gdd-doc-writing` skill.
-- **Components / realms / hoards** — cloned under `components/`, `realms/`, `hoards/` (all gitignored, independent Git repos). A VS Code workspace file is generated on demand via `ws vscode`; it is not committed.
+- **Components / realms / hoards** — the things Yggdrasil orchestrates, cloned under `components/`, `realms/`, `hoards/` (all gitignored, independent Git repos). **Components** are the code repos you work on. A **realm** is a shared community-config layer: it declares which components exist and wires each one's test / lint / build commands (adapters), so a whole team gets the same setup by adopting one realm instead of configuring every repo by hand. **Hoards** are non-code collections (notes, vaults). A VS Code workspace file is generated on demand via `ws vscode`; it is not committed.
 
 ## AI usage
 

--- a/docs/git-provider-setup.md
+++ b/docs/git-provider-setup.md
@@ -11,9 +11,8 @@ All workspace credentials live in `.env` at the yggdrasil root (gitignored). The
 | Variable | Purpose | Required when |
 |---|---|---|
 | `GH_TOKEN` | GitHub PAT (`gh` reads it directly) | Using GitHub remotes |
-| `GH_USER` | GitHub username — derived from the token via `gh api /user` if unset, but explicitly set when running as a separate machine-user account (a bot account with collaborator-only access on specific repos). Pairs with `GH_TOKEN` to assert the operating identity. | Optional in single-user setups; recommended for machine-user / scoped-access setups |
 | `GITLAB_TOKEN` | Default GitLab PAT (`glab` fallback) | Using GitLab remotes |
-| `GITLAB_USER` | GitLab username — referenced in setup docs and example `.env`; not currently consumed by `ws` scripts. Reserved for future parity with `GH_USER`'s machine-user pattern. | Optional |
+| `GITLAB_USER` | GitLab username — referenced in setup docs and example `.env`. | Optional |
 | `GITLAB_HOST` | Self-hosted GitLab hostname | Self-hosted GitLab only |
 | `GITLAB_<scope>_<owner>_<role>` | Per-fork / per-group GitLab tokens | Multi-token GitLab setups (see GitLab section) |
 
@@ -66,13 +65,24 @@ The three `read:*` scopes are the recommended baseline alongside `repo`. They do
 
 > **Why classic and not fine-grained?** Fine-grained PATs have known limitations with cross-org pull requests and workflow file access. Classic PATs are simpler and more reliable for GDD workspaces that span multiple orgs or forks.
 
+#### Classic PAT vs fine-grained vs a machine account
+
+The base setup above (a classic PAT on your own account) is the right default for a single user willing to manage one token. The trade-offs, if you outgrow it:
+
+| Option | Pros | Cons |
+|---|---|---|
+| **Classic PAT** (default) | One token; works across every org/fork you can access; no per-repo wiring | Account-wide — it can reach everything your account can; you renew it by hand at expiry |
+| **Fine-grained PAT** | Least privilege — scope to specific repos + specific permissions | More maintenance: shorter max lifetimes, per-repo/per-org selection to keep current, org-owner approval for org-owned repos; still hits the cross-org/workflow limits above |
+| **Separate machine (bot) account** | Access managed through normal team/collaborator membership instead of token juggling; not tied to your personal identity; durable | One more account to create and hold a seat for |
+
+A machine account is often the nicest long-term answer for shared or automated work: you add the bot as a collaborator (or to a team) on the specific repos, and access is maintained via team management rather than by rotating a personal token. Reach for fine-grained tokens or a machine account when least-privilege or shared ownership actually matters; until then, a classic PAT keeps setup a single step.
+
 ### Store the token
 
 Create `.env` in the yggdrasil root (gitignored):
 
 ```bash
 export GH_TOKEN=ghp_xxxxxxxxxxxx
-export GH_USER=your-github-username
 ```
 
 ### Load and verify

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -16,3 +16,13 @@ These differ from the [Getting Started](../getting-started/index.md) walkthrough
 Most tutorials here are **docs pages** like Guarded Kubernetes — read-and-run walkthroughs of a feature.
 
 The **GitHub Pages** one is a **scaffold** instead: run `ws component init gh-pages <name>` and the walkthrough is the generated `components/<name>/README.md` (the table links to the template version). It lives with its template rather than as a docs page because the thing you learn on is a real repo you create and deploy. See [Getting Started → Recommended first scaffold](../getting-started/index.md#recommended-first-scaffold) for where it fits in onboarding.
+
+## Three ways a newcomer meets GDD
+
+These are easy to conflate — they're different things:
+
+1. **Scaffold a template** — `ws component init gh-pages <name>` creates a brand-new repo you own and deploy. The fastest way to feel the full loop on a tiny live target. Templates are starting points, not standalone courses; each is a scaffold, not a guided lesson.
+2. **Explore a suggested realm project** — the active realm may list existing live projects in its `ecosystem.yaml`; `ws clone <project>` (or `ws clone --all`) pulls them **as-is** to read or contribute to. These are real codebases, not tutorials — reach for one only if its domain interests you, not as a first "learn GDD" step.
+3. **Feature walkthroughs** — the docs-page tutorials in the table above. Note Guarded Kubernetes is **process, not code**, and assumes a cluster you can write to — valuable, but not a first stop for a total newcomer.
+
+The `realm-template` starter's own README currently points first-timers at option 2 (`ws clone --all`); for most newcomers option 1 (the `gh-pages` scaffold) is the gentler first loop.

--- a/scripts/git-auth.sh
+++ b/scripts/git-auth.sh
@@ -20,10 +20,13 @@
 #
 # Usage:
 #   git_auth_env_for_url "$url"      # sets GIT_AUTH_ENV / LABEL / PROVIDER
-#   env "${GIT_AUTH_ENV[@]}" git clone "$url" "$target"
+#   env ${GIT_AUTH_ENV[@]+"${GIT_AUTH_ENV[@]}"} git clone "$url" "$target"
 #
 # On SSH remotes, tokenless HTTPS, or unknown hosts, GIT_AUTH_ENV is left
-# empty and git uses its normal behavior.
+# empty and git uses its normal behavior. Always expand it with the guarded
+# ${GIT_AUTH_ENV[@]+"${GIT_AUTH_ENV[@]}"} form, never a bare
+# "${GIT_AUTH_ENV[@]}": on bash < 4.4 (macOS ships 3.2) a bare expansion of
+# an EMPTY array trips `set -u` with "unbound variable".
 
 # Load guard — safe to source repeatedly (ws-realm.sh sources this, and
 # several scripts source ws-realm.sh).
@@ -106,7 +109,7 @@ git_auth_basic_header() {
 
 # Populate GIT_AUTH_ENV (array), GIT_AUTH_LABEL, GIT_AUTH_PROVIDER for a URL.
 # Leaves GIT_AUTH_ENV empty when no token applies (SSH, tokenless, unknown host),
-# in which case the caller's `env "${GIT_AUTH_ENV[@]}" git …` is a plain git call.
+# in which case the caller's `env ${GIT_AUTH_ENV[@]+"${GIT_AUTH_ENV[@]}"} git …` is a plain git call.
 git_auth_env_for_url() {
   local remote_url="$1"
   local host provider="" default_token_var="" token="" user="" token_label="" header=""

--- a/scripts/git-provider.sh
+++ b/scripts/git-provider.sh
@@ -132,22 +132,34 @@ gp_token_is_placeholder() {
 # Usage: gp_token_api_login PROVIDER HOST TOKEN
 gp_token_api_login() {
     local provider="$1" host="$2" tok="$3"
+    # Portable, optional timeout so a slow or unreachable network can't hang the
+    # probe. Absent on stock macOS (no coreutils) — then we run without it.
+    local -a to=()
+    if command -v timeout >/dev/null 2>&1; then to=(timeout 10)
+    elif command -v gtimeout >/dev/null 2>&1; then to=(gtimeout 10)
+    fi
+    local out rc
     case "$provider" in
         github)
             command -v gh >/dev/null 2>&1 || return 2
-            env GH_TOKEN="$tok" GH_HOST="$host" gh api user --jq .login 2>/dev/null || return 1
+            out=$(env GH_TOKEN="$tok" GH_HOST="$host" ${to[@]+"${to[@]}"} gh api user --jq .login 2>/dev/null)
+            rc=$?
             ;;
         gitlab)
             command -v glab >/dev/null 2>&1 || return 2
             command -v jq >/dev/null 2>&1 || return 2
-            local out
-            out=$(env GITLAB_TOKEN="$tok" GITLAB_HOST="$host" glab api user 2>/dev/null) || return 1
-            out=$(printf '%s' "$out" | jq -r '.username // empty' 2>/dev/null)
-            [[ -n "$out" ]] || return 1
-            printf '%s' "$out"
+            out=$(env GITLAB_TOKEN="$tok" GITLAB_HOST="$host" ${to[@]+"${to[@]}"} glab api user 2>/dev/null)
+            rc=$?
+            [[ $rc -eq 0 ]] && out=$(printf '%s' "$out" | jq -r '.username // empty' 2>/dev/null)
             ;;
-        *) return 2 ;;
+        *)
+            return 2
+            ;;
     esac
+    # 124 = `timeout` killed the probe → unreachable/transport, not a rejection.
+    [[ $rc -eq 124 ]] && return 3
+    [[ $rc -ne 0 || -z "$out" ]] && return 1
+    printf '%s' "$out"
 }
 
 # Load a provider implementation by name.

--- a/scripts/git-provider.sh
+++ b/scripts/git-provider.sh
@@ -103,8 +103,10 @@ gp_pat_create_url() {
     enc=$(_gp_urlencode "$desc")
     case "$provider" in
         github)
-            # Classic PAT: `repo` covers push + PR creation via the API.
-            printf 'https://%s/settings/tokens/new?scopes=repo&description=%s' "$host" "$enc"
+            # Classic PAT. `repo` covers push + PR creation; the read:* scopes are
+            # the recommended baseline (docs/git-provider-setup.md) that keep
+            # `gh pr edit`-shaped ops from failing with a read:org scope error.
+            printf 'https://%s/settings/tokens/new?scopes=repo,read:org,read:discussion,read:project&description=%s' "$host" "$enc"
             ;;
         gitlab)
             # `api` (MR creation) + `write_repository` (git push over HTTPS).

--- a/scripts/git-provider.sh
+++ b/scripts/git-provider.sh
@@ -75,6 +75,21 @@ gp_detect() {
     return 1
 }
 
+# Percent-encode a string for a URL query value: everything outside the RFC
+# 3986 unreserved set (A-Z a-z 0-9 - _ . ~) becomes %XX. Keeps deep-link
+# descriptions/names safe even with &, ?, #, +, =, %, or spaces in them.
+_gp_urlencode() {
+    local s="$1" out="" i c
+    for (( i = 0; i < ${#s}; i++ )); do
+        c="${s:i:1}"
+        case "$c" in
+            [A-Za-z0-9._~-]) out+="$c" ;;
+            *) printf -v c '%%%02X' "'$c"; out+="$c" ;;
+        esac
+    done
+    printf '%s' "$out"
+}
+
 # Build a deep-link URL to create a personal access token with the scopes
 # ws push / cr / review need pre-selected, so the user lands on a page with
 # the right boxes already checked instead of guessing. The scope + name/
@@ -84,8 +99,8 @@ gp_detect() {
 # Usage: gp_pat_create_url PROVIDER HOST [DESCRIPTION]
 gp_pat_create_url() {
     local provider="$1" host="$2" desc="${3:-GDD}"
-    # Minimal URL-encoding for the description/name — spaces to %20.
-    local enc="${desc// /%20}"
+    local enc
+    enc=$(_gp_urlencode "$desc")
     case "$provider" in
         github)
             # Classic PAT: `repo` covers push + PR creation via the API.

--- a/scripts/git-provider.sh
+++ b/scripts/git-provider.sh
@@ -116,6 +116,40 @@ gp_pat_create_url() {
     esac
 }
 
+# True (rc 0) if VALUE is one of the literal sample token values shipped in
+# .env.example, so `ws diagnose` can flag "you left the placeholder" instead of
+# reporting it as a real token. Exact match only — no heuristics.
+gp_token_is_placeholder() {
+    case "$1" in
+        ghp_xxxxxxxxxxxx|glpat-xxxxxxxxxxxx) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# Best-effort token validity probe. Echoes the account login on success (rc 0);
+# rc 1 = the provider rejected the token; rc 2 = couldn't check (CLI/jq missing
+# or provider unsupported). Never prints the token itself.
+# Usage: gp_token_api_login PROVIDER HOST TOKEN
+gp_token_api_login() {
+    local provider="$1" host="$2" tok="$3"
+    case "$provider" in
+        github)
+            command -v gh >/dev/null 2>&1 || return 2
+            env GH_TOKEN="$tok" GH_HOST="$host" gh api user --jq .login 2>/dev/null || return 1
+            ;;
+        gitlab)
+            command -v glab >/dev/null 2>&1 || return 2
+            command -v jq >/dev/null 2>&1 || return 2
+            local out
+            out=$(env GITLAB_TOKEN="$tok" GITLAB_HOST="$host" glab api user 2>/dev/null) || return 1
+            out=$(printf '%s' "$out" | jq -r '.username // empty' 2>/dev/null)
+            [[ -n "$out" ]] || return 1
+            printf '%s' "$out"
+            ;;
+        *) return 2 ;;
+    esac
+}
+
 # Load a provider implementation by name.
 # Usage: gp_load PROVIDER
 gp_load() {

--- a/scripts/git-provider.sh
+++ b/scripts/git-provider.sh
@@ -75,6 +75,32 @@ gp_detect() {
     return 1
 }
 
+# Build a deep-link URL to create a personal access token with the scopes
+# ws push / cr / review need pre-selected, so the user lands on a page with
+# the right boxes already checked instead of guessing. The scope + name/
+# description query params are honored by github.com and GitHub Enterprise,
+# and by gitlab.com and self-hosted GitLab. On an unrecognized provider it
+# falls back to the host root so the link still goes somewhere useful.
+# Usage: gp_pat_create_url PROVIDER HOST [DESCRIPTION]
+gp_pat_create_url() {
+    local provider="$1" host="$2" desc="${3:-GDD}"
+    # Minimal URL-encoding for the description/name — spaces to %20.
+    local enc="${desc// /%20}"
+    case "$provider" in
+        github)
+            # Classic PAT: `repo` covers push + PR creation via the API.
+            printf 'https://%s/settings/tokens/new?scopes=repo&description=%s' "$host" "$enc"
+            ;;
+        gitlab)
+            # `api` (MR creation) + `write_repository` (git push over HTTPS).
+            printf 'https://%s/-/user_settings/personal_access_tokens?name=%s&scopes=api,write_repository' "$host" "$enc"
+            ;;
+        *)
+            printf 'https://%s' "$host"
+            ;;
+    esac
+}
+
 # Load a provider implementation by name.
 # Usage: gp_load PROVIDER
 gp_load() {

--- a/scripts/git-push.sh
+++ b/scripts/git-push.sh
@@ -31,7 +31,7 @@ source "$SCRIPT_DIR/ws-realm.sh"
 # the rest of this script is unchanged.
 git_push_auth_env_for_remote() {
   git_auth_env_for_url "$1"
-  GIT_PUSH_AUTH_ENV=("${GIT_AUTH_ENV[@]}")
+  GIT_PUSH_AUTH_ENV=(${GIT_AUTH_ENV[@]+"${GIT_AUTH_ENV[@]}"})
   GIT_PUSH_AUTH_LABEL="$GIT_AUTH_LABEL"
   GIT_PUSH_AUTH_PROVIDER="$GIT_AUTH_PROVIDER"
 }
@@ -126,7 +126,7 @@ if [[ "$TARGET_KIND" == "tag" ]]; then
   if [[ -n "$GIT_PUSH_AUTH_LABEL" ]]; then
     echo "Using $GIT_PUSH_AUTH_LABEL for HTTPS $GIT_PUSH_AUTH_PROVIDER push auth (no credential helper prompt)"
   fi
-  env "${GIT_PUSH_AUTH_ENV[@]}" git push "$REMOTE_NAME" "refs/tags/$TARGET:refs/tags/$TARGET"
+  env ${GIT_PUSH_AUTH_ENV[@]+"${GIT_PUSH_AUTH_ENV[@]}"} git push "$REMOTE_NAME" "refs/tags/$TARGET:refs/tags/$TARGET"
   exit 0
 fi
 
@@ -163,11 +163,11 @@ if [[ -n "$FORCE" ]]; then
   if [[ -n "$GIT_PUSH_AUTH_LABEL" ]]; then
     echo "Using $GIT_PUSH_AUTH_LABEL for HTTPS $GIT_PUSH_AUTH_PROVIDER push auth (no credential helper prompt)"
   fi
-  env "${GIT_PUSH_AUTH_ENV[@]}" git push --force ${SET_UPSTREAM:+$SET_UPSTREAM} "$REMOTE_NAME" "$BRANCH"
+  env ${GIT_PUSH_AUTH_ENV[@]+"${GIT_PUSH_AUTH_ENV[@]}"} git push --force ${SET_UPSTREAM:+$SET_UPSTREAM} "$REMOTE_NAME" "$BRANCH"
 else
   echo "Pushing $BRANCH → $REMOTE_NAME ($ORG_REPO)"
   if [[ -n "$GIT_PUSH_AUTH_LABEL" ]]; then
     echo "Using $GIT_PUSH_AUTH_LABEL for HTTPS $GIT_PUSH_AUTH_PROVIDER push auth (no credential helper prompt)"
   fi
-  env "${GIT_PUSH_AUTH_ENV[@]}" git push ${SET_UPSTREAM:+$SET_UPSTREAM} "$REMOTE_NAME" "$BRANCH"
+  env ${GIT_PUSH_AUTH_ENV[@]+"${GIT_PUSH_AUTH_ENV[@]}"} git push ${SET_UPSTREAM:+$SET_UPSTREAM} "$REMOTE_NAME" "$BRANCH"
 fi

--- a/scripts/validate-agent-setup.sh
+++ b/scripts/validate-agent-setup.sh
@@ -58,20 +58,16 @@ else
   exit 1
 fi
 
-if [[ -n "${GH_USER:-}" ]]; then
-  echo "  $PASS GH_USER set in environment: $GH_USER"
+gh_login=$(gh api /user --jq .login 2>/dev/null || echo "")
+if [[ -n "$gh_login" ]]; then
+  echo "  $PASS authenticated as: $gh_login"
 else
-  GH_USER=$(gh api /user --jq .login 2>/dev/null || echo "")
-  if [[ -n "$GH_USER" ]]; then
-    echo "  $PASS authenticated as: $GH_USER"
-  else
-    echo "  $FAIL could not retrieve GitHub username"
-    echo "       Set GH_USER in .env, or add Account (read) permission to a fine-grained PAT."
-    ERRORS=$((ERRORS + 1))
-    echo ""
-    echo "Cannot continue without a confirmed identity. Fix auth first."
-    exit 1
-  fi
+  echo "  $FAIL could not retrieve GitHub username"
+  echo "       Add 'Account (read)' permission to the token (fine-grained PATs need it)."
+  ERRORS=$((ERRORS + 1))
+  echo ""
+  echo "Cannot continue without a confirmed identity. Fix auth first."
+  exit 1
 fi
 
 # ── 2. git URL rewrite and credential helper ─────────────────────────────────

--- a/scripts/ws
+++ b/scripts/ws
@@ -611,31 +611,70 @@ _ws_pat_setup_lines() {
     printf "      → Then add 'export %s=<token>' to .env  (copy .env.example)" "$var_name"
 }
 
+# Health line for a token var that IS set: placeholder → warn + guide; else,
+# unless api checks are off, verify the token against the provider API; else
+# just report it as set. Args: var_name value provider host no_api.
+_ws_token_status() {
+    local var_name="$1" value="$2" provider="$3" host="$4" no_api="$5"
+    if gp_token_is_placeholder "$value"; then
+        printf '⚠ %s is set to the .env.example placeholder — replace it with a real token\n%s' \
+            "$var_name" "$(_ws_pat_setup_lines "$provider" "$host" "$var_name")"
+        return
+    fi
+    # Skip the live probe when asked (--no-api-check) or under bats, to keep the
+    # test suite offline and deterministic (same guard style as _ws_footer).
+    if [[ -n "$no_api" || -n "${BATS_TEST_NAME:-}" ]]; then
+        printf '✓ %s is set (not verified — omit --no-api-check to test the token)' "$var_name"
+        return
+    fi
+    local login rc
+    login=$(gp_token_api_login "$provider" "$host" "$value")
+    rc=$?
+    case "$rc" in
+        0) printf '✓ %s is valid (authenticated as %s)' "$var_name" "$login" ;;
+        1) printf '✗ %s is set but REJECTED by %s — bad credentials (expired, wrong value, or missing scope)\n%s' \
+               "$var_name" "$provider" "$(_ws_pat_setup_lines "$provider" "$host" "$var_name")" ;;
+        *) printf '✓ %s is set (could not verify — %s CLI unavailable)' "$var_name" "$provider" ;;
+    esac
+}
+
 ws_diagnose() {
     # ws:use-when investigating push/cr failures — remote + token coverage
-    local _arg
+    local _arg comp="" no_api=""
     for _arg in "$@"; do
-        if [[ "$_arg" == "--help" || "$_arg" == "-h" ]]; then
-            cat <<'HELP'
-Usage: ws diagnose <component|realm|hoard|yggdrasil>
+        case "$_arg" in
+            --help|-h)
+                cat <<'HELP'
+Usage: ws diagnose [--no-api-check] <component|realm|hoard|yggdrasil>
 
-  target  Any resolvable workspace target — a declared ecosystem
-          component, a realm dir, a hoard dir, or yggdrasil itself
+  target          Any resolvable workspace target — a declared ecosystem
+                  component, a realm dir, a hoard dir, or yggdrasil itself
+  --no-api-check  Skip the live token-validity probe (offline checks only).
+                  Use when the network/provider is down, or when debugging
+                  something unrelated to auth.
 
-Shows ecosystem config (components only), clone status, remotes,
-provider, and token coverage. Run this when 'ws push' or 'ws cr'
-fails with auth or remote errors.
+Shows ecosystem config (components only), clone status, remotes, provider,
+and token coverage. By default a set token is verified against the provider
+API; a placeholder or rejected token is flagged. Run this when 'ws push' or
+'ws cr' fails with auth or remote errors.
 HELP
-            return 0
-        fi
+                return 0
+                ;;
+            --no-api-check) no_api=1 ;;
+            -*)
+                echo "ws diagnose: unknown option '$_arg'" >&2
+                echo "  Usage: ws diagnose [--no-api-check] <component|realm|hoard|yggdrasil>" >&2
+                exit 1
+                ;;
+            *) [[ -z "$comp" ]] && comp="$_arg" ;;
+        esac
     done
-    if [[ $# -lt 1 ]]; then
-        echo "Usage: ws diagnose <component|realm|hoard|yggdrasil>" >&2
+    if [[ -z "$comp" ]]; then
+        echo "Usage: ws diagnose [--no-api-check] <component|realm|hoard|yggdrasil>" >&2
         echo "  Shows ecosystem config, clone status, remotes, provider, and token coverage." >&2
         echo "  Run this when 'ws push' or 'ws cr' fails with auth or remote errors." >&2
         exit 1
     fi
-    local comp="$1"
     local eco
     eco=$(ws_resolve_ecosystem)
 
@@ -717,7 +756,7 @@ HELP
         if [[ -n "$best_var" && "$best_var" != "null" ]]; then
             local token_val="${!best_var:-}"
             if [[ -n "$token_val" ]]; then
-                token_status="✓ $best_var is set"
+                token_status=$(_ws_token_status "$best_var" "$token_val" "$provider" "${normalized%%/*}" "$no_api")
             else
                 token_status="✗ $best_var is NOT SET"
                 token_status+=$'\n'"$(_ws_pat_setup_lines "$provider" "${normalized%%/*}" "$best_var")"
@@ -739,7 +778,7 @@ HELP
             if [[ -n "$default_var" ]]; then
                 local default_val="${!default_var:-}"
                 if [[ -n "$default_val" ]]; then
-                    token_status="✓ $default_var is set (default for $provider; no gitTokens entry needed)"
+                    token_status=$(_ws_token_status "$default_var" "$default_val" "$provider" "${normalized%%/*}" "$no_api")
                 else
                     # Note: $default_var being unset doesn't necessarily mean
                     # `gh`/`glab` will fail — interactive `gh auth login` /

--- a/scripts/ws
+++ b/scripts/ws
@@ -600,6 +600,17 @@ HELP
     bash "$SCRIPT_DIR/git-issue.sh" "$COMPONENT_DIR" "$remote" "$@"
 }
 
+# Shared "create + store a token" guidance for a missing token var. Used by
+# both branches of ws_diagnose's token-coverage report so the two copies can't
+# drift. Emits two indented "→" lines (no trailing newline; caller joins).
+_ws_pat_setup_lines() {
+    local provider="$1" host="$2" var_name="$3"
+    local pat_url
+    pat_url=$(gp_pat_create_url "$provider" "$host" "GDD agent write token")
+    printf '      → Create one (scopes pre-selected, opens in browser): %s\n' "$pat_url"
+    printf "      → Then add 'export %s=<token>' to .env  (copy .env.example)" "$var_name"
+}
+
 ws_diagnose() {
     # ws:use-when investigating push/cr failures — remote + token coverage
     local _arg
@@ -708,11 +719,8 @@ HELP
             if [[ -n "$token_val" ]]; then
                 token_status="✓ $best_var is set"
             else
-                local pat_url
-                pat_url=$(gp_pat_create_url "$provider" "${normalized%%/*}" "GDD agent write token")
                 token_status="✗ $best_var is NOT SET"
-                token_status+=$'\n'"      → Create one (scopes pre-selected, opens in browser): $pat_url"
-                token_status+=$'\n'"      → Then add 'export $best_var=<token>' to .env  (copy .env.example)"
+                token_status+=$'\n'"$(_ws_pat_setup_lines "$provider" "${normalized%%/*}" "$best_var")"
             fi
         else
             # No gitTokens entry. For known providers, fall back to the
@@ -738,11 +746,8 @@ HELP
                     # `glab auth login` stores credentials separately. But
                     # agent / non-interactive flows (ws push, ws cr, ws review)
                     # need the env var, so we still flag it.
-                    local pat_url
-                    pat_url=$(gp_pat_create_url "$provider" "${normalized%%/*}" "GDD agent write token")
                     token_status="✗ $default_var is NOT SET — required for agent/non-interactive ops (ws push, ws cr, ws review)."
-                    token_status+=$'\n'"      → Create one (scopes pre-selected, opens in browser): $pat_url"
-                    token_status+=$'\n'"      → Then add 'export $default_var=<token>' to .env  (copy .env.example)"
+                    token_status+=$'\n'"$(_ws_pat_setup_lines "$provider" "${normalized%%/*}" "$default_var")"
                     token_status+=$'\n'"      Interactive 'gh auth login' / 'glab auth login' may still work for direct CLI use, but agent flows need the .env var."
                 fi
             else

--- a/scripts/ws
+++ b/scripts/ws
@@ -634,6 +634,7 @@ _ws_token_status() {
         0) printf '✓ %s is valid (authenticated as %s)' "$var_name" "$login" ;;
         1) printf '✗ %s is set but REJECTED by %s — bad credentials (expired, wrong value, or missing scope)\n%s' \
                "$var_name" "$provider" "$(_ws_pat_setup_lines "$provider" "$host" "$var_name")" ;;
+        3) printf '✓ %s is set (could not verify — %s unreachable or the probe timed out)' "$var_name" "$provider" ;;
         *) printf '✓ %s is set (could not verify — %s CLI unavailable)' "$var_name" "$provider" ;;
     esac
 }

--- a/scripts/ws
+++ b/scripts/ws
@@ -709,7 +709,7 @@ HELP
                 token_status="✓ $best_var is set"
             else
                 local pat_url
-                pat_url=$(gp_pat_create_url "$provider" "${normalized%%/*}" "GDD ${comp}")
+                pat_url=$(gp_pat_create_url "$provider" "${normalized%%/*}" "GDD agent write token")
                 token_status="✗ $best_var is NOT SET"
                 token_status+=$'\n'"      → Create one (scopes pre-selected, opens in browser): $pat_url"
                 token_status+=$'\n'"      → Then add 'export $best_var=<token>' to .env  (copy .env.example)"
@@ -739,7 +739,7 @@ HELP
                     # agent / non-interactive flows (ws push, ws cr, ws review)
                     # need the env var, so we still flag it.
                     local pat_url
-                    pat_url=$(gp_pat_create_url "$provider" "${normalized%%/*}" "GDD ${comp}")
+                    pat_url=$(gp_pat_create_url "$provider" "${normalized%%/*}" "GDD agent write token")
                     token_status="✗ $default_var is NOT SET — required for agent/non-interactive ops (ws push, ws cr, ws review)."
                     token_status+=$'\n'"      → Create one (scopes pre-selected, opens in browser): $pat_url"
                     token_status+=$'\n'"      → Then add 'export $default_var=<token>' to .env  (copy .env.example)"

--- a/scripts/ws
+++ b/scripts/ws
@@ -799,6 +799,22 @@ HELP
         echo "    $remote ($provider): $token_status"
     done < <(git -C "$comp_dir" remote)
 
+    # Identity sanity — flag unedited ecosystem.local.yaml placeholders before
+    # they leak into CR / issue bodies (@HUMAN_ACCOUNT) or fork flows.
+    local human_account fork_remote
+    human_account=$(yq '.identity.human_account // ""' "$eco" 2>/dev/null)
+    fork_remote=$(yq '.identity.forkRemote // ""' "$eco" 2>/dev/null)
+    echo "  Identity:"
+    if [[ -z "$human_account" || "$human_account" == "your-github-username" ]]; then
+        echo "    ⚠ identity.human_account is ${human_account:-unset} — set it in ecosystem.local.yaml"
+        echo "      (it fills @HUMAN_ACCOUNT in CR / issue bodies via ws cr / ws issue)"
+    else
+        echo "    ✓ human_account: $human_account"
+    fi
+    if [[ "$fork_remote" == "your-fork-remote-name" ]]; then
+        echo "    ⚠ identity.forkRemote is still the placeholder (only needed for ws clone-fork / fork CR flows)"
+    fi
+
     echo ""
 }
 

--- a/scripts/ws
+++ b/scripts/ws
@@ -891,7 +891,7 @@ EOF
     if [[ -n "$test_url" ]]; then
         GIT_AUTH_ENV=()
         git_auth_env_for_url "$test_url"
-        if env "${GIT_AUTH_ENV[@]}" git ls-remote "$test_url" HEAD &>/dev/null; then
+        if env ${GIT_AUTH_ENV[@]+"${GIT_AUTH_ENV[@]}"} git ls-remote "$test_url" HEAD &>/dev/null; then
             if [[ -n "${GIT_AUTH_LABEL:-}" ]]; then
                 echo "   ✓ git access verified using $GIT_AUTH_LABEL ($test_url)"
             else

--- a/scripts/ws
+++ b/scripts/ws
@@ -708,7 +708,11 @@ HELP
             if [[ -n "$token_val" ]]; then
                 token_status="✓ $best_var is set"
             else
-                token_status="✗ $best_var is NOT SET — add 'export $best_var=<token>' to .env"
+                local pat_url
+                pat_url=$(gp_pat_create_url "$provider" "${normalized%%/*}" "GDD ${comp}")
+                token_status="✗ $best_var is NOT SET"
+                token_status+=$'\n'"      → Create one (scopes pre-selected, opens in browser): $pat_url"
+                token_status+=$'\n'"      → Then add 'export $best_var=<token>' to .env  (copy .env.example)"
             fi
         else
             # No gitTokens entry. For known providers, fall back to the
@@ -734,7 +738,12 @@ HELP
                     # `glab auth login` stores credentials separately. But
                     # agent / non-interactive flows (ws push, ws cr, ws review)
                     # need the env var, so we still flag it.
-                    token_status="✗ $default_var is NOT SET — required for agent/non-interactive ops (ws push, ws cr, ws review). Add 'export $default_var=<token>' to .env. Interactive 'gh auth login' / 'glab auth login' may still work for direct CLI use."
+                    local pat_url
+                    pat_url=$(gp_pat_create_url "$provider" "${normalized%%/*}" "GDD ${comp}")
+                    token_status="✗ $default_var is NOT SET — required for agent/non-interactive ops (ws push, ws cr, ws review)."
+                    token_status+=$'\n'"      → Create one (scopes pre-selected, opens in browser): $pat_url"
+                    token_status+=$'\n'"      → Then add 'export $default_var=<token>' to .env  (copy .env.example)"
+                    token_status+=$'\n'"      Interactive 'gh auth login' / 'glab auth login' may still work for direct CLI use, but agent flows need the .env var."
                 fi
             else
                 token_status="✗ no gitTokens entry matches normalized path: $normalized"
@@ -985,6 +994,20 @@ _ws_footer() {
     else
         printf '↪ switching tasks? `ws orient` lists available tools.\n' >&2
     fi
+    # Command-specific next-step nudge. After a push the review phase is
+    # next: steer toward `ws review` over raw gh/glab (or the ws gh / ws
+    # glab escape hatches), which is easy to reach for now that tokens are
+    # injected but loses thread-resolution / since-filtering / attribution.
+    case "$COMMAND" in
+        push)
+            local _rev='↪ review phase: use `ws review <comp> [cr#]` to read/triage CR feedback — prefer it over raw gh/glab or `ws gh`/`ws glab` unless truly needed.'
+            if [[ -t 2 ]]; then
+                printf '\e[2m%s\e[0m\n' "$_rev" >&2
+            else
+                printf '%s\n' "$_rev" >&2
+            fi
+            ;;
+    esac
 }
 
 case "$COMMAND" in

--- a/scripts/ws-clone-fork.sh
+++ b/scripts/ws-clone-fork.sh
@@ -606,7 +606,7 @@ else
     echo "         CLONE: $FORK_REMOTE_URL → $TARGET (remote: $FORK_REMOTE)"
     GIT_AUTH_ENV=()
     git_auth_env_for_url "$FORK_REMOTE_URL"
-    env "${GIT_AUTH_ENV[@]}" git clone --origin "$FORK_REMOTE" "$FORK_REMOTE_URL" "$TARGET"
+    env ${GIT_AUTH_ENV[@]+"${GIT_AUTH_ENV[@]}"} git clone --origin "$FORK_REMOTE" "$FORK_REMOTE_URL" "$TARGET"
     git -C "$TARGET" remote add "$UPSTREAM_REMOTE_NAME" "$UPSTREAM_REMOTE_URL"
 fi
 
@@ -616,7 +616,7 @@ echo "  Step 3: sync local + fork main with source project ..."
 
 GIT_AUTH_ENV=()
 git_auth_env_for_url "$UPSTREAM_REMOTE_URL"
-env "${GIT_AUTH_ENV[@]}" git -C "$TARGET" fetch "$UPSTREAM_REMOTE_NAME" --quiet
+env ${GIT_AUTH_ENV[@]+"${GIT_AUTH_ENV[@]}"} git -C "$TARGET" fetch "$UPSTREAM_REMOTE_NAME" --quiet
 
 # Determine the upstream default branch (might be "main" or "master")
 DEFAULT_BRANCH=$(echo "$local_upstream_details" | jq -r '.default_branch // "main"')
@@ -680,7 +680,7 @@ echo "  Step 4: push synced $DEFAULT_BRANCH to fork ..."
 # and status, then stream the output and branch on the real status.
 GIT_AUTH_ENV=()
 git_auth_env_for_url "$FORK_REMOTE_URL"
-if push_output=$(env "${GIT_AUTH_ENV[@]}" git -C "$TARGET" push "$FORK_REMOTE" "refs/heads/$DEFAULT_BRANCH:refs/heads/$DEFAULT_BRANCH" 2>&1); then
+if push_output=$(env ${GIT_AUTH_ENV[@]+"${GIT_AUTH_ENV[@]}"} git -C "$TARGET" push "$FORK_REMOTE" "refs/heads/$DEFAULT_BRANCH:refs/heads/$DEFAULT_BRANCH" 2>&1); then
     push_ok=true
 else
     push_ok=false

--- a/scripts/ws-clone.sh
+++ b/scripts/ws-clone.sh
@@ -140,7 +140,7 @@ clone_component() {
     local -a GIT_AUTH_ENV=()
     local GIT_AUTH_LABEL="" GIT_AUTH_PROVIDER=""
     git_auth_env_for_url "$repo_url"
-    env "${GIT_AUTH_ENV[@]}" git clone --origin "$remote" "$repo_url" "$target"
+    env ${GIT_AUTH_ENV[@]+"${GIT_AUTH_ENV[@]}"} git clone --origin "$remote" "$repo_url" "$target"
 }
 
 clone_url() {
@@ -179,7 +179,7 @@ clone_url() {
         local -a GIT_AUTH_ENV=()
         local GIT_AUTH_LABEL="" GIT_AUTH_PROVIDER=""
         git_auth_env_for_url "$url"
-        env "${GIT_AUTH_ENV[@]}" git clone --origin "$remote" "$url" "$target"
+        env ${GIT_AUTH_ENV[@]+"${GIT_AUTH_ENV[@]}"} git clone --origin "$remote" "$url" "$target"
     fi
 
     if [[ "$add_eco" == "true" ]]; then

--- a/scripts/ws-hoard.sh
+++ b/scripts/ws-hoard.sh
@@ -527,7 +527,7 @@ ws_hoard_init_from_yaml() {
     local GIT_AUTH_LABEL="" GIT_AUTH_PROVIDER=""
     git_auth_env_for_url "$upstream"
     echo "Cloning $upstream into $target..."
-    if ! env "${GIT_AUTH_ENV[@]}" git clone "$upstream" "$target" 2>/dev/null; then
+    if ! env ${GIT_AUTH_ENV[@]+"${GIT_AUTH_ENV[@]}"} git clone "$upstream" "$target" 2>/dev/null; then
         if [[ -n "$fallback" ]]; then
             # The failed upstream clone may have left $target half-populated
             # (partial fetch, broken .git/, etc.). Wipe it before retrying so
@@ -535,7 +535,7 @@ ws_hoard_init_from_yaml() {
             rm -rf "$target"
             echo "  Upstream clone failed; trying fallback: $fallback" >&2
             git_auth_env_for_url "$fallback"
-            if ! env "${GIT_AUTH_ENV[@]}" git clone "$fallback" "$target" 2>/dev/null; then
+            if ! env ${GIT_AUTH_ENV[@]+"${GIT_AUTH_ENV[@]}"} git clone "$fallback" "$target" 2>/dev/null; then
                 echo "ERROR: clone failed for both upstream and fallback." >&2
                 echo "  upstream: $upstream" >&2
                 echo "  fallback: $fallback" >&2
@@ -896,7 +896,7 @@ ws_hoard_clone_url() {
     local GIT_AUTH_LABEL="" GIT_AUTH_PROVIDER=""
     git_auth_env_for_url "$url"
     [[ -n "$GIT_AUTH_LABEL" ]] && echo "Using $GIT_AUTH_LABEL for HTTPS $GIT_AUTH_PROVIDER clone auth (no credential helper prompt)"
-    env "${GIT_AUTH_ENV[@]}" git clone "$url" "$target"
+    env ${GIT_AUTH_ENV[@]+"${GIT_AUTH_ENV[@]}"} git clone "$url" "$target"
     echo ""
     echo "Hoard cloned: $target"
 

--- a/scripts/ws-pull.sh
+++ b/scripts/ws-pull.sh
@@ -79,7 +79,7 @@ pull_repo() {
     local -a GIT_AUTH_ENV=()
     local GIT_AUTH_LABEL="" GIT_AUTH_PROVIDER=""
     [[ -n "$remote_url" ]] && git_auth_env_for_url "$remote_url"
-    if ! env "${GIT_AUTH_ENV[@]}" git -C "$target" pull --rebase 2>&1 | sed 's/^/  /'; then
+    if ! env ${GIT_AUTH_ENV[@]+"${GIT_AUTH_ENV[@]}"} git -C "$target" pull --rebase 2>&1 | sed 's/^/  /'; then
         echo "  CONFLICT: aborting rebase — resolve manually in $target"
         git -C "$target" rebase --abort 2>/dev/null
         HAD_FAILURES=1

--- a/scripts/ws-realm.sh
+++ b/scripts/ws-realm.sh
@@ -280,6 +280,20 @@ ws_realm_help() {
 }
 
 ws_realm_init() {
+    if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+        cat <<'HELP'
+Usage: ws realm init
+
+Clone the shared template realm (realm-template) into realms/ for the
+tutorial flow, creating ecosystem.local.yaml from the example if it is
+absent. Takes no arguments.
+
+After it runs you can either try the quick tutorial
+('ws component init gh-pages <name>') or make the realm your own — fork it
+on GitHub, rename to realm-<your-community>, then 'ws realm <your-fork-url>'.
+HELP
+        return 0
+    fi
     # Copy ecosystem.local.yaml.example if no local config exists.
     # Must happen BEFORE ws_resolve_ecosystem — the example file contains
     # defaults.templateRealm which the merge needs to find.
@@ -538,7 +552,7 @@ case "$SUBCMD" in
         ws_realm_help
         ;;
     init)
-        ws_realm_init
+        ws_realm_init "$@"
         ;;
     use)
         ws_realm_use "$@"

--- a/scripts/ws-realm.sh
+++ b/scripts/ws-realm.sh
@@ -312,9 +312,14 @@ ws_realm_init() {
     local -a GIT_AUTH_ENV=()
     local GIT_AUTH_LABEL="" GIT_AUTH_PROVIDER=""
     git_auth_env_for_url "$template_url"
-    env "${GIT_AUTH_ENV[@]}" git clone "$template_url" "$target"
+    env ${GIT_AUTH_ENV[@]+"${GIT_AUTH_ENV[@]}"} git clone "$template_url" "$target"
     echo ""
-    echo "Template realm ready. Run 'ws clone --all' to clone tutorial components."
+    echo "Template realm ready — you're on the shared 'realm-template' starter."
+    echo ""
+    echo "New to GDD? Fastest first loop:  ws component init gh-pages my-page   (edit -> PR -> live site)"
+    echo "Make it your own:                fork this repo on GitHub, rename it realm-<your-community>,"
+    echo "                                 then adopt your fork:  ws realm <your-fork-url>"
+    echo "Or browse the example projects:  ws clone --all   (clones the realm's suggested repos as-is)"
 }
 
 ws_realm_use() {
@@ -405,7 +410,7 @@ ws_realm_clone_url() {
     local -a GIT_AUTH_ENV=()
     local GIT_AUTH_LABEL="" GIT_AUTH_PROVIDER=""
     git_auth_env_for_url "$url"
-    env "${GIT_AUTH_ENV[@]}" git clone "$url" "$target"
+    env ${GIT_AUTH_ENV[@]+"${GIT_AUTH_ENV[@]}"} git clone "$url" "$target"
     echo ""
     echo "Community realm ready. Run 'ws clone --all' to clone components."
 }

--- a/tests/git-auth/empty-array-guard.bats
+++ b/tests/git-auth/empty-array-guard.bats
@@ -1,0 +1,46 @@
+#!/usr/bin/env bats
+
+# Regression tests for the empty-array auth-env guard.
+#
+# git-auth.sh leaves GIT_AUTH_ENV empty on SSH / tokenless / unknown-host
+# remotes. Call sites expand it as `env <auth-env> git <cmd>`. Under
+# `set -u`, a BARE "${arr[@]}" on an EMPTY array is an "unbound variable"
+# error on bash < 4.4 — and macOS ships bash 3.2, so this crashed the very
+# first `ws realm init` on a stock Mac. The fix is the guarded expansion
+# ${arr[@]+"${arr[@]}"}, which expands to nothing when empty on every bash.
+#
+# The crash is bash-version-specific, so a behavioral test on modern bash
+# (4.4+) would pass with OR without the fix and could not catch a
+# regression. The load-bearing guard here is therefore the STATIC pair
+# below: they fail if anyone reintroduces a bare `env "${..._AUTH_ENV[@]}"`
+# expansion in scripts/. The behavioral tests document intent and would
+# fail on bash 3.2 in the unguarded form.
+
+REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+
+@test "no bare env \"\${GIT_AUTH_ENV[@]}\" expansion remains in scripts/" {
+    # grep exits non-zero when there are no matches — that's the pass.
+    run grep -rnF 'env "${GIT_AUTH_ENV[@]}"' "$REPO_ROOT/scripts"
+    [ "$status" -ne 0 ]
+}
+
+@test "no bare env \"\${GIT_PUSH_AUTH_ENV[@]}\" expansion remains in scripts/" {
+    run grep -rnF 'env "${GIT_PUSH_AUTH_ENV[@]}"' "$REPO_ROOT/scripts"
+    [ "$status" -ne 0 ]
+}
+
+@test "guarded auth-env expansion is empty-array-safe under set -u" {
+    # The exact call-site shape with an EMPTY array. Crashed on bash 3.2
+    # in the bare form; the guarded form must run cleanly under `set -u`
+    # on every bash.
+    run bash -c 'set -u; declare -a e=(); env ${e[@]+"${e[@]}"} true'
+    [ "$status" -eq 0 ]
+}
+
+@test "guarded auth-env expansion still passes variables through when populated" {
+    # When the array HAS entries (token injected), the guard must not drop
+    # them — env must still export the injected variable to the child.
+    run bash -c 'set -u; declare -a e=(FOO=bar); env ${e[@]+"${e[@]}"} printenv FOO'
+    [ "$status" -eq 0 ]
+    [ "$output" = "bar" ]
+}

--- a/tests/git-auth/empty-array-guard.bats
+++ b/tests/git-auth/empty-array-guard.bats
@@ -44,3 +44,13 @@ REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
     [ "$status" -eq 0 ]
     [ "$output" = "bar" ]
 }
+
+@test "guarded auth-env expansion preserves elements that contain spaces" {
+    # Refutes the "unquoted → word-splits" claim: the inner quotes in
+    # ${e[@]+"${e[@]}"} keep each element intact, spaces and all. The real
+    # GIT_AUTH_ENV carries a GIT_CONFIG_VALUE_* = 'Authorization: Basic …' with
+    # spaces; if this word-split, env would try to run 'Basic' as a command.
+    run bash -c 'set -u; declare -a e=("V=a b c"); env ${e[@]+"${e[@]}"} printenv V'
+    [ "$status" -eq 0 ]
+    [ "$output" = "a b c" ]
+}

--- a/tests/git-provider/pat-url.bats
+++ b/tests/git-provider/pat-url.bats
@@ -33,3 +33,10 @@ setup() {
     run gp_pat_create_url bitbucket example.org "GDD"
     [ "$output" = "https://example.org" ]
 }
+
+@test "reserved characters in the description are percent-encoded, not left raw" {
+    # A general deep-link builder must encode &, ?, #, +, space, etc. so they
+    # can't be misread as query-string syntax.
+    run gp_pat_create_url github github.com "a&b?c#d e+f"
+    [ "$output" = "https://github.com/settings/tokens/new?scopes=repo&description=a%26b%3Fc%23d%20e%2Bf" ]
+}

--- a/tests/git-provider/pat-url.bats
+++ b/tests/git-provider/pat-url.bats
@@ -16,12 +16,12 @@ setup() {
     # PAT is account-wide, so naming it after one repo would mislead.
     run gp_pat_create_url github github.com "GDD agent write token"
     [ "$status" -eq 0 ]
-    [ "$output" = "https://github.com/settings/tokens/new?scopes=repo&description=GDD%20agent%20write%20token" ]
+    [ "$output" = "https://github.com/settings/tokens/new?scopes=repo,read:org,read:discussion,read:project&description=GDD%20agent%20write%20token" ]
 }
 
 @test "github enterprise host is honored (not hardcoded to github.com)" {
     run gp_pat_create_url github github.example.com "GDD"
-    [ "$output" = "https://github.example.com/settings/tokens/new?scopes=repo&description=GDD" ]
+    [ "$output" = "https://github.example.com/settings/tokens/new?scopes=repo,read:org,read:discussion,read:project&description=GDD" ]
 }
 
 @test "gitlab link pre-selects api + write_repository scopes" {
@@ -38,5 +38,5 @@ setup() {
     # A general deep-link builder must encode &, ?, #, +, space, etc. so they
     # can't be misread as query-string syntax.
     run gp_pat_create_url github github.com "a&b?c#d e+f"
-    [ "$output" = "https://github.com/settings/tokens/new?scopes=repo&description=a%26b%3Fc%23d%20e%2Bf" ]
+    [ "$output" = "https://github.com/settings/tokens/new?scopes=repo,read:org,read:discussion,read:project&description=a%26b%3Fc%23d%20e%2Bf" ]
 }

--- a/tests/git-provider/pat-url.bats
+++ b/tests/git-provider/pat-url.bats
@@ -11,10 +11,12 @@ setup() {
     source "$REPO_ROOT/scripts/git-provider.sh"
 }
 
-@test "github link pre-selects the repo scope and URL-encodes the description" {
-    run gp_pat_create_url github github.com "GDD yggdrasil"
+@test "github link pre-selects the repo scope and URL-encodes the multi-word description" {
+    # The description is a purpose label, not a repo name — a classic repo-scope
+    # PAT is account-wide, so naming it after one repo would mislead.
+    run gp_pat_create_url github github.com "GDD agent write token"
     [ "$status" -eq 0 ]
-    [ "$output" = "https://github.com/settings/tokens/new?scopes=repo&description=GDD%20yggdrasil" ]
+    [ "$output" = "https://github.com/settings/tokens/new?scopes=repo&description=GDD%20agent%20write%20token" ]
 }
 
 @test "github enterprise host is honored (not hardcoded to github.com)" {

--- a/tests/git-provider/pat-url.bats
+++ b/tests/git-provider/pat-url.bats
@@ -1,0 +1,33 @@
+#!/usr/bin/env bats
+
+# gp_pat_create_url — builds a deep-link URL to create a provider personal
+# access token with the scopes ws push / cr / review need pre-selected, so a
+# newcomer lands on a page with the right boxes checked instead of guessing.
+# Pure string logic; sourced and called directly.
+
+REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+
+setup() {
+    source "$REPO_ROOT/scripts/git-provider.sh"
+}
+
+@test "github link pre-selects the repo scope and URL-encodes the description" {
+    run gp_pat_create_url github github.com "GDD yggdrasil"
+    [ "$status" -eq 0 ]
+    [ "$output" = "https://github.com/settings/tokens/new?scopes=repo&description=GDD%20yggdrasil" ]
+}
+
+@test "github enterprise host is honored (not hardcoded to github.com)" {
+    run gp_pat_create_url github github.example.com "GDD"
+    [ "$output" = "https://github.example.com/settings/tokens/new?scopes=repo&description=GDD" ]
+}
+
+@test "gitlab link pre-selects api + write_repository scopes" {
+    run gp_pat_create_url gitlab gitlab.com "GDD demo"
+    [ "$output" = "https://gitlab.com/-/user_settings/personal_access_tokens?name=GDD%20demo&scopes=api,write_repository" ]
+}
+
+@test "unknown provider falls back to the host root" {
+    run gp_pat_create_url bitbucket example.org "GDD"
+    [ "$output" = "https://example.org" ]
+}

--- a/tests/git-provider/token-check.bats
+++ b/tests/git-provider/token-check.bats
@@ -23,7 +23,9 @@ setup() {
 }
 
 @test "placeholder check rejects a real-looking token" {
-    run gp_token_is_placeholder "ghp_A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8"
+    # Obviously-fake value that still has the ghp_+length shape but won't trip
+    # secret scanners (it's all zeros).
+    run gp_token_is_placeholder "ghp_0000000000000000000000000000000000" # gitleaks:allow
     [ "$status" -ne 0 ]
 }
 

--- a/tests/git-provider/token-check.bats
+++ b/tests/git-provider/token-check.bats
@@ -1,0 +1,61 @@
+#!/usr/bin/env bats
+
+# gp_token_is_placeholder + gp_token_api_login — the offline placeholder check
+# and the best-effort validity probe behind `ws diagnose`'s token coverage.
+# Sourced directly; the probe's provider CLI is stubbed so no network is hit.
+
+REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+
+setup() {
+    source "$REPO_ROOT/scripts/git-provider.sh"
+    STUB_DIR="$BATS_TEST_TMPDIR/bin"
+    mkdir -p "$STUB_DIR"
+}
+
+@test "placeholder check matches the shipped GitHub sample token" {
+    run gp_token_is_placeholder "ghp_xxxxxxxxxxxx"
+    [ "$status" -eq 0 ]
+}
+
+@test "placeholder check matches the shipped GitLab sample token" {
+    run gp_token_is_placeholder "glpat-xxxxxxxxxxxx"
+    [ "$status" -eq 0 ]
+}
+
+@test "placeholder check rejects a real-looking token" {
+    run gp_token_is_placeholder "ghp_A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8"
+    [ "$status" -ne 0 ]
+}
+
+@test "placeholder check rejects empty" {
+    run gp_token_is_placeholder ""
+    [ "$status" -ne 0 ]
+}
+
+@test "api probe echoes the login when the provider accepts the token" {
+    cat > "$STUB_DIR/gh" <<'SH'
+#!/usr/bin/env bash
+echo "octocat"
+SH
+    chmod +x "$STUB_DIR/gh"
+    PATH="$STUB_DIR:$PATH"
+    run gp_token_api_login github github.com sometoken
+    [ "$status" -eq 0 ]
+    [ "$output" = "octocat" ]
+}
+
+@test "api probe returns rc 1 when the provider rejects the token" {
+    cat > "$STUB_DIR/gh" <<'SH'
+#!/usr/bin/env bash
+exit 1
+SH
+    chmod +x "$STUB_DIR/gh"
+    PATH="$STUB_DIR:$PATH"
+    run gp_token_api_login github github.com badtoken
+    [ "$status" -eq 1 ]
+}
+
+@test "api probe returns rc 2 for an unsupported provider" {
+    run gp_token_api_login bitbucket bitbucket.org tok
+    [ "$status" -eq 2 ]
+}

--- a/tests/ws-diagnose/identity.bats
+++ b/tests/ws-diagnose/identity.bats
@@ -1,0 +1,40 @@
+#!/usr/bin/env bats
+
+# `ws diagnose` must flag an unedited identity.human_account placeholder
+# ('your-github-username' from ecosystem.local.yaml.example) before it leaks
+# into a CR/issue body via @HUMAN_ACCOUNT, and confirm a real value.
+
+REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+WS_BIN="$REPO_ROOT/scripts/ws"
+
+setup() {
+    WORK="$BATS_TEST_TMPDIR/work"
+    mkdir -p "$WORK"
+    git init -q "$WORK"
+    git -C "$WORK" config user.name "T"
+    git -C "$WORK" config user.email "t@example.local"
+    git -C "$WORK" commit -q --allow-empty -m seed
+    printf 'components: {}\n' > "$WORK/ecosystem.yaml"
+    export ROOT_DIR="$WORK"
+    export ECOSYSTEM="$WORK/ecosystem.yaml"
+    export ECOSYSTEM_LOCAL="$WORK/ecosystem.local.yaml"
+    export WS_FOOTER_DISABLE=1
+}
+
+run_diagnose() {
+    run env -u GH_TOKEN -u GITHUB_TOKEN bash "$WS_BIN" diagnose yggdrasil --no-api-check
+}
+
+@test "ws diagnose flags the placeholder human_account" {
+    printf 'identity:\n  human_account: your-github-username\n' > "$WORK/ecosystem.local.yaml"
+    run_diagnose
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"identity.human_account is your-github-username"* ]]
+}
+
+@test "ws diagnose confirms a real human_account" {
+    printf 'identity:\n  human_account: realdev\n' > "$WORK/ecosystem.local.yaml"
+    run_diagnose
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"✓ human_account: realdev"* ]]
+}

--- a/tests/ws-realm/help.bats
+++ b/tests/ws-realm/help.bats
@@ -1,0 +1,20 @@
+#!/usr/bin/env bats
+
+# `ws realm init --help` must print usage and return, NOT start cloning the
+# template realm. Regression for the dispatcher dropping args before
+# ws_realm_init (so --help fell through and ran the command).
+
+REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+WS_BIN="$REPO_ROOT/scripts/ws"
+
+@test "ws realm init --help prints usage and does not run" {
+    run bash "$WS_BIN" realm init --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage: ws realm init"* ]]
+}
+
+@test "ws realm init -h prints usage too" {
+    run bash "$WS_BIN" realm init -h
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage: ws realm init"* ]]
+}


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @Cervator via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

Onboarding-hardening fixes surfaced while walking a first-time user through GDD on a stock macOS machine.

- **bash 3.2 auth-env guard (fix):** `ws clone`/`push`/`pull`/`realm`/`hoard` expanded a possibly-empty `GIT_AUTH_ENV` with a bare `"${arr[@]}"`, which crashes under `set -u` on bash < 4.4 — and macOS ships bash 3.2, so the first `ws realm init` aborted. Guard all sites with `${arr[@]+"${arr[@]}"}` (the form already used at `scripts/ws:522`). Adds `tests/git-auth/` — a static regression guard (the crash is version-specific, so a behavioural test on modern bash can't catch it) plus empty-array behavioural cases.
- **Prompt newcomers to name their realm (B):** `ws realm init` now nudges fork+rename to `realm-<community>` and points first-timers at the light `ws component init gh-pages` loop instead of `ws clone --all`; `gdd-orientation` gets a matching directive.
- **Clarify the three tutorial flavors (D):** `docs/tutorials/index.md` distinguishes scaffolding a template, cloning a suggested realm project as-is, and feature walkthroughs (k8s = process, not code).
- **Scope-preselected token deep links (E):** `ws diagnose`'s "token NOT SET" message now prints a provider link with scopes pre-selected (`gp_pat_create_url`; host-aware for GHE/self-hosted). Adds `tests/git-provider/`.
- **Steer the review phase to `ws review` (F):** now that tokens are injected and `ws gh`/`ws glab` are easy to reach for, add a `ws review` row + note to the AGENTS.md reflex contract and a one-line `ws push` trailer.
- **Token-setup docs + remove `GH_USER` (G):** classic-PAT pros/cons and a fine-grained-vs-machine-account comparison; and remove `GH_USER`, which was only a `validate-agent-setup.sh` fallback (no auth path reads it — the token carries the identity) and whose docs oversold it.

## Test plan

- [x] Full workspace suite green — 562 bats tests, 0 failures (`bats tests/**/*.bats`).
- [x] New regression suites: `tests/git-auth/empty-array-guard.bats`, `tests/git-provider/pat-url.bats`.
- [x] Verified `ws diagnose` renders the scope-preselected link and `ws realm init` prints the new guidance.
- [ ] Reviewer: confirm the guarded expansion reads cleanly at each call site and the docs changes render.

## Related

- No tracker issue — surfaced live during a first-run onboarding session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `ws diagnose --no-api-check` to skip live token verification and improved identity reporting (including placeholder flags).
  * Enhanced token guidance with provider-specific PAT creation links and clearer `.env` export instructions.

* **Bug Fixes**
  * Fixed safer handling of unset auth environment variables across clone/fetch/push/pull/release flows (empty-array guards).

* **Documentation**
  * Updated newcomer onboarding and session-framing next steps; refreshed GitHub/GitLab token setup examples and guidance.

* **Tests**
  * Added/expanded suites covering PAT deep links, placeholder detection, auth-safety behavior, `ws realm init` help, and `ws diagnose` identity output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
