### PR TITLE
feat(codex): add focused workflow redirect bridge

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -2,7 +2,7 @@
 
 This directory contains a hook script that fires during Claude Code sessions in this workspace. The main hook event fires automatically — no action needed once the workspace is cloned and Claude Code is started in it. It is registered in [`../settings.json`](../settings.json) under `hooks.PreToolUse` and is meant to make agent behavior more predictable and to teach safer command patterns by giving immediate corrective feedback.
 
-**Codex uses a separate bridge, not this monolith.** The first focused Codex hook at [`.codex/hooks/gdd-k8s-hook.sh`](../../.codex/hooks/gdd-k8s-hook.sh) handles only the guarded-Kubernetes mentoring path and reuses `scripts/ws-k8s-guard.sh`; safe calls defer to normal Codex sandbox and approval routing. The [Codex project configuration](../../.codex/README.md) covers trust and troubleshooting. The remaining Claude hook pieces stay Claude-specific until each has a suitable lifecycle surface or belongs in a future platform-neutral policy engine.
+**Codex uses focused bridges, not this monolith.** Its Kubernetes bridge reuses the shared guard, and its redirect bridge consumes only `[redirect-commands]` from `hook-rules`. The remaining allow, ask, composition, adapter, scratch, PowerShell, and PermissionRequest behavior stays Claude-specific until another focused bridge or an evidence-backed shared evaluator is warranted. The [Codex project configuration](../../.codex/README.md) covers trust and troubleshooting.
 
 **New here?** [`docs/gdd/agent-training.md`](../../docs/gdd/agent-training.md) is the user-friendly companion that covers why you'll see deny output early in a session, why the discipline doesn't double API cost, and how to handle the "this legit command got denied" case. This README is the technical spec — what each tier checks, the audit log format, registration, and troubleshooting.
 
@@ -28,7 +28,7 @@ Two files drive the hook's allow/ask/deny decisions beyond the committed `settin
 
 | File | Tracked in git? | Purpose |
 |---|---|---|
-| `.claude/hooks/hook-rules` | **Yes** | Committed baseline — transparent project policy for `[scratch-dirs]` and `[ask-commands]` |
+| `.claude/hooks/hook-rules` | **Yes** | Committed baseline — transparent project policy, including shared `[redirect-commands]` rules |
 | `.claude/hooks/hook-rules.local` | **No** (gitignored) | Per-machine overrides — copy from `hook-rules.local.example` |
 
 The format is flat sectioned text: `[section]` headers, one entry per line, `#` comments, blank lines ignored.
@@ -38,6 +38,8 @@ The format is flat sectioned text: `[section]` headers, one entry per line, `#` 
 **`[scratch-dirs]`** — workspace-relative paths under which Edit/Write tool calls auto-allow. Keeps in lockstep with the "Workspace-local scratch" section of [`.gitignore`](../../.gitignore). Entries in `hook-rules.local` add to the baseline; they never replace it.
 
 **`[ask-commands]`** — glob patterns for destructive or arbitrary-execution Bash commands that should always produce a permission prompt, regardless of session mode. A match in either file triggers Tier 3 (ask) not a deny — the human approves and the command runs. `hook-rules.local` entries are additive-only: you can make more commands prompt, but you cannot remove a pattern committed in `hook-rules`. This is intentional — per-machine config can tighten the safety floor, never loosen it.
+
+**`[redirect-commands]`** — platform-neutral workflow redirects shared by the Claude hook and the focused Codex redirect bridge. Keep Bash-glob semantics and suggestion text usable in both harnesses. A valid session bypass explicitly allows in Claude and defers to normal sandbox/approval routing in Codex.
 
 **`[adapter-redirect-commands]`** — Tier 3 patterns for raw test/lint/build runners. The hook resolves the component from `$cwd` and the active realm's adapter file; wired adapters get a deny-with-bypass, missing adapters get a one-line stderr nudge and fall through. See `[adapter-redirect-commands]` in `hook-rules` for the format.
 
@@ -73,7 +75,7 @@ A deny here is a *training* signal, not a safety floor (that's Tier 4 ask). The 
 
 The recurring-bypass pattern — same slug bypassed every session — is a signal that the corresponding `ws` subcommand needs to grow that capability. Periodic `grep BYPASS-ALLOW ~/.claude/hook-audit.log` surfaces it.
 
-**Adding a new redirect.** Append a row to the `[redirect-commands]` section of `.claude/hooks/hook-rules`: `<slug> | <pattern> | <suggestion>`. The slug must match `^[a-z][a-z0-9-]*$` (start with a letter so the `ws hook-bypass [a-z]*` ask-pattern always catches a slug invocation). The pattern is a bash glob. The suggestion is free text (column 3, may contain pipes — parsing splits on the first two ` | ` only). The new slug is automatically bypassable via `ws hook-bypass <new-slug>`; no script change needed.
+**Adding a new redirect.** Append a row to the `[redirect-commands]` section of `.claude/hooks/hook-rules`: `<slug> | <pattern> | <suggestion>`. The slug must match `^[a-z][a-z0-9-]*$` (start with a letter so the `ws hook-bypass [a-z]*` ask-pattern always catches a slug invocation). The pattern is a bash glob. The suggestion is free text (column 3, may contain pipes — parsing splits on the first two ` | ` only). This section is shared by Claude and Codex, so keep its pattern and guidance platform-neutral. The new slug is automatically bypassable via `ws hook-bypass <new-slug>`; no script change needed.
 
 ### PowerShell: blocked by default
 

--- a/.claude/hooks/hook-rules
+++ b/.claude/hooks/hook-rules
@@ -54,6 +54,8 @@ git-commit   | git commit*    | Use `ws commit <comp> <bodyfile>` — handles Co
 git-push     | git push*      | Use `ws push <comp> [branch]` — handles fork-remote selection from identity.forkRemote and sets upstream on first push. `ws hook-bypass git-push` for a session-scoped bypass.
 gh-pr-create | gh pr create*  | Use `ws cr <comp> <title> <bodyfile>` — bodyfile-driven, applies identity substitutions, picks the right token + remote. `ws hook-bypass gh-pr-create` for a session-scoped bypass.
 git-mv       | git mv*        | Don't `git mv` — it pre-stages the rename and breaks `ws commit`'s bodyfile staging. Instead `mv <src> <dst>` (plain), then list BOTH the old and new paths under `add:` in your `ws commit` bodyfile; git still records a clean rename. `ws hook-bypass git-mv` for a session-scoped bypass.
+gh-cli       | gh *           | Use `ws gh <args>` — injects the workspace GH_TOKEN from .env so the command authenticates without interactive `gh auth login`. Any `gh` subcommand passes through. `ws hook-bypass gh-cli` for a session-scoped bypass.
+glab-cli     | glab *         | Use `ws glab <args>` — injects the workspace GitLab token from .env so the command authenticates without interactive login. Any `glab` subcommand passes through. `ws hook-bypass glab-cli` for a session-scoped bypass.
 
 [adapter-redirect-commands]
 # Tier 3 — raw test/lint/build runners with a ws equivalent. The hook

--- a/.codex/README.md
+++ b/.codex/README.md
@@ -2,9 +2,18 @@
 
 Yggdrasil uses this directory for Codex-specific project configuration. Workspace policy and reusable skills remain agent-neutral under `AGENTS.md` and `.agent/skills/`; this layer contains only behavior that must integrate with a Codex lifecycle surface.
 
-## Kubernetes scope-guard bridge
+## Focused PreToolUse bridges
 
-[`hooks.json`](hooks.json) registers one focused `PreToolUse` bridge for Bash calls. [`hooks/gdd-k8s-hook.sh`](hooks/gdd-k8s-hook.sh) classifies raw `kubectl`, guarded `ws k8s`, and directly invoked scripts containing `kubectl` whether or not the current GDD session has a Kubernetes scope armed.
+[`hooks.json`](hooks.json) registers two focused `PreToolUse` bridges for Bash calls:
+
+- [`hooks/gdd-k8s-hook.sh`](hooks/gdd-k8s-hook.sh) enforces the guarded-Kubernetes scope contract.
+- [`hooks/gdd-redirect-hook.sh`](hooks/gdd-redirect-hook.sh) reads the shared `[redirect-commands]` policy and redirects raw commit, push, PR-creation, and rename commands to their `ws` workflows.
+
+Both bridges deny or defer. Unrelated commands and valid redirect bypasses return no hook decision, so Codex still applies its normal sandbox, network, rules, and approval flow.
+
+### Kubernetes scope guard
+
+The Kubernetes bridge classifies raw `kubectl`, guarded `ws k8s`, and directly invoked scripts containing `kubectl` whether or not the current GDD session has a Kubernetes scope armed.
 
 Before classification, the bridge normalizes common transparent launch forms: leading environment assignments, `env`, `command`, absolute kubectl paths, shell options before a direct script, relative script paths anchored to the tool cwd, and literal kubectl inside `bash -c` or `sh -c`. It does not claim visibility into arbitrary nested execution through task runners, client libraries, Helm, or dynamically constructed command names.
 
@@ -15,11 +24,15 @@ The bridge is deny-or-defer:
 - Safe reads, guarded `ws k8s` calls, scope management, and unrelated commands return no hook decision. Codex still applies its normal sandbox, network, rules, and approval flow.
 - `ws hook-bypass k8s` lifts the unscoped write floor and raw-command interception for the current session after explicit user confirmation. It does not disable an already-armed guard inside `ws k8s`.
 
-The bridge does not import Claude's generic command allowlist, shell-composition checks, destructive-command prompts, or component adapter redirects. Those independent features remain Claude-specific until each has a suitable Codex lifecycle surface or belongs in a future platform-neutral policy engine.
+### Workflow redirects
+
+The redirect bridge reads only `[redirect-commands]` from `.claude/hooks/hook-rules` and the additive local rules file. A match returns the same corrective `ws` suggestion used by Claude. `ws hook-bypass <slug>` remains session-bound, but a valid Codex bypass defers to normal routing rather than auto-allowing the raw command.
+
+The bridges do not import Claude's generic command allowlist, shell-composition checks, destructive-command prompts, or component adapter redirects. Those independent features remain Claude-specific until each has a suitable focused bridge or an evidence-backed shared evaluator.
 
 ## Trust the hook
 
-Codex reviews project-local command hooks by content hash. After cloning this workspace or changing a hook, open `/hooks`, inspect the `.codex/hooks.json` registration and command, then trust it. Codex skips an untrusted or changed hook and prints a startup warning until it is reviewed.
+Codex reviews project-local command hooks by content hash. After cloning this workspace or changing either hook, open `/hooks`, inspect the `.codex/hooks.json` registrations and commands, then trust them. Codex skips an untrusted or changed hook and prints a startup warning until it is reviewed.
 
 The hook writes only deny, bypass, and infrastructure-warning entries to `~/.codex/hook-audit.log`. Deferred calls are already visible through normal Codex execution and are not duplicated there.
 
@@ -31,4 +44,4 @@ Set `WS_HOOK_DISABLE=1` for an emergency session-local passthrough. Managed Code
 - Run `ws k8s scope show` to inspect the scope through the supported wrapper.
 - Check `~/.codex/hook-audit.log` for deny or prerequisite-warning entries.
 - Use `/hooks` to confirm the project hook is enabled and trusted after any content change.
-- Run `ws test yggdrasil tests/hook/codex-k8s-hook.bats` to verify the focused bridge contract.
+- Run `ws test yggdrasil tests/hook/codex-k8s-hook.bats tests/hook/codex-redirect-hook.bats` to verify both focused bridge contracts.

--- a/.codex/README.md
+++ b/.codex/README.md
@@ -32,7 +32,7 @@ The bridges do not import Claude's generic command allowlist, shell-composition 
 
 ## Trust the hook
 
-Codex reviews project-local command hooks by content hash. After cloning this workspace or changing either hook, open `/hooks`, inspect the `.codex/hooks.json` registrations and commands, then trust them. Codex skips an untrusted or changed hook and prints a startup warning until it is reviewed.
+Codex reviews project-local command hooks by content hash. After cloning this workspace or changing either hook, open `/hooks`, inspect the `.codex/hooks.json` registrations and commands, then trust them. Trusting a hook there can activate it in the current session; restart Codex only if the hook does not refresh. Codex skips an untrusted or changed hook and prints a startup warning until it is reviewed.
 
 The hook writes only deny, bypass, and infrastructure-warning entries to `~/.codex/hook-audit.log`. Deferred calls are already visible through normal Codex execution and are not duplicated there.
 

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -9,6 +9,12 @@
             "command": "bash \"$(git rev-parse --show-toplevel)/.codex/hooks/gdd-k8s-hook.sh\"",
             "timeout": 30,
             "statusMessage": "Checking Kubernetes guard scope"
+          },
+          {
+            "type": "command",
+            "command": "bash \"$(git rev-parse --show-toplevel)/.codex/hooks/gdd-redirect-hook.sh\"",
+            "timeout": 30,
+            "statusMessage": "Checking GDD command redirects"
           }
         ]
       }

--- a/.codex/hooks/gdd-redirect-hook.sh
+++ b/.codex/hooks/gdd-redirect-hook.sh
@@ -55,29 +55,68 @@ normalize_for_match() {
     esac
 }
 
-[[ -f "$rules_file" ]] || exit 0
 redirect_commands=()
-section=""
-while IFS= read -r line || [[ -n "$line" ]]; do
-    line="${line%$'\r'}"
-    line="${line#"${line%%[![:space:]]*}"}"
-    line="${line%"${line##*[![:space:]]}"}"
-    [[ -z "$line" || "$line" == \#* ]] && continue
-    case "$line" in
-        "["*"]") section="${line#\[}"; section="${section%\]}"; continue ;;
-    esac
-    [[ "$section" == "redirect-commands" ]] || continue
-    [[ "$line" == *" | "* ]] || continue
-    slug="${line%% | *}"
-    rest="${line#* | }"
-    [[ "$rest" == *" | "* ]] || continue
-    pattern="${rest%% | *}"
-    suggestion="${rest#* | }"
-    slug="${slug%"${slug##*[![:space:]]}"}"
-    pattern="${pattern%"${pattern##*[![:space:]]}"}"
-    [[ "$slug" =~ ^[a-z][a-z0-9-]*$ && -n "$pattern" && -n "$suggestion" ]] || continue
-    redirect_commands+=("$slug|$pattern|$suggestion")
-done < "$rules_file"
+
+parse_redirect_rules() {
+    local file="$1"
+    [[ -f "$file" ]] || return 0
+    local section="" line slug pattern suggestion rest
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        line="${line%$'\r'}"
+        line="${line#"${line%%[![:space:]]*}"}"
+        line="${line%"${line##*[![:space:]]}"}"
+        [[ -z "$line" || "$line" == \#* ]] && continue
+        case "$line" in
+            "["*"]") section="${line#\[}"; section="${section%\]}"; continue ;;
+        esac
+        [[ "$section" == "redirect-commands" ]] || continue
+        if [[ "$line" != *" | "* ]]; then
+            audit "WARNING (hook-rules: malformed [redirect-commands] entry, missing separator): $file"
+            continue
+        fi
+        slug="${line%% | *}"
+        rest="${line#* | }"
+        if [[ "$rest" != *" | "* ]]; then
+            audit "WARNING (hook-rules: malformed [redirect-commands] entry, only two columns): $file"
+            continue
+        fi
+        pattern="${rest%% | *}"
+        suggestion="${rest#* | }"
+        slug="${slug%"${slug##*[![:space:]]}"}"
+        pattern="${pattern%"${pattern##*[![:space:]]}"}"
+        if [[ ! "$slug" =~ ^[a-z][a-z0-9-]*$ || -z "$pattern" || -z "$suggestion" ]]; then
+            audit "WARNING (hook-rules: malformed [redirect-commands] entry, invalid fields): $file"
+            continue
+        fi
+        redirect_commands+=("$slug|$pattern|$suggestion")
+    done < "$file"
+}
+
+if [[ ! -f "$rules_file" ]]; then
+    audit "PASSTHROUGH [PreToolUse] (redirect rules unavailable): $(audit_safe "$cmd")"
+    exit 0
+fi
+parse_redirect_rules "$rules_file"
+parse_redirect_rules "${GDD_REDIRECT_RULES_LOCAL_FILE:-$GDD_PROJECT_ROOT/.claude/hooks/hook-rules.local}"
+
+session_id="$("$JQ" -r '.session_id // ""' <<< "$input")"
+
+marker_field() {
+    local file="$1" key="$2" line
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        line="${line%$'\r'}"
+        case "$line" in
+            "$key="*) printf '%s' "${line#"$key="}"; return 0 ;;
+            "$key:"*)
+                line="${line#"$key:"}"
+                line="${line#"${line%%[![:space:]]*}"}"
+                printf '%s' "$line"
+                return 0
+                ;;
+        esac
+    done < "$file"
+    return 0
+}
 
 match_cmd="$(normalize_for_match "$cmd")"
 for entry in ${redirect_commands[@]+"${redirect_commands[@]}"}; do
@@ -88,6 +127,15 @@ for entry in ${redirect_commands[@]+"${redirect_commands[@]}"}; do
     match_pattern="$(normalize_for_match "$pattern")"
     # shellcheck disable=SC2053
     if [[ "$match_cmd" == $match_pattern ]]; then
+        marker="$GDD_PROJECT_ROOT/.tmp/hook-bypass/$slug.bypass"
+        if [[ -n "$session_id" && -f "$marker" ]]; then
+            marker_session_id="$(marker_field "$marker" session_id)"
+            marker_reason="$(marker_field "$marker" reason)"
+            if [[ "$marker_session_id" == "$session_id" ]]; then
+                audit "BYPASS-REDIRECT [$slug] reason=\"$(audit_safe "$marker_reason")\" [PreToolUse]: $(audit_safe "$cmd")"
+                exit 0
+            fi
+        fi
         deny "$slug" "$suggestion"
     fi
 done

--- a/.codex/hooks/gdd-redirect-hook.sh
+++ b/.codex/hooks/gdd-redirect-hook.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Focused Codex PreToolUse bridge for GDD workflow redirects.
+# Denies configured raw commands with ws guidance and defers everything else.
+set -euo pipefail
+
+input="$(cat)"
+JQ="${JQ:-jq}"
+command -v "$JQ" >/dev/null 2>&1 || exit 0
+"$JQ" -e . >/dev/null 2>&1 <<< "$input" || exit 0
+
+event="$("$JQ" -r '.hook_event_name // "PreToolUse"' <<< "$input")"
+tool_name="$("$JQ" -r '.tool_name // ""' <<< "$input")"
+cmd="$("$JQ" -r '.tool_input.command // ""' <<< "$input")"
+[[ "$event" == "PreToolUse" && "$tool_name" == "Bash" && -n "$cmd" ]] || exit 0
+[[ "${WS_HOOK_DISABLE:-0}" == "1" ]] && exit 0
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+: "${GDD_PROJECT_ROOT:="$(cd "$SCRIPT_DIR/../.." && pwd)"}"
+rules_file="${GDD_REDIRECT_RULES_FILE:-$GDD_PROJECT_ROOT/.claude/hooks/hook-rules}"
+audit_log="$HOME/.codex/hook-audit.log"
+
+audit_safe() {
+    local value="$1"
+    value="${value//$'\n'/\\n}"
+    value="${value//$'\r'/\\r}"
+    printf '%s' "$value"
+}
+
+audit() {
+    mkdir -p "$(dirname "$audit_log")"
+    printf '[%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$1" >> "$audit_log"
+}
+
+deny() {
+    local slug="$1" reason="$2"
+    audit "DENY-REDIRECT [$slug] [PreToolUse]: $(audit_safe "$cmd")"
+    "$JQ" -nc --arg reason "$reason" '{
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: $reason
+      }
+    }'
+    exit 0
+}
+
+normalize_for_match() {
+    local value="$1"
+    case "$value" in
+        "bash ./scripts/"*) printf '%s' "${value#bash ./scripts/}" ;;
+        "bash scripts/"*) printf '%s' "${value#bash scripts/}" ;;
+        "./scripts/"*) printf '%s' "${value#./scripts/}" ;;
+        "scripts/"*) printf '%s' "${value#scripts/}" ;;
+        *) printf '%s' "$value" ;;
+    esac
+}
+
+[[ -f "$rules_file" ]] || exit 0
+redirect_commands=()
+section=""
+while IFS= read -r line || [[ -n "$line" ]]; do
+    line="${line%$'\r'}"
+    line="${line#"${line%%[![:space:]]*}"}"
+    line="${line%"${line##*[![:space:]]}"}"
+    [[ -z "$line" || "$line" == \#* ]] && continue
+    case "$line" in
+        "["*"]") section="${line#\[}"; section="${section%\]}"; continue ;;
+    esac
+    [[ "$section" == "redirect-commands" ]] || continue
+    [[ "$line" == *" | "* ]] || continue
+    slug="${line%% | *}"
+    rest="${line#* | }"
+    [[ "$rest" == *" | "* ]] || continue
+    pattern="${rest%% | *}"
+    suggestion="${rest#* | }"
+    slug="${slug%"${slug##*[![:space:]]}"}"
+    pattern="${pattern%"${pattern##*[![:space:]]}"}"
+    [[ "$slug" =~ ^[a-z][a-z0-9-]*$ && -n "$pattern" && -n "$suggestion" ]] || continue
+    redirect_commands+=("$slug|$pattern|$suggestion")
+done < "$rules_file"
+
+match_cmd="$(normalize_for_match "$cmd")"
+for entry in ${redirect_commands[@]+"${redirect_commands[@]}"}; do
+    slug="${entry%%|*}"
+    rest="${entry#*|}"
+    pattern="${rest%%|*}"
+    suggestion="${rest#*|}"
+    match_pattern="$(normalize_for_match "$pattern")"
+    # shellcheck disable=SC2053
+    if [[ "$match_cmd" == $match_pattern ]]; then
+        deny "$slug" "$suggestion"
+    fi
+done
+
+exit 0

--- a/.codex/hooks/gdd-redirect-hook.sh
+++ b/.codex/hooks/gdd-redirect-hook.sh
@@ -8,7 +8,7 @@ JQ="${JQ:-jq}"
 command -v "$JQ" >/dev/null 2>&1 || exit 0
 "$JQ" -e . >/dev/null 2>&1 <<< "$input" || exit 0
 
-event="$("$JQ" -r '.hook_event_name // "PreToolUse"' <<< "$input")"
+event="$("$JQ" -r '.hook_event_name // ""' <<< "$input")"
 tool_name="$("$JQ" -r '.tool_name // ""' <<< "$input")"
 cmd="$("$JQ" -r '.tool_input.command // ""' <<< "$input")"
 [[ "$event" == "PreToolUse" && "$tool_name" == "Bash" && -n "$cmd" ]] || exit 0

--- a/docs/gdd/agent-training.md
+++ b/docs/gdd/agent-training.md
@@ -28,7 +28,7 @@ Suppressed for `orient` itself, `--help` variants, and under bats (so test outpu
 
 ### The hook as a Claude-only backstop
 
-The broad PreToolUse hook (`.claude/hooks/gdd-permission-hook.sh`) is Claude-specific — it is not a portable agent contract. Codex has one deliberately narrower bridge for the guarded-Kubernetes mentoring path; it does not inherit Claude's allowlist, shell-composition, or generic ask semantics. For Gemini CLI, Cursor, and other agents, and for every behavior not yet bridged to Codex, the load-bearing layers remain the portable ones: `AGENTS.md`'s reflex contract (read at session start), `ws orient`'s discovery menu, and the per-command footer (all `ws`-wrapped, all portable). Treat harness hooks as training and enforcement helpers rather than the workspace's safety floor.
+The broad PreToolUse hook (`.claude/hooks/gdd-permission-hook.sh`) is Claude-specific — it is not a portable agent contract. Codex has deliberately narrower bridges for guarded Kubernetes and the shared raw-command redirects; it does not inherit Claude's allowlist, shell-composition, adapter, or generic ask semantics. For Gemini CLI, Cursor, and other agents, and for every behavior not yet bridged to Codex, the load-bearing layers remain the portable ones: `AGENTS.md`'s reflex contract (read at session start), `ws orient`'s discovery menu, and the per-command footer (all `ws`-wrapped, all portable). Treat harness hooks as training and enforcement helpers rather than the workspace's safety floor.
 
 ---
 

--- a/docs/gdd/features.md
+++ b/docs/gdd/features.md
@@ -119,6 +119,8 @@ The hook is roughly free in API-token cost — splitting a `cmd | head 20` into 
 
 Per-machine extras (opt-in): if a command you trust keeps getting denied, copy `.claude/hooks/hook-rules.local.example` to `hook-rules.local` (in the same directory) and add bash glob patterns under the `[allow-extras]` section. The live file is gitignored — patterns stay per-machine and don't leak into project policy.
 
+Codex uses smaller feature bridges rather than importing the Claude hook wholesale. Its redirect bridge consumes the same `[redirect-commands]` guidance for raw commit, push, PR-creation, and rename commands; its Kubernetes bridge applies the shared guard policy. Both deny or defer, leaving unrelated and bypassed calls to normal Codex routing. These hooks improve workflow consistency but are not a security boundary.
+
 ---
 
 ## Kubernetes practice guard — `ws k8s`

--- a/docs/gdd/permissions.md
+++ b/docs/gdd/permissions.md
@@ -58,6 +58,8 @@ The Codex bridge maps the same platform-neutral classification differently becau
 
 Tier 2 of the PreToolUse hook denies a curated list of raw commands (`git commit`, `git push`, `gh pr create`, `git mv`) with a corrective message pointing at the friendlier equivalent — a training layer, not a safety floor. The session-scoped escape hatch is `ws hook-bypass <slug>`, itself ask-gated so every bypass force-prompts the human. Mechanics and the full redirect list: [`.claude/hooks/README.md`](../../.claude/hooks/README.md) § Redirect tier and bypass; the human-facing walkthrough is [Agent Training](agent-training.md#what-happens-when-you-reach-for-git-commit--git-push--gh-pr-create).
 
+Codex consumes the same `[redirect-commands]` rows through a focused deny-or-defer bridge. A match returns the same `ws` guidance. A valid session-scoped bypass removes the redirect decision but does not auto-allow the command; Codex still applies its sandbox, network, and approval routing.
+
 ### `ws commit` flags auto-approve
 
 `ws commit`, `ws whoami`, `ws test`, and `ws lint` are allowlisted by default in this workspace's `.claude/settings.json`. The `ws commit` allow patterns are:

--- a/docs/plans/2026-07-08-codex-redirect-hook-design.md
+++ b/docs/plans/2026-07-08-codex-redirect-hook-design.md
@@ -1,0 +1,196 @@
+# Focused Codex Redirect Hook Design
+
+Status: approved design
+
+## Context
+
+Yggdrasil asks agents to use `ws` wrappers for operations where the wrapper adds behavior that raw provider commands do not: commit attribution and bodyfile staging, fork-remote selection, token injection, provider selection, and review-request metadata. Claude currently reinforces that contract through the `[redirect-commands]` tier in `.claude/hooks/hook-rules`. Codex reads the same root instructions but only has a focused Kubernetes hook, so a training-data reflex can still reach raw `git commit`, `git push`, `gh pr create`, or `git mv`.
+
+Raw `git push` is the highest-cost example. It bypasses `ws push` token injection and destination selection, which can route authentication through an IDE askpass or the operating-system credential helper and produce avoidable Keychain prompts. The desired response is not a broader Codex allowlist or a port of the Claude permission monolith. It is one focused deny-or-defer hook for the existing redirect policy.
+
+## Goals
+
+- Give Codex the same corrective redirect messages for the committed `[redirect-commands]` rules.
+- Keep the hook independent from Claude's allowlist, ask tier, shell-composition policy, adapter redirects, scratch paths, and PermissionRequest behavior.
+- Preserve the existing `ws hook-bypass <slug>` escape hatch without auto-allowing the bypassed command in Codex.
+- Defer unrelated commands to Codex's normal sandbox, approval, and network handling.
+- Keep rule additions data-driven: adding a valid `[redirect-commands]` row should affect both Claude and Codex without editing either hook.
+- Use the feature as a second data point for deciding how cross-agent hook portability should evolve.
+
+## Non-Goals
+
+- Port the Claude hook wholesale.
+- Reproduce `.claude/settings.json` allow behavior in Codex.
+- Translate Claude's human-required ask tier into Codex prompt rules.
+- Handle `[adapter-redirect-commands]` or `[scoped-redirect-commands]`; those have different context and enforcement semantics.
+- Expand the current redirect rule set or invent a general Git command parser.
+- Treat redirects as a security boundary. They are a training and workflow-correctness layer; provider authorization remains authoritative.
+
+## Immediate Design
+
+### Registration and isolation
+
+Add `.codex/hooks/gdd-redirect-hook.sh` as a second command hook under the existing `PreToolUse` Bash matcher in `.codex/hooks.json`. The Kubernetes and redirect hooks remain separate executables:
+
+- The Kubernetes hook evaluates Kubernetes candidates and defers unrelated commands.
+- The redirect hook evaluates only `[redirect-commands]` candidates and defers unrelated commands.
+
+The feature sets do not overlap today. A raw Git or GitHub provider command is invisible to the Kubernetes hook; a Kubernetes command is invisible to the redirect hook. No dispatcher or cross-feature precedence layer is needed.
+
+### Input contract
+
+The redirect hook reads one JSON payload from stdin and acts only when all of the following are true:
+
+- `hook_event_name` is `PreToolUse`.
+- `tool_name` is `Bash`.
+- `tool_input.command` is non-empty.
+- `WS_HOOK_DISABLE` is not `1`.
+
+Malformed JSON, unavailable `jq`, non-Bash tools, unrelated events, and empty commands return no decision.
+
+### Rule discovery
+
+Resolve the project root from the hook's own location, following the pattern established by the focused Kubernetes hook. Read:
+
+1. `.claude/hooks/hook-rules` as the committed baseline.
+2. `.claude/hooks/hook-rules.local`, when present, as an additive per-machine layer.
+
+Although the file currently lives under `.claude/`, `[redirect-commands]` is platform-neutral policy data. Moving the entire rules file is deliberately deferred because most other sections remain Claude-specific. The Codex README and Claude hook README will state that this one section is shared.
+
+### Focused parser
+
+Parse only content inside `[redirect-commands]`. Ignore all other known or unknown sections rather than attempting to validate the whole rules file. Each redirect row has the existing shape:
+
+```text
+<slug> | <bash-glob pattern> | <suggestion text>
+```
+
+Parser behavior:
+
+- Ignore blank lines and comments.
+- Split on the first two ` | ` separators so suggestion text may contain additional pipes.
+- Trim the slug and pattern.
+- Require slug shape `^[a-z][a-z0-9-]*$`.
+- Require non-empty pattern and suggestion.
+- Skip malformed rows, write one warning to `~/.codex/hook-audit.log`, and continue parsing later rows.
+
+This small parser intentionally duplicates the format boundary instead of extracting code from the stable Claude monolith. Cross-harness parity tests, not shared implementation, guard the format in this first iteration.
+
+### Matching
+
+Normalize the command and configured pattern with the existing wrapper-path rules:
+
+- `bash ./scripts/<command>` becomes `<command>`.
+- `bash scripts/<command>` becomes `<command>`.
+- `./scripts/<command>` becomes `<command>`.
+- `scripts/<command>` becomes `<command>`.
+
+Then apply Bash glob matching exactly as the Claude redirect tier does. The hook does not broaden patterns to infer Git subcommands behind arbitrary `env`, `git -C`, `git -c`, aliases, or shell wrappers. Those can be added as explicit policy rows if real usage demonstrates a need.
+
+### Deny response
+
+When a rule matches and no bypass is active, return Codex-compatible `PreToolUse` deny JSON using the rule's suggestion as `permissionDecisionReason`. Record a concise deny entry in `~/.codex/hook-audit.log` with the slug and normalized command.
+
+The hook never emits an allow decision. A non-match simply exits successfully with no JSON output so Codex retains its normal policy path.
+
+### Session-scoped bypass
+
+For a matching slug, inspect:
+
+```text
+<project-root>/.tmp/hook-bypass/<slug>.bypass
+```
+
+Honor the bypass only when the marker's `session_id` exactly matches the hook payload's non-empty session ID. A matching bypass writes a `BYPASS-REDIRECT` audit entry and exits with no decision. This differs intentionally from Claude's explicit allow response: in Codex, bypassing the training redirect should still leave sandbox, network, and approval review intact.
+
+Missing, malformed, stale, or cross-session markers do not weaken the redirect; the command remains denied.
+
+### Failure behavior
+
+The bridge fails open only for infrastructure failures where it cannot classify the request: malformed payload, missing `jq`, missing rules file, or unreadable configuration. It audits the missing-rule or parse condition when possible. Once a valid rule matches, unexpected bypass-reading failures fail closed for that redirect and return the normal corrective deny.
+
+## Tests
+
+Add `tests/hook/codex-redirect-hook.bats` with focused cases for:
+
+- Unrelated Bash and non-Bash calls defer with no output.
+- Malformed payload and `WS_HOOK_DISABLE=1` defer.
+- Every committed redirect row denies a representative command and returns its configured suggestion.
+- Command and pattern normalization match Claude's current behavior.
+- Suggestion text containing additional pipes is preserved.
+- Malformed rows are skipped and audited without hiding later valid rows.
+- A valid local redirect is additive.
+- Matching-session bypass defers and audits; missing, malformed, stale, and mismatched markers still deny.
+- The hook never emits an allow decision.
+- `.codex/hooks.json` registers both focused hooks under Bash `PreToolUse`.
+
+Update the existing Codex Kubernetes registration assertion so it verifies coexistence rather than requiring exactly one command hook. Run both focused hook suites and the full Yggdrasil Bats suite.
+
+## Documentation
+
+Update:
+
+- `.codex/README.md` to describe the two focused bridges, trust review, audit output, and troubleshooting.
+- `.claude/hooks/README.md` to identify `[redirect-commands]` as shared policy data while the remaining monolith stays Claude-specific.
+- `docs/gdd/agent-training.md`, `docs/gdd/permissions.md`, and `docs/gdd/features.md` where they currently say Codex only has the Kubernetes bridge.
+
+Public documentation remains organization-agnostic and continues to describe redirects as workflow training, not cybersecurity enforcement.
+
+## Incremental Cross-Agent Architecture
+
+The redirect hook should not predetermine a single universal hook engine. Cross-agent support can evolve feature by feature, using the smallest sharing boundary earned by each feature.
+
+### Pattern A: fully split agent-specific scripts
+
+Claude and Codex each implement a focused feature from shared declarative policy or a shared behavioral contract. This is the starting pattern for redirects.
+
+Use it when:
+
+- The feature is small.
+- Harness output and lifecycle semantics differ materially.
+- Sharing implementation would force conditionals for each agent.
+- One implementation is already stable and changing it would add regression risk.
+
+Trade-off: parser or matching fixes may need to be applied twice. Parity tests and a narrow data format keep that cost visible.
+
+### Pattern B: shared feature evaluator with thin agent forwarders
+
+Extract one platform-neutral evaluator for a single feature, then keep tiny Claude/Codex forwarders responsible for payload decoding and decision encoding. The Kubernetes guard already approximates this pattern: `scripts/ws-k8s-guard.sh` owns the verdict while each harness bridge maps it to local behavior.
+
+Use it when:
+
+- The same classification bug or parser change has been fixed in multiple harnesses.
+- A third harness needs the feature.
+- The feature's inputs and verdicts can be expressed without harness-specific concepts.
+- Shared tests can exercise the evaluator directly.
+
+For redirects, a future evaluator might accept `(command, session_id, project_root)` and return `NO_MATCH`, `REDIRECT:<slug>:<suggestion>`, or `BYPASS:<slug>`. Agent-specific scripts would remain responsible for audit locations and hook JSON.
+
+### Pattern C: one generic policy engine
+
+A universal engine would parse all policy sections, establish cross-feature precedence, manage bypasses and audit events, and return platform-neutral verdicts for thin harness adapters.
+
+Do not build it merely to reduce file count. Consider it only when several focused features demonstrate actual shared needs such as:
+
+- Ordering conflicts between independent hooks.
+- Repeated payload normalization and audit code causing defects.
+- Three or more harnesses consuming the same policy sections.
+- A stable common verdict model spanning redirect, ask, allow, and scoped guard behavior.
+- Hook startup cost or trust review becoming meaningfully burdensome.
+
+The main risk is flattening different safety semantics into a lowest-common-denominator abstraction. Claude's force-ask behavior, Codex's deny-or-defer bridge, and provider/sandbox approvals are not interchangeable. A generic engine is useful only if it preserves those distinctions rather than hiding them.
+
+### Iteration rule
+
+Default to focused hooks. After each new cross-agent feature, review whether implementation duplication is still cheaper than abstraction. Extract a shared feature evaluator when evidence supports it; introduce a dispatcher or engine only when independent hooks need explicit ordering or common lifecycle management.
+
+This keeps portability incremental: each feature delivers value and supplies another concrete data point for the eventual architecture.
+
+## Decision Summary
+
+- Build a second focused Codex hook for `[redirect-commands]`.
+- Read the existing committed and local rule files directly.
+- Preserve exact current matching semantics and suggestions.
+- Honor session-scoped bypasses by deferring, never auto-allowing.
+- Leave the Claude monolith unchanged except for documentation and parity expectations.
+- Treat feature-by-feature bridges as the default architecture; earn shared evaluators and any wider engine through repeated evidence.

--- a/docs/superpowers/plans/2026-07-08-codex-redirect-hook.md
+++ b/docs/superpowers/plans/2026-07-08-codex-redirect-hook.md
@@ -1,0 +1,657 @@
+# Focused Codex Redirect Hook Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a focused Codex `PreToolUse` bridge that enforces the existing `[redirect-commands]` workflow guidance while deferring unrelated calls to normal Codex routing.
+
+**Architecture:** A new `.codex/hooks/gdd-redirect-hook.sh` independently decodes Codex hook payloads, reads only the shared redirect section from the existing rule files, and returns deny-or-defer decisions. It remains separate from the Kubernetes bridge and from Claude's broader permission monolith; session bypasses defer rather than auto-allow.
+
+**Tech Stack:** Bash, jq, Bats, Codex project hooks JSON, Markdown.
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|---|---|---|
+| `.codex/hooks/gdd-redirect-hook.sh` | Create | Decode Codex payloads, parse redirect rules, match commands, honor bypass markers, emit deny JSON, audit decisions. |
+| `.codex/hooks.json` | Modify | Register the redirect hook beside the existing Kubernetes hook. |
+| `tests/hook/codex-redirect-hook.bats` | Create | Focused behavior, parser, local-rule, bypass, and registration tests. |
+| `tests/hook/codex-k8s-hook.bats` | Modify | Replace the one-hook invariant with a coexistence invariant. |
+| `.codex/README.md` | Modify | Document both focused Codex bridges and trust/audit behavior. |
+| `.claude/hooks/README.md` | Modify | Identify `[redirect-commands]` as shared policy data. |
+| `docs/gdd/agent-training.md` | Modify | Replace the Kubernetes-only Codex statement with focused bridge coverage. |
+| `docs/gdd/permissions.md` | Modify | Describe Codex redirect deny-or-defer semantics and bypass behavior. |
+| `docs/gdd/features.md` | Modify | Summarize the redirect bridge alongside the Kubernetes bridge. |
+
+## Task 1: Core Redirect Matching and Registration
+
+**Files:**
+- Create: `tests/hook/codex-redirect-hook.bats`
+- Create: `.codex/hooks/gdd-redirect-hook.sh`
+- Modify: `.codex/hooks.json`
+- Modify: `tests/hook/codex-k8s-hook.bats`
+
+- [ ] **Step 1: Write the initial failing hook tests**
+
+Create `tests/hook/codex-redirect-hook.bats` with this initial content:
+
+```bash
+#!/usr/bin/env bats
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    HOOK_BIN="$REPO_ROOT/.codex/hooks/gdd-redirect-hook.sh"
+    WORK="$BATS_TEST_TMPDIR/work"
+    export HOME="$WORK/home"
+    mkdir -p "$WORK/.claude/hooks" "$WORK/.tmp/hook-bypass" "$HOME/.codex"
+    cp "$REPO_ROOT/.claude/hooks/hook-rules" "$WORK/.claude/hooks/hook-rules"
+}
+
+run_hook() {
+    local command="$1"
+    local session_id="${2:-codex-redirect-test}"
+    local tool_name="${3:-Bash}"
+    local payload
+    payload="$(jq -nc \
+        --arg sid "$session_id" \
+        --arg tool "$tool_name" \
+        --arg command "$command" \
+        --arg cwd "$WORK" \
+        '{session_id:$sid,hook_event_name:"PreToolUse",tool_name:$tool,tool_input:{command:$command},cwd:$cwd}')"
+    run env HOME="$HOME" GDD_PROJECT_ROOT="$WORK" bash "$HOOK_BIN" <<< "$payload"
+}
+
+@test "unrelated Bash command defers to normal Codex routing" {
+    run_hook 'git status'
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "non-Bash tool defers" {
+    run_hook 'git push' codex-redirect-test apply_patch
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "malformed payload defers" {
+    run env HOME="$HOME" GDD_PROJECT_ROOT="$WORK" bash "$HOOK_BIN" <<< 'not-json'
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "git push is denied with the configured ws guidance" {
+    run_hook 'git push origin topic'
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.hookSpecificOutput.permissionDecision' <<< "$output")" = "deny" ]
+    [[ "$(jq -r '.hookSpecificOutput.permissionDecisionReason' <<< "$output")" == *'Use `ws push <comp> [branch]`'* ]]
+}
+
+@test "each shipped redirect denies a representative raw command" {
+    local command slug
+    while IFS='|' read -r command slug; do
+        run_hook "$command"
+        [ "$status" -eq 0 ]
+        [ "$(jq -r '.hookSpecificOutput.permissionDecision' <<< "$output")" = "deny" ]
+        grep -q "DENY-REDIRECT \[$slug\]" "$HOME/.codex/hook-audit.log"
+    done <<'CASES'
+git commit -m test|git-commit
+git push|git-push
+gh pr create --title test|gh-pr-create
+git mv old new|git-mv
+CASES
+}
+
+@test "WS_HOOK_DISABLE bypasses redirect evaluation" {
+    local payload
+    payload='{"session_id":"codex-redirect-test","hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"git push"}}'
+    run env HOME="$HOME" GDD_PROJECT_ROOT="$WORK" WS_HOOK_DISABLE=1 bash "$HOOK_BIN" <<< "$payload"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+```
+
+- [ ] **Step 2: Run the new tests and verify RED**
+
+Run:
+
+```bash
+ws test yggdrasil tests/hook/codex-redirect-hook.bats
+```
+
+Expected: FAIL because `.codex/hooks/gdd-redirect-hook.sh` does not exist and redirect assertions receive no valid deny response.
+
+- [ ] **Step 3: Create the minimal core hook**
+
+Create `.codex/hooks/gdd-redirect-hook.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Focused Codex PreToolUse bridge for GDD workflow redirects.
+# Denies configured raw commands with ws guidance and defers everything else.
+set -euo pipefail
+
+input="$(cat)"
+JQ="${JQ:-jq}"
+command -v "$JQ" >/dev/null 2>&1 || exit 0
+"$JQ" -e . >/dev/null 2>&1 <<< "$input" || exit 0
+
+event="$("$JQ" -r '.hook_event_name // "PreToolUse"' <<< "$input")"
+tool_name="$("$JQ" -r '.tool_name // ""' <<< "$input")"
+cmd="$("$JQ" -r '.tool_input.command // ""' <<< "$input")"
+[[ "$event" == "PreToolUse" && "$tool_name" == "Bash" && -n "$cmd" ]] || exit 0
+[[ "${WS_HOOK_DISABLE:-0}" == "1" ]] && exit 0
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+: "${GDD_PROJECT_ROOT:="$(cd "$SCRIPT_DIR/../.." && pwd)"}"
+rules_file="${GDD_REDIRECT_RULES_FILE:-$GDD_PROJECT_ROOT/.claude/hooks/hook-rules}"
+audit_log="$HOME/.codex/hook-audit.log"
+
+audit_safe() {
+    local value="$1"
+    value="${value//$'\n'/\\n}"
+    value="${value//$'\r'/\\r}"
+    printf '%s' "$value"
+}
+
+audit() {
+    mkdir -p "$(dirname "$audit_log")"
+    printf '[%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$1" >> "$audit_log"
+}
+
+deny() {
+    local slug="$1" reason="$2"
+    audit "DENY-REDIRECT [$slug] [PreToolUse]: $(audit_safe "$cmd")"
+    "$JQ" -nc --arg reason "$reason" '{
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: $reason
+      }
+    }'
+    exit 0
+}
+
+normalize_for_match() {
+    local value="$1"
+    case "$value" in
+        "bash ./scripts/"*) printf '%s' "${value#bash ./scripts/}" ;;
+        "bash scripts/"*) printf '%s' "${value#bash scripts/}" ;;
+        "./scripts/"*) printf '%s' "${value#./scripts/}" ;;
+        "scripts/"*) printf '%s' "${value#scripts/}" ;;
+        *) printf '%s' "$value" ;;
+    esac
+}
+
+[[ -f "$rules_file" ]] || exit 0
+redirect_commands=()
+section=""
+while IFS= read -r line || [[ -n "$line" ]]; do
+    line="${line%$'\r'}"
+    line="${line#"${line%%[![:space:]]*}"}"
+    line="${line%"${line##*[![:space:]]}"}"
+    [[ -z "$line" || "$line" == \#* ]] && continue
+    case "$line" in
+        "["*"]") section="${line#\[}"; section="${section%\]}"; continue ;;
+    esac
+    [[ "$section" == "redirect-commands" ]] || continue
+    [[ "$line" == *" | "* ]] || continue
+    slug="${line%% | *}"
+    rest="${line#* | }"
+    [[ "$rest" == *" | "* ]] || continue
+    pattern="${rest%% | *}"
+    suggestion="${rest#* | }"
+    slug="${slug%"${slug##*[![:space:]]}"}"
+    pattern="${pattern%"${pattern##*[![:space:]]}"}"
+    [[ "$slug" =~ ^[a-z][a-z0-9-]*$ && -n "$pattern" && -n "$suggestion" ]] || continue
+    redirect_commands+=("$slug|$pattern|$suggestion")
+done < "$rules_file"
+
+match_cmd="$(normalize_for_match "$cmd")"
+for entry in ${redirect_commands[@]+"${redirect_commands[@]}"}; do
+    slug="${entry%%|*}"
+    rest="${entry#*|}"
+    pattern="${rest%%|*}"
+    suggestion="${rest#*|}"
+    match_pattern="$(normalize_for_match "$pattern")"
+    # shellcheck disable=SC2053
+    if [[ "$match_cmd" == $match_pattern ]]; then
+        deny "$slug" "$suggestion"
+    fi
+done
+
+exit 0
+```
+
+Make it executable:
+
+```bash
+chmod +x .codex/hooks/gdd-redirect-hook.sh
+```
+
+- [ ] **Step 4: Register the second focused hook**
+
+Change `.codex/hooks.json` so the existing matcher has two command hooks:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "^Bash$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$(git rev-parse --show-toplevel)/.codex/hooks/gdd-k8s-hook.sh\"",
+            "timeout": 30,
+            "statusMessage": "Checking Kubernetes guard scope"
+          },
+          {
+            "type": "command",
+            "command": "bash \"$(git rev-parse --show-toplevel)/.codex/hooks/gdd-redirect-hook.sh\"",
+            "timeout": 30,
+            "statusMessage": "Checking GDD command redirects"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+- [ ] **Step 5: Update the Kubernetes registration invariant**
+
+Replace the registration test at the end of `tests/hook/codex-k8s-hook.bats` with:
+
+```bash
+@test "Codex registration contains both focused Bash PreToolUse bridges" {
+    run jq -e '
+        .hooks.PreToolUse
+        | length == 1
+          and .[0].matcher == "^Bash$"
+          and (.[0].hooks | length == 2)
+          and any(.[0].hooks[]; .command | contains(".codex/hooks/gdd-k8s-hook.sh"))
+          and any(.[0].hooks[]; .command | contains(".codex/hooks/gdd-redirect-hook.sh"))
+    ' "$REPO_ROOT/.codex/hooks.json"
+    [ "$status" -eq 0 ]
+
+    run jq -e '.hooks | has("PermissionRequest") | not' "$REPO_ROOT/.codex/hooks.json"
+    [ "$status" -eq 0 ]
+}
+```
+
+- [ ] **Step 6: Run both focused hook suites and verify GREEN**
+
+Run:
+
+```bash
+ws test yggdrasil tests/hook/codex-redirect-hook.bats tests/hook/codex-k8s-hook.bats
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 7: Commit the core hook**
+
+Create `.commits/codex-redirect-hook-core.md` using `templates/commit.md` with:
+
+```yaml
+---
+message: "feat(codex): add focused workflow redirect hook"
+add:
+  - .codex/hooks/gdd-redirect-hook.sh
+  - .codex/hooks.json
+  - tests/hook/codex-redirect-hook.bats
+  - tests/hook/codex-k8s-hook.bats
+---
+```
+
+Body: `Add a deny-or-defer Codex bridge for the committed redirect-command policy while keeping the Kubernetes bridge independent.`
+
+Run:
+
+```bash
+ws commit yggdrasil .commits/codex-redirect-hook-core.md
+```
+
+Expected: one commit containing the core bridge, registration, and initial tests.
+
+## Task 2: Parser Diagnostics, Local Rules, and Session Bypass
+
+**Files:**
+- Modify: `tests/hook/codex-redirect-hook.bats`
+- Modify: `.codex/hooks/gdd-redirect-hook.sh`
+
+- [ ] **Step 1: Append failing edge and bypass tests**
+
+Append to `tests/hook/codex-redirect-hook.bats`:
+
+```bash
+@test "suggestion text may contain additional pipes" {
+    cat > "$WORK/.claude/hooks/hook-rules" <<'RULES'
+[redirect-commands]
+custom | custom raw* | Use `ws custom` | keep this suffix.
+RULES
+    run_hook 'custom raw input'
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.hookSpecificOutput.permissionDecisionReason' <<< "$output")" = 'Use `ws custom` | keep this suffix.' ]
+}
+
+@test "malformed redirect rows are audited and later valid rows still work" {
+    cat > "$WORK/.claude/hooks/hook-rules" <<'RULES'
+[redirect-commands]
+missing separators
+bad_slug | bad* | invalid slug
+valid | valid raw* | Use `ws valid`.
+RULES
+    run_hook 'valid raw input'
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.hookSpecificOutput.permissionDecision' <<< "$output")" = "deny" ]
+    grep -q 'malformed \[redirect-commands\]' "$HOME/.codex/hook-audit.log"
+}
+
+@test "missing baseline rules defer and audit the infrastructure gap" {
+    rm "$WORK/.claude/hooks/hook-rules"
+    run_hook 'git push'
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+    grep -q 'redirect rules unavailable' "$HOME/.codex/hook-audit.log"
+}
+
+@test "command and pattern normalization match wrapper-path forms" {
+    cat > "$WORK/.claude/hooks/hook-rules" <<'RULES'
+[redirect-commands]
+custom | scripts/custom raw* | Use `ws custom`.
+RULES
+    run_hook 'bash scripts/custom raw input'
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.hookSpecificOutput.permissionDecisionReason' <<< "$output")" = 'Use `ws custom`.' ]
+}
+
+@test "hook-rules.local adds a redirect" {
+    cat > "$WORK/.claude/hooks/hook-rules.local" <<'RULES'
+[redirect-commands]
+local-tool | local-tool raw* | Use `ws local-tool`.
+RULES
+    run_hook 'local-tool raw input'
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.hookSpecificOutput.permissionDecisionReason' <<< "$output")" = 'Use `ws local-tool`.' ]
+}
+
+@test "matching-session bypass defers without emitting allow" {
+    cat > "$WORK/.tmp/hook-bypass/git-push.bypass" <<'MARKER'
+session_id: codex-redirect-test
+reason: provider debugging
+MARKER
+    run_hook 'git push'
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+    grep -q 'BYPASS-REDIRECT \[git-push\]' "$HOME/.codex/hook-audit.log"
+}
+
+@test "mismatched-session bypass still denies" {
+    cat > "$WORK/.tmp/hook-bypass/git-push.bypass" <<'MARKER'
+session_id: another-session
+reason: wrong owner
+MARKER
+    run_hook 'git push'
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.hookSpecificOutput.permissionDecision' <<< "$output")" = "deny" ]
+}
+
+@test "malformed bypass marker still denies" {
+    printf '%s\n' 'reason: missing session' > "$WORK/.tmp/hook-bypass/git-push.bypass"
+    run_hook 'git push'
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.hookSpecificOutput.permissionDecision' <<< "$output")" = "deny" ]
+}
+```
+
+- [ ] **Step 2: Run the focused tests and verify RED**
+
+Run:
+
+```bash
+ws test yggdrasil tests/hook/codex-redirect-hook.bats
+```
+
+Expected: local-rule and bypass tests fail; malformed-row audit assertion fails.
+
+- [ ] **Step 3: Replace parsing with a diagnostic additive parser**
+
+In `.codex/hooks/gdd-redirect-hook.sh`, replace the single-file parsing block with:
+
+```bash
+redirect_commands=()
+
+parse_redirect_rules() {
+    local file="$1"
+    [[ -f "$file" ]] || return 0
+    local section="" line slug pattern suggestion rest
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        line="${line%$'\r'}"
+        line="${line#"${line%%[![:space:]]*}"}"
+        line="${line%"${line##*[![:space:]]}"}"
+        [[ -z "$line" || "$line" == \#* ]] && continue
+        case "$line" in
+            "["*"]") section="${line#\[}"; section="${section%\]}"; continue ;;
+        esac
+        [[ "$section" == "redirect-commands" ]] || continue
+        if [[ "$line" != *" | "* ]]; then
+            audit "WARNING (hook-rules: malformed [redirect-commands] entry, missing separator): $file"
+            continue
+        fi
+        slug="${line%% | *}"
+        rest="${line#* | }"
+        if [[ "$rest" != *" | "* ]]; then
+            audit "WARNING (hook-rules: malformed [redirect-commands] entry, only two columns): $file"
+            continue
+        fi
+        pattern="${rest%% | *}"
+        suggestion="${rest#* | }"
+        slug="${slug%"${slug##*[![:space:]]}"}"
+        pattern="${pattern%"${pattern##*[![:space:]]}"}"
+        if [[ ! "$slug" =~ ^[a-z][a-z0-9-]*$ || -z "$pattern" || -z "$suggestion" ]]; then
+            audit "WARNING (hook-rules: malformed [redirect-commands] entry, invalid fields): $file"
+            continue
+        fi
+        redirect_commands+=("$slug|$pattern|$suggestion")
+    done < "$file"
+}
+
+if [[ ! -f "$rules_file" ]]; then
+    audit "PASSTHROUGH [PreToolUse] (redirect rules unavailable): $(audit_safe "$cmd")"
+    exit 0
+fi
+parse_redirect_rules "$rules_file"
+parse_redirect_rules "${GDD_REDIRECT_RULES_LOCAL_FILE:-$GDD_PROJECT_ROOT/.claude/hooks/hook-rules.local}"
+```
+
+- [ ] **Step 4: Add marker-field parsing and bypass handling**
+
+Before the matching loop, add:
+
+```bash
+session_id="$("$JQ" -r '.session_id // ""' <<< "$input")"
+
+marker_field() {
+    local file="$1" key="$2" line
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        line="${line%$'\r'}"
+        case "$line" in
+            "$key="*) printf '%s' "${line#"$key="}"; return 0 ;;
+            "$key:"*)
+                line="${line#"$key:"}"
+                line="${line#"${line%%[![:space:]]*}"}"
+                printf '%s' "$line"
+                return 0
+                ;;
+        esac
+    done < "$file"
+}
+```
+
+Inside the matching branch, before `deny`, add:
+
+```bash
+marker="$GDD_PROJECT_ROOT/.tmp/hook-bypass/$slug.bypass"
+if [[ -n "$session_id" && -f "$marker" ]]; then
+    marker_session_id="$(marker_field "$marker" session_id)"
+    marker_reason="$(marker_field "$marker" reason)"
+    if [[ "$marker_session_id" == "$session_id" ]]; then
+        audit "BYPASS-REDIRECT [$slug] reason=\"$(audit_safe "$marker_reason")\" [PreToolUse]: $(audit_safe "$cmd")"
+        exit 0
+    fi
+fi
+```
+
+- [ ] **Step 5: Run the focused tests and verify GREEN**
+
+Run:
+
+```bash
+ws test yggdrasil tests/hook/codex-redirect-hook.bats
+```
+
+Expected: all redirect-hook tests pass with no Bats warnings.
+
+- [ ] **Step 6: Run both Codex hook suites**
+
+Run:
+
+```bash
+ws test yggdrasil tests/hook/codex-redirect-hook.bats tests/hook/codex-k8s-hook.bats
+```
+
+Expected: all tests pass; the independent hooks do not change each other's behavior.
+
+- [ ] **Step 7: Commit parser and bypass behavior**
+
+Create `.commits/codex-redirect-hook-bypass.md` with:
+
+```yaml
+---
+message: "fix(codex): harden redirect rules and bypass handling"
+add:
+  - .codex/hooks/gdd-redirect-hook.sh
+  - tests/hook/codex-redirect-hook.bats
+---
+```
+
+Body: `Add additive local rules, malformed-row diagnostics, pipe-preserving suggestions, and session-bound bypass deferral without weakening normal Codex approvals.`
+
+Run:
+
+```bash
+ws commit yggdrasil .commits/codex-redirect-hook-bypass.md
+```
+
+## Task 3: Documentation and Full Verification
+
+**Files:**
+- Modify: `.codex/README.md`
+- Modify: `.claude/hooks/README.md`
+- Modify: `docs/gdd/agent-training.md`
+- Modify: `docs/gdd/permissions.md`
+- Modify: `docs/gdd/features.md`
+
+- [ ] **Step 1: Update the Codex bridge inventory**
+
+In `.codex/README.md`, replace the Kubernetes-only opening with:
+
+```markdown
+[`hooks.json`](hooks.json) registers two focused `PreToolUse` bridges for Bash calls:
+
+- [`hooks/gdd-k8s-hook.sh`](hooks/gdd-k8s-hook.sh) enforces the guarded-Kubernetes scope contract.
+- [`hooks/gdd-redirect-hook.sh`](hooks/gdd-redirect-hook.sh) reads the shared `[redirect-commands]` policy and redirects raw commit, push, PR-creation, and rename commands to their `ws` workflows.
+
+Both bridges deny or defer. Unrelated commands and valid redirect bypasses return no hook decision, so Codex still applies its normal sandbox, network, rules, and approval flow.
+```
+
+Add troubleshooting bullets naming `~/.codex/hook-audit.log`, `/hooks` trust review after either hook changes, and `ws test yggdrasil tests/hook/codex-redirect-hook.bats`.
+
+- [ ] **Step 2: Mark redirect rules as shared policy data**
+
+In `.claude/hooks/README.md`, replace the statement that Codex only has a Kubernetes bridge with:
+
+```markdown
+**Codex uses focused bridges, not this monolith.** Its Kubernetes bridge reuses the shared guard, and its redirect bridge consumes only `[redirect-commands]` from `hook-rules`. The remaining allow, ask, composition, adapter, scratch, PowerShell, and PermissionRequest behavior stays Claude-specific until another focused bridge or an evidence-backed shared evaluator is warranted.
+```
+
+In the `[redirect-commands]` documentation, add: `This section is shared by the Claude hook and the focused Codex redirect bridge; keep its glob semantics and suggestion text platform-neutral.`
+
+- [ ] **Step 3: Update public GDD docs**
+
+Apply these content changes without adding organization-specific terminology:
+
+- `docs/gdd/agent-training.md`: state that Codex has focused Kubernetes and redirect bridges, while allow/ask/composition behavior remains Claude-only.
+- `docs/gdd/permissions.md`: explain that a Codex redirect match denies with the same `ws` guidance; a valid session bypass defers to normal Codex routing rather than auto-allowing.
+- `docs/gdd/features.md`: list the redirect bridge as a focused cross-harness training feature and retain the statement that hooks are not a security boundary.
+
+- [ ] **Step 4: Run focused documentation-adjacent tests**
+
+Run:
+
+```bash
+ws test yggdrasil tests/hook/codex-redirect-hook.bats tests/hook/codex-k8s-hook.bats tests/hook/gdd-permission-hook.bats
+```
+
+Expected: all focused hook tests pass.
+
+- [ ] **Step 5: Run the full suite**
+
+Run:
+
+```bash
+ws test yggdrasil
+```
+
+Expected: all Bats tests pass.
+
+- [ ] **Step 6: Run static verification**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no output and exit status 0.
+
+Run:
+
+```bash
+jq -e . .codex/hooks.json
+```
+
+Expected: normalized JSON output and exit status 0.
+
+- [ ] **Step 7: Commit documentation**
+
+Create `.commits/codex-redirect-hook-docs.md` with:
+
+```yaml
+---
+message: "docs(codex): document focused redirect parity"
+add:
+  - .codex/README.md
+  - .claude/hooks/README.md
+  - docs/gdd/agent-training.md
+  - docs/gdd/permissions.md
+  - docs/gdd/features.md
+---
+```
+
+Body: `Document the two focused Codex bridges, shared redirect policy, bypass deferral semantics, and the remaining boundary around Claude-specific permission behavior.`
+
+Run:
+
+```bash
+ws commit yggdrasil .commits/codex-redirect-hook-docs.md
+```
+
+## Final Verification
+
+- [ ] Run `ws log yggdrasil` and confirm the branch contains the design, plan, core hook, hardening, and documentation commits.
+- [ ] Run `git status --short --branch` and confirm the worktree is clean.
+- [ ] Re-run `ws test yggdrasil` if any file changed after the recorded full-suite run.
+- [ ] Do not push or open a CR until the human reviews the completed local commit stack.

--- a/docs/superpowers/plans/2026-07-09-pr-126-review-fixes.md
+++ b/docs/superpowers/plans/2026-07-09-pr-126-review-fixes.md
@@ -1,0 +1,77 @@
+# PR 126 Review Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Resolve four verified review findings in the Codex redirect and Kubernetes context-only scope behavior.
+
+**Architecture:** Tighten validation at the two existing boundaries: Codex payload admission and Kubernetes scope normalization. Keep `*` as the single context-only representation and preserve all downstream guard decisions through existing helpers.
+
+**Tech Stack:** Bash, jq, Bats
+
+---
+
+### Task 1: Add regression coverage
+
+**Files:**
+- Modify: `tests/hook/codex-redirect-hook.bats`
+- Modify: `tests/ws-k8s/wrapper.bats`
+
+- [ ] **Step 1: Add a missing-event test**
+
+Add a parseable Bash payload with no `hook_event_name` and assert the redirect hook emits no decision.
+
+- [ ] **Step 2: Add Kubernetes normalization tests**
+
+Assert `alice-sandbox,*` displays as context-only, `all` remains a literal namespace, and context-only scope permits named namespace create and delete operations.
+
+- [ ] **Step 3: Verify the tests fail for the intended reasons**
+
+Run: `ws test yggdrasil tests/hook/codex-redirect-hook.bats tests/ws-k8s/wrapper.bats`
+
+Expected: the missing-event payload is denied, mixed wildcard output is not canonical, `all` displays as context-only, and namespace lifecycle coverage passes against the existing intended behavior.
+
+### Task 2: Tighten the implementation and docs
+
+**Files:**
+- Modify: `.codex/hooks/gdd-redirect-hook.sh`
+- Modify: `scripts/ws-k8s.sh`
+- Modify: `docs/tutorials/guarded-kubernetes.md`
+
+- [ ] **Step 1: Require the explicit hook event**
+
+Change the jq fallback for `hook_event_name` from `PreToolUse` to the empty string.
+
+- [ ] **Step 2: Canonicalize wildcard scope**
+
+Reuse `_k8s_ns_in_csv` to detect a `*` element and normalize the namespace CSV to the `*` sentinel. Do not treat `all` specially.
+
+- [ ] **Step 3: Update user-facing guidance**
+
+Remove `--namespace all` as a context-only alias from usage, help, and tutorial text.
+
+- [ ] **Step 4: Verify focused and full behavior**
+
+Run: `ws test yggdrasil tests/hook/codex-redirect-hook.bats tests/ws-k8s/wrapper.bats tests/hook/codex-k8s-hook.bats`
+
+Expected: all focused tests pass.
+
+Run: `ws test yggdrasil`
+
+Expected: all workspace tests pass.
+
+### Task 3: Publish the review fix
+
+**Files:**
+- Create: `.commits/pr-126-review-fixes.md`
+
+- [ ] **Step 1: Verify repository state**
+
+Run `git diff --check` and `ws status yggdrasil`; expect no formatting defects and only the intended files changed.
+
+- [ ] **Step 2: Commit once**
+
+Use `ws commit yggdrasil .commits/pr-126-review-fixes.md` with every implementation, test, doc, design, and plan file listed in the bodyfile.
+
+- [ ] **Step 3: Push to GitHub**
+
+Run `ws push yggdrasil --remote siliconsaga feat/codex-redirect-hook` and verify the existing PR branch updates.

--- a/docs/superpowers/plans/2026-07-09-pr-126-review-fixes.md
+++ b/docs/superpowers/plans/2026-07-09-pr-126-review-fixes.md
@@ -28,7 +28,7 @@ Assert `alice-sandbox,*` displays as context-only, `all` remains a literal names
 
 Run: `ws test yggdrasil tests/hook/codex-redirect-hook.bats tests/ws-k8s/wrapper.bats`
 
-Expected: the missing-event payload is denied, mixed wildcard output is not canonical, `all` displays as context-only, and namespace lifecycle coverage passes against the existing intended behavior.
+Expected RED: the command fails because the missing-event payload defers instead of being denied, mixed wildcard output is not canonical, and `all` remains a literal namespace instead of being treated as context-only; namespace lifecycle coverage passes against the existing intended behavior.
 
 ### Task 2: Tighten the implementation and docs
 

--- a/docs/superpowers/specs/2026-07-09-pr-126-review-fixes-design.md
+++ b/docs/superpowers/specs/2026-07-09-pr-126-review-fixes-design.md
@@ -1,0 +1,16 @@
+# PR 126 Review Fixes Design
+
+## Scope
+
+Address four verified review findings without widening the focused Codex redirect or Kubernetes guard designs.
+
+## Behavior
+
+- The Codex redirect bridge requires an explicit `hook_event_name: PreToolUse`; a parseable payload with no event defers.
+- Kubernetes context-only scope is represented only by the canonical `*` sentinel. Omitting `--namespace`, passing `--namespace '*'`, or including `*` in a namespace CSV normalizes to that sentinel.
+- `--namespace all` targets the literal, valid Kubernetes namespace named `all`.
+- Context-only scope continues to authorize named namespace create/delete operations while retaining context and cluster-scoped protections.
+
+## Validation
+
+Add regression tests before implementation for the missing hook event, mixed wildcard normalization, literal `all`, and context-only namespace lifecycle path. Run the focused redirect and Kubernetes suites, then the full Yggdrasil suite.

--- a/docs/tutorials/guarded-kubernetes.md
+++ b/docs/tutorials/guarded-kubernetes.md
@@ -71,6 +71,17 @@ The scope lives in a per-session file, not your kubeconfig. `ws k8s scope clear`
 
 > **Scope changes require a session ID.** `ws k8s scope set` writes to a session-scoped file and will fail without one. In a standalone terminal this means asking your agent to run the command — the error message will say so. Advanced users can export `GDD_SESSION_ID` directly to run scope commands outside the harness.
 
+#### Context-only scope (pin the cluster, free up the namespaces)
+
+On a throwaway local cluster where you're doing deep infra testing across a dozen namespaces that come and go, per-namespace scoping is constant friction. There, the safety that matters is pinning the **context** (don't accidentally hit prod), not enumerating namespaces. Arm a **context-only** scope by omitting `--namespace` (or passing `--namespace '*'` / `--namespace all`):
+
+```bash
+ws k8s scope set --context <ctx>            # context-only; all namespaces in scope for writes
+ws k8s scope set --context <ctx> --namespace '*'   # equivalent (quote the * so the shell can't expand it)
+```
+
+`ws k8s scope show` reports `namespaces: (all — context-only)`. Writes to *any* namespace are allowed — there's no per-namespace rejection. The context-pin protections are unchanged: a command with an explicit different `--context` is still rejected, and context-mutating (`kubectl config use-context …`), cluster-scoped (nodes, CRDs, `clusterrole`, …), and `--all-namespaces` writes are still blocked exactly as in a namespaced scope. To go back to per-namespace scoping, just re-arm with an explicit `--namespace <ns[,ns]>` list (it overwrites).
+
 **That's the setup.** From here on, every `ws k8s …` command is checked against this scope.
 
 ---

--- a/docs/tutorials/guarded-kubernetes.md
+++ b/docs/tutorials/guarded-kubernetes.md
@@ -73,7 +73,7 @@ The scope lives in a per-session file, not your kubeconfig. `ws k8s scope clear`
 
 #### Context-only scope (pin the cluster, free up the namespaces)
 
-On a throwaway local cluster where you're doing deep infra testing across a dozen namespaces that come and go, per-namespace scoping is constant friction. There, the safety that matters is pinning the **context** (don't accidentally hit prod), not enumerating namespaces. Arm a **context-only** scope by omitting `--namespace` (or passing `--namespace '*'` / `--namespace all`):
+On a throwaway local cluster where you're doing deep infra testing across a dozen namespaces that come and go, per-namespace scoping is constant friction. There, the safety that matters is pinning the **context** (don't accidentally hit prod), not enumerating namespaces. Arm a **context-only** scope by omitting `--namespace` or including `*` in the namespace list:
 
 ```bash
 ws k8s scope set --context <ctx>            # context-only; all namespaces in scope for writes

--- a/scripts/ws-k8s-guard.sh
+++ b/scripts/ws-k8s-guard.sh
@@ -155,9 +155,15 @@ _k8s_is_namespace_type() {
 }
 
 # Membership test: is $1 one of the comma-separated namespaces in $2?
+# A `*` element is the context-only (all-namespaces) sentinel: it matches ANY
+# namespace, so a context-only scope treats every namespace as in scope for
+# writes. See _k8s_scope, `ws k8s scope set` with no --namespace.
 _k8s_ns_in_csv() {
     local nm="$1" one; local -a arr; IFS=',' read -ra arr <<< "$2"
-    for one in "${arr[@]}"; do [[ "$one" == "$nm" ]] && return 0; done
+    for one in "${arr[@]}"; do
+        [[ "$one" == "*" ]] && return 0
+        [[ "$one" == "$nm" ]] && return 0
+    done
     return 1
 }
 
@@ -353,12 +359,9 @@ k8s_guard_evaluate() {
         target_ns="$("${KUBECTL:-kubectl}" config view --minify --context "$scope_ctx" -o 'jsonpath={..namespace}' 2>/dev/null)"
         [[ -z "$target_ns" ]] && target_ns="default"
     fi
-    local ns
-    local -a _scope_ns  # Fix B: declare local to avoid caller-scope leak
-    IFS=',' read -ra _scope_ns <<< "$scope_ns_csv"
-    for ns in "${_scope_ns[@]}"; do
-        [[ "$ns" == "$target_ns" ]] && { printf 'WRITE_IN_SCOPE'; return 0; }
-    done
+    # Membership via _k8s_ns_in_csv so a context-only `*` scope accepts any
+    # target namespace (all namespaces in scope for writes).
+    _k8s_ns_in_csv "$target_ns" "$scope_ns_csv" && { printf 'WRITE_IN_SCOPE'; return 0; }
     printf 'BLOCK:scope:write target namespace %s is outside the guard scope (%s)' "$target_ns" "$scope_ns_csv"
 }
 

--- a/scripts/ws-k8s.sh
+++ b/scripts/ws-k8s.sh
@@ -32,15 +32,15 @@ _k8s_scope() {
                     ns="$2"; ns_given=1; shift 2 ;;
                 *) echo "ERROR: unknown arg '$1'" >&2; return 1 ;;
             esac; done
-            [[ -n "$ctx" ]] || { echo "Usage: ws k8s scope set --context <c> [--namespace <n[,n]>]  (omit --namespace, or pass '*'/all, for a context-only scope)" >&2; return 1; }
-            # Context-only scope: no --namespace given, or an explicit '*'/all
-            # wildcard. Pins the context but leaves ALL namespaces in scope for
+            [[ -n "$ctx" ]] || { echo "Usage: ws k8s scope set --context <c> [--namespace <n[,n]>]  (omit --namespace, or include '*', for a context-only scope)" >&2; return 1; }
+            # Context-only scope: no --namespace given, or a namespace CSV with
+            # a '*' element. Pins the context but leaves ALL namespaces in scope for
             # writes — for a throwaway cluster doing deep infra testing across a
             # dozen dynamically-created namespaces, where per-namespace scoping is
             # constant friction and pinning the context is the safety that matters.
             # Stored as the sentinel '*' in GDD_K8S_NAMESPACES; the guard's
             # _k8s_ns_in_csv treats '*' as matching any namespace.
-            if [[ $ns_given -eq 0 || "$ns" == "*" || "$ns" == "all" ]]; then ns="*"; fi
+            if [[ $ns_given -eq 0 ]] || _k8s_ns_in_csv "*" "$ns"; then ns="*"; fi
             "$KUBECTL" config get-contexts "$ctx" >/dev/null 2>&1 || { echo "ERROR: context '$ctx' not found." >&2; return 1; }
             # The context must exist (you can't create a kube context through the
             # guard). A namespace, though, may legitimately not exist yet: arming
@@ -128,7 +128,7 @@ Scope management:
   ws k8s scope show                                        print the armed scope
   ws k8s scope clear                                       disarm
 
-Context-only scope (no --namespace, or --namespace '*'/all): pins the context
+Context-only scope (no --namespace, or a namespace list containing '*'): pins the context
 but leaves ALL namespaces in scope for writes — no per-namespace rejection.
 Handy for a throwaway cluster doing infra testing across many dynamic
 namespaces. Context-pin protections still apply (a different --context and

--- a/scripts/ws-k8s.sh
+++ b/scripts/ws-k8s.sh
@@ -15,40 +15,58 @@ _k8s_scope() {
     case "$sub" in
         show)
             local c n; c="$(ws_session_get GDD_K8S_CONTEXT)"; n="$(ws_session_get GDD_K8S_NAMESPACES)"
-            if [[ -n "$c" ]]; then echo "context: $c"; echo "namespaces: $n"; else echo "scope: none"; fi ;;
+            if [[ -n "$c" ]]; then
+                echo "context: $c"
+                if [[ "$n" == "*" ]]; then echo "namespaces: (all — context-only)"; else echo "namespaces: $n"; fi
+            else echo "scope: none"; fi ;;
         clear)
             ws_session_set GDD_K8S_CONTEXT ""; ws_session_set GDD_K8S_NAMESPACES ""; echo "guard scope cleared" ;;
         set)
-            local ctx="" ns=""
+            local ctx="" ns="" ns_given=0
             while [[ $# -gt 0 ]]; do case "$1" in
                 --context)
                     [[ $# -ge 2 && -n "${2:-}" ]] || { echo "ERROR: --context requires a value" >&2; return 1; }
                     ctx="$2"; shift 2 ;;
                 --namespace)
                     [[ $# -ge 2 && -n "${2:-}" ]] || { echo "ERROR: --namespace requires a value" >&2; return 1; }
-                    ns="$2"; shift 2 ;;
+                    ns="$2"; ns_given=1; shift 2 ;;
                 *) echo "ERROR: unknown arg '$1'" >&2; return 1 ;;
             esac; done
-            [[ -n "$ctx" && -n "$ns" ]] || { echo "Usage: ws k8s scope set --context <c> --namespace <n[,n]>" >&2; return 1; }
+            [[ -n "$ctx" ]] || { echo "Usage: ws k8s scope set --context <c> [--namespace <n[,n]>]  (omit --namespace, or pass '*'/all, for a context-only scope)" >&2; return 1; }
+            # Context-only scope: no --namespace given, or an explicit '*'/all
+            # wildcard. Pins the context but leaves ALL namespaces in scope for
+            # writes — for a throwaway cluster doing deep infra testing across a
+            # dozen dynamically-created namespaces, where per-namespace scoping is
+            # constant friction and pinning the context is the safety that matters.
+            # Stored as the sentinel '*' in GDD_K8S_NAMESPACES; the guard's
+            # _k8s_ns_in_csv treats '*' as matching any namespace.
+            if [[ $ns_given -eq 0 || "$ns" == "*" || "$ns" == "all" ]]; then ns="*"; fi
             "$KUBECTL" config get-contexts "$ctx" >/dev/null 2>&1 || { echo "ERROR: context '$ctx' not found." >&2; return 1; }
             # The context must exist (you can't create a kube context through the
             # guard). A namespace, though, may legitimately not exist yet: arming
             # a scope on namespaces you intend to create (across one or more
             # environments) is a supported workflow — in-scope 'ws k8s create
             # namespace <ns>' can then create them. So a missing namespace WARNS
-            # (surfacing a likely typo) but does not block the arm.
-            local one; local -a _ns; IFS=',' read -ra _ns <<< "$ns"
-            local _missing=()
-            for one in "${_ns[@]}"; do
-                "$KUBECTL" --context "$ctx" get namespace "$one" >/dev/null 2>&1 || _missing+=("$one")
-            done
-            if [[ ${#_missing[@]} -gt 0 ]]; then
-                echo "NOTE: namespace(s) not found on context '$ctx' — arming anyway: ${_missing[*]}" >&2
-                echo "  In-scope 'ws k8s create namespace <ns>' can create them. If one is a typo, re-run scope set with the correct name." >&2
+            # (surfacing a likely typo) but does not block the arm. Context-only
+            # (ns='*') has no per-namespace list to check, so this is skipped.
+            if [[ "$ns" != "*" ]]; then
+                local one; local -a _ns; IFS=',' read -ra _ns <<< "$ns"
+                local _missing=()
+                for one in "${_ns[@]}"; do
+                    "$KUBECTL" --context "$ctx" get namespace "$one" >/dev/null 2>&1 || _missing+=("$one")
+                done
+                if [[ ${#_missing[@]} -gt 0 ]]; then
+                    echo "NOTE: namespace(s) not found on context '$ctx' — arming anyway: ${_missing[*]}" >&2
+                    echo "  In-scope 'ws k8s create namespace <ns>' can create them. If one is a typo, re-run scope set with the correct name." >&2
+                fi
             fi
             ws_session_set GDD_K8S_CONTEXT "$ctx"
             ws_session_set GDD_K8S_NAMESPACES "$ns"
-            echo "guard scope armed: context=$ctx namespaces=$ns" ;;
+            if [[ "$ns" == "*" ]]; then
+                echo "guard scope armed: context=$ctx namespaces=(all — context-only)"
+            else
+                echo "guard scope armed: context=$ctx namespaces=$ns"
+            fi ;;
         *) echo "Usage: ws k8s scope set|show|clear" >&2; return 1 ;;
     esac
 }
@@ -106,8 +124,15 @@ while Codex denies until a scope or explicitly confirmed session bypass exists.
 
 Scope management:
   ws k8s scope set --context <ctx> --namespace <ns[,ns]>   arm the guard
+  ws k8s scope set --context <ctx>                         context-only scope
   ws k8s scope show                                        print the armed scope
   ws k8s scope clear                                       disarm
+
+Context-only scope (no --namespace, or --namespace '*'/all): pins the context
+but leaves ALL namespaces in scope for writes — no per-namespace rejection.
+Handy for a throwaway cluster doing infra testing across many dynamic
+namespaces. Context-pin protections still apply (a different --context and
+context-mutating/cluster-scoped/--all-namespaces writes are still blocked).
 
 Guarded passthrough (any other args go to kubectl, with --context injected):
   ws k8s get pods                  in-scope read  → runs

--- a/tests/hook/codex-k8s-hook.bats
+++ b/tests/hook/codex-k8s-hook.bats
@@ -263,10 +263,15 @@ assert_denied() {
     grep -q 'PASSTHROUGH.*shared Kubernetes guard unavailable' "$HOME/.codex/hook-audit.log"
 }
 
-@test "Codex registration contains only the focused Bash PreToolUse bridge" {
-    run jq -e \
-        '.hooks.PreToolUse | (length == 1 and .[0].matcher == "^Bash$" and (.[0].hooks | length == 1) and (.[0].hooks[0].command | contains(".codex/hooks/gdd-k8s-hook.sh")))' \
-        "$REPO_ROOT/.codex/hooks.json"
+@test "Codex registration contains both focused Bash PreToolUse bridges" {
+    run jq -e '
+        .hooks.PreToolUse
+        | length == 1
+          and .[0].matcher == "^Bash$"
+          and (.[0].hooks | length == 2)
+          and any(.[0].hooks[]; .command | contains(".codex/hooks/gdd-k8s-hook.sh"))
+          and any(.[0].hooks[]; .command | contains(".codex/hooks/gdd-redirect-hook.sh"))
+    ' "$REPO_ROOT/.codex/hooks.json"
     [ "$status" -eq 0 ]
     run jq -e '.hooks | has("PermissionRequest") | not' "$REPO_ROOT/.codex/hooks.json"
     [ "$status" -eq 0 ]

--- a/tests/hook/codex-redirect-hook.bats
+++ b/tests/hook/codex-redirect-hook.bats
@@ -41,6 +41,14 @@ run_hook() {
     [ -z "$output" ]
 }
 
+@test "payload without an explicit hook event defers" {
+    local payload
+    payload='{"session_id":"codex-redirect-test","tool_name":"Bash","tool_input":{"command":"git push"}}'
+    run env HOME="$HOME" GDD_PROJECT_ROOT="$WORK" bash "$HOOK_BIN" <<< "$payload"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
 @test "git push is denied with the configured ws guidance" {
     run_hook 'git push origin topic'
     [ "$status" -eq 0 ]

--- a/tests/hook/codex-redirect-hook.bats
+++ b/tests/hook/codex-redirect-hook.bats
@@ -70,3 +70,82 @@ CASES
     [ "$status" -eq 0 ]
     [ -z "$output" ]
 }
+
+@test "suggestion text may contain additional pipes" {
+    cat > "$WORK/.claude/hooks/hook-rules" <<'RULES'
+[redirect-commands]
+custom | custom raw* | Use `ws custom` | keep this suffix.
+RULES
+    run_hook 'custom raw input'
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.hookSpecificOutput.permissionDecisionReason' <<< "$output")" = 'Use `ws custom` | keep this suffix.' ]
+}
+
+@test "malformed redirect rows are audited and later valid rows still work" {
+    cat > "$WORK/.claude/hooks/hook-rules" <<'RULES'
+[redirect-commands]
+missing separators
+bad_slug | bad* | invalid slug
+valid | valid raw* | Use `ws valid`.
+RULES
+    run_hook 'valid raw input'
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.hookSpecificOutput.permissionDecision' <<< "$output")" = "deny" ]
+    grep -q 'malformed \[redirect-commands\]' "$HOME/.codex/hook-audit.log"
+}
+
+@test "missing baseline rules defer and audit the infrastructure gap" {
+    rm "$WORK/.claude/hooks/hook-rules"
+    run_hook 'git push'
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+    grep -q 'redirect rules unavailable' "$HOME/.codex/hook-audit.log"
+}
+
+@test "command and pattern normalization match wrapper-path forms" {
+    cat > "$WORK/.claude/hooks/hook-rules" <<'RULES'
+[redirect-commands]
+custom | scripts/custom raw* | Use `ws custom`.
+RULES
+    run_hook 'bash scripts/custom raw input'
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.hookSpecificOutput.permissionDecisionReason' <<< "$output")" = 'Use `ws custom`.' ]
+}
+
+@test "hook-rules.local adds a redirect" {
+    cat > "$WORK/.claude/hooks/hook-rules.local" <<'RULES'
+[redirect-commands]
+local-tool | local-tool raw* | Use `ws local-tool`.
+RULES
+    run_hook 'local-tool raw input'
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.hookSpecificOutput.permissionDecisionReason' <<< "$output")" = 'Use `ws local-tool`.' ]
+}
+
+@test "matching-session bypass defers without emitting allow" {
+    cat > "$WORK/.tmp/hook-bypass/git-push.bypass" <<'MARKER'
+session_id: codex-redirect-test
+reason: provider debugging
+MARKER
+    run_hook 'git push'
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+    grep -q 'BYPASS-REDIRECT \[git-push\]' "$HOME/.codex/hook-audit.log"
+}
+
+@test "mismatched-session bypass still denies" {
+    cat > "$WORK/.tmp/hook-bypass/git-push.bypass" <<'MARKER'
+session_id: another-session
+reason: wrong owner
+MARKER
+    run_hook 'git push'
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.hookSpecificOutput.permissionDecision' <<< "$output")" = "deny" ]
+}
+
+@test "malformed bypass marker still denies" {
+    printf '%s\n' 'reason: missing session' > "$WORK/.tmp/hook-bypass/git-push.bypass"
+    run_hook 'git push'
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.hookSpecificOutput.permissionDecision' <<< "$output")" = "deny" ]
+}

--- a/tests/hook/codex-redirect-hook.bats
+++ b/tests/hook/codex-redirect-hook.bats
@@ -1,0 +1,72 @@
+#!/usr/bin/env bats
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    HOOK_BIN="$REPO_ROOT/.codex/hooks/gdd-redirect-hook.sh"
+    WORK="$BATS_TEST_TMPDIR/work"
+    export HOME="$WORK/home"
+    mkdir -p "$WORK/.claude/hooks" "$WORK/.tmp/hook-bypass" "$HOME/.codex"
+    cp "$REPO_ROOT/.claude/hooks/hook-rules" "$WORK/.claude/hooks/hook-rules"
+}
+
+run_hook() {
+    local command="$1"
+    local session_id="${2:-codex-redirect-test}"
+    local tool_name="${3:-Bash}"
+    local payload
+    payload="$(jq -nc \
+        --arg sid "$session_id" \
+        --arg tool "$tool_name" \
+        --arg command "$command" \
+        --arg cwd "$WORK" \
+        '{session_id:$sid,hook_event_name:"PreToolUse",tool_name:$tool,tool_input:{command:$command},cwd:$cwd}')"
+    run env HOME="$HOME" GDD_PROJECT_ROOT="$WORK" bash "$HOOK_BIN" <<< "$payload"
+}
+
+@test "unrelated Bash command defers to normal Codex routing" {
+    run_hook 'git status'
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "non-Bash tool defers" {
+    run_hook 'git push' codex-redirect-test apply_patch
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "malformed payload defers" {
+    run env HOME="$HOME" GDD_PROJECT_ROOT="$WORK" bash "$HOOK_BIN" <<< 'not-json'
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "git push is denied with the configured ws guidance" {
+    run_hook 'git push origin topic'
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.hookSpecificOutput.permissionDecision' <<< "$output")" = "deny" ]
+    [[ "$(jq -r '.hookSpecificOutput.permissionDecisionReason' <<< "$output")" == *'Use `ws push <comp> [branch]`'* ]]
+}
+
+@test "each shipped redirect denies a representative raw command" {
+    local command slug
+    while IFS='|' read -r command slug; do
+        run_hook "$command"
+        [ "$status" -eq 0 ]
+        [ "$(jq -r '.hookSpecificOutput.permissionDecision' <<< "$output")" = "deny" ]
+        grep -q "DENY-REDIRECT \[$slug\]" "$HOME/.codex/hook-audit.log"
+    done <<'CASES'
+git commit -m test|git-commit
+git push|git-push
+gh pr create --title test|gh-pr-create
+git mv old new|git-mv
+CASES
+}
+
+@test "WS_HOOK_DISABLE bypasses redirect evaluation" {
+    local payload
+    payload='{"session_id":"codex-redirect-test","hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"git push"}}'
+    run env HOME="$HOME" GDD_PROJECT_ROOT="$WORK" WS_HOOK_DISABLE=1 bash "$HOOK_BIN" <<< "$payload"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}

--- a/tests/hook/codex-redirect-hook.bats
+++ b/tests/hook/codex-redirect-hook.bats
@@ -68,6 +68,8 @@ git commit -m test|git-commit
 git push|git-push
 gh pr create --title test|gh-pr-create
 git mv old new|git-mv
+gh pr view 123|gh-cli
+glab mr view 456|glab-cli
 CASES
 }
 

--- a/tests/ws-k8s/wrapper.bats
+++ b/tests/ws-k8s/wrapper.bats
@@ -83,6 +83,58 @@ run_ws() { run env WS_FOOTER_DISABLE=1 ROOT_DIR="$ROOT_DIR" KUBECTL="$KUBECTL" b
     run_ws k8s scope show
     [[ "$output" == *"alice-sandbox,prod"* ]]
 }
+@test "context-only: scope set with no --namespace arms and show reports all-namespaces" {
+    run_ws k8s scope set --context kind-practice
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"context-only"* ]]
+    run_ws k8s scope show
+    [[ "$output" == *"kind-practice"* ]]
+    [[ "$output" == *"(all — context-only)"* ]]
+}
+@test "context-only: --namespace '*' also arms context-only" {
+    run_ws k8s scope set --context kind-practice --namespace '*'
+    [ "$status" -eq 0 ]
+    run_ws k8s scope show
+    [[ "$output" == *"(all — context-only)"* ]]
+}
+@test "context-only: --namespace all also arms context-only" {
+    run_ws k8s scope set --context kind-practice --namespace all
+    [ "$status" -eq 0 ]
+    run_ws k8s scope show
+    [[ "$output" == *"(all — context-only)"* ]]
+}
+@test "context-only: write to an arbitrary namespace is ALLOWED and forces --context" {
+    run_ws k8s scope set --context kind-practice
+    : > "$ROOT_DIR/kubectl.log"
+    run_ws k8s delete pod foo -n gitea
+    [ "$status" -eq 0 ]
+    grep -q -- '--context kind-practice' "$ROOT_DIR/kubectl.log"
+    run_ws k8s run probe --image=pause -n crossplane
+    [ "$status" -eq 0 ]
+}
+@test "context-only: reads are still free cluster-wide" {
+    run_ws k8s scope set --context kind-practice
+    : > "$ROOT_DIR/kubectl.log"
+    run_ws k8s get pods -n kube-system
+    [ "$status" -eq 0 ]
+    grep -q -- '--context kind-practice' "$ROOT_DIR/kubectl.log"
+}
+@test "context-only: an explicit different --context is still REJECTED" {
+    run_ws k8s scope set --context kind-practice
+    : > "$ROOT_DIR/kubectl.log"
+    run_ws k8s delete pod foo --context other-cluster -n gitea
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"REJECTED"* ]]
+    [ ! -s "$ROOT_DIR/kubectl.log" ]
+}
+@test "context-only: a cluster-scoped write is still REJECTED (context-pin protections intact)" {
+    run_ws k8s scope set --context kind-practice
+    : > "$ROOT_DIR/kubectl.log"
+    run_ws k8s delete clusterrole foo
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"REJECTED"* ]]
+    [ ! -s "$ROOT_DIR/kubectl.log" ]
+}
 @test "scope clear removes the scope" {
     run_ws k8s scope set --context kind-practice --namespace alice-sandbox
     run_ws k8s scope clear

--- a/tests/ws-k8s/wrapper.bats
+++ b/tests/ws-k8s/wrapper.bats
@@ -97,11 +97,19 @@ run_ws() { run env WS_FOOTER_DISABLE=1 ROOT_DIR="$ROOT_DIR" KUBECTL="$KUBECTL" b
     run_ws k8s scope show
     [[ "$output" == *"(all — context-only)"* ]]
 }
-@test "context-only: --namespace all also arms context-only" {
+@test "context-only: a mixed namespace list containing '*' normalizes to context-only" {
+    run_ws k8s scope set --context kind-practice --namespace 'alice-sandbox,*'
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"(all — context-only)"* ]]
+    run_ws k8s scope show
+    [[ "$output" == *"(all — context-only)"* ]]
+}
+@test "namespace named all remains a literal namespace scope" {
     run_ws k8s scope set --context kind-practice --namespace all
     [ "$status" -eq 0 ]
     run_ws k8s scope show
-    [[ "$output" == *"(all — context-only)"* ]]
+    [[ "$output" == *"namespaces: all"* ]]
+    [[ "$output" != *"context-only"* ]]
 }
 @test "context-only: write to an arbitrary namespace is ALLOWED and forces --context" {
     run_ws k8s scope set --context kind-practice
@@ -111,6 +119,16 @@ run_ws() { run env WS_FOOTER_DISABLE=1 ROOT_DIR="$ROOT_DIR" KUBECTL="$KUBECTL" b
     grep -q -- '--context kind-practice' "$ROOT_DIR/kubectl.log"
     run_ws k8s run probe --image=pause -n crossplane
     [ "$status" -eq 0 ]
+}
+@test "context-only: named namespace create and delete operations are allowed" {
+    run_ws k8s scope set --context kind-practice
+    : > "$ROOT_DIR/kubectl.log"
+    run_ws k8s create namespace ephemeral
+    [ "$status" -eq 0 ]
+    run_ws k8s delete ns/ephemeral
+    [ "$status" -eq 0 ]
+    grep -q -- '--context kind-practice create namespace ephemeral' "$ROOT_DIR/kubectl.log"
+    grep -q -- '--context kind-practice delete ns/ephemeral' "$ROOT_DIR/kubectl.log"
 }
 @test "context-only: reads are still free cluster-wide" {
     run_ws k8s scope set --context kind-practice


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @rpraestholm via [GDD](https://gitlab-master.nvidia.com/gni-cis/gdd).

## Summary

- Add a focused Codex `PreToolUse` bridge that consumes the shared `[redirect-commands]` policy and directs raw commit, push, PR-creation, and rename commands toward their `ws` workflows.
- Keep Codex authorization boundaries intact: unrelated commands and valid session bypasses defer to normal sandbox and approval routing rather than receiving an automatic allow decision.
- Harden redirect parsing and diagnostics for malformed, missing, and local additive rule files, with session-bound bypass validation and audit records.
- Document the focused cross-harness architecture, project-hook trust flow through `/hooks`, and the Claude-specific permission behavior that remains outside the Codex bridges.
- Add a context-only Kubernetes guard scope for workflows that need one pinned cluster but dynamic namespaces while retaining context mismatch, cluster-scoped write, and unbounded-write protections.

## Test plan

- [x] Run `ws test yggdrasil` (`670/670` passing).
- [x] Trust the new project hook through `/hooks` and verify raw `git commit --dry-run` is denied with `ws commit` guidance before Git executes.
- [x] Run the combined Kubernetes wrapper and Codex hook suites (`63/63` passing) after resolving the context-only guard cherry-pick.
- [x] Verify `.codex/hooks.json` registers both focused Bash bridges and the redirect hook remains executable.
- [x] Verify the Yggdrasil worktree is clean and `git diff --check` reports no errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a focused Codex workflow-redirect hook enforcing shared redirect rules alongside the Kubernetes safety guard.
  * Introduced Kubernetes “context-only” scoping (wildcard `*`) for write-safety without an explicit namespace list.
  * Added new redirect rules for `gh` and `glab`, with session-scoped bypass support.
* **Bug Fixes**
  * Improved command matching for wrapped/script-path forms and clarified session-scoped bypass behavior (no auto-allow).
* **Documentation**
  * Updated Codex and GDD guides for redirect tiers, deny-or-defer semantics, and context-only scoping.
* **Tests**
  * Expanded Bats coverage for redirect enforcement, bypass, registration, malformed inputs, and context-only scoping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->