### PR TITLE
fix(clone-fork): create renamed GitLab forks

### DIFF
--- a/scripts/ws-clone-fork.sh
+++ b/scripts/ws-clone-fork.sh
@@ -292,6 +292,7 @@ else
 fi
 
 FORK_NAMESPACE="$(dirname "$FORK_PATH")"  # destination namespace for project creation
+FORK_REPO_NAME="$(basename "$FORK_PATH")"
 
 # --- token resolution (longest-prefix match) --------------------------------
 # Token-walk lives in ws-realm.sh as `ws_resolve_token_var`. We pass the
@@ -560,10 +561,16 @@ if [[ -z "$FORK_DETAILS" ]]; then
             exit 1
         fi
 
-        # POST /projects/:id/fork with namespace_path
+        # POST /projects/:id/fork with namespace_path. When forkRepo gives the
+        # fork a different slug, pass it explicitly so creation and polling use
+        # the same project path.
         fork_create_result=""
         fork_create_err="$ERR_TMP"
-        if ! fork_create_result=$(api_call "$FORK_TOKEN_VAR" "projects/$UPSTREAM_ID/fork" -X POST -f "namespace_path=$FORK_NAMESPACE" 2>"$fork_create_err"); then
+        fork_create_args=(-X POST -f "namespace_path=$FORK_NAMESPACE")
+        if [[ "$FORK_REPO_NAME" != "$UPSTREAM_REPO_NAME" ]]; then
+            fork_create_args+=(-f "name=$FORK_REPO_NAME" -f "path=$FORK_REPO_NAME")
+        fi
+        if ! fork_create_result=$(api_call "$FORK_TOKEN_VAR" "projects/$UPSTREAM_ID/fork" "${fork_create_args[@]}" 2>"$fork_create_err"); then
             echo "ERROR: Fork creation failed." >&2
             cat "$fork_create_err" >&2
             # Common failure: token lacks Maintainer role on the destination group.

--- a/tests/ws-clone-fork/provider-parity.bats
+++ b/tests/ws-clone-fork/provider-parity.bats
@@ -368,3 +368,64 @@ YAML
     [[ "$output" == *"https://github.com/source-org/widget/fork"* ]]
     [[ "$output" != *"/-/forks/new"* ]]
 }
+
+@test "gitlab forkRepo override passes a renamed project to the fork API" {
+    local glab_log="$BATS_TEST_TMPDIR/glab.log"
+    local fork_marker="$BATS_TEST_TMPDIR/gitlab-fork-created"
+    export glab_log fork_marker
+    cat > "$TEST_BIN/glab" <<'SH'
+#!/usr/bin/env bash
+{ printf 'glab:'; printf ' %q' "$@"; printf '\n'; } >> "$glab_log"
+
+case "$*" in
+    *"projects/explicit%2Fforks%2Fwidget-cfr"*)
+        if [[ -f "$fork_marker" ]]; then
+            printf '{"id":2,"import_status":"failed","import_error":"stop after request capture"}\n'
+            exit 0
+        fi
+        echo "404 Project Not Found" >&2
+        exit 1
+        ;;
+    *"projects/source%2Fteam%2Fwidget"*)
+        printf '{"id":1,"default_branch":"main"}\n'
+        exit 0
+        ;;
+    *"projects/1/fork"*)
+        touch "$fork_marker"
+        printf '{"id":2,"import_status":"scheduled"}\n'
+        exit 0
+        ;;
+esac
+
+echo "unexpected glab call: $*" >&2
+exit 1
+SH
+    chmod +x "$TEST_BIN/glab"
+
+    write_ecosystem <<'YAML'
+identity:
+  forkRemote: alice-fork-group
+defaults:
+  gitProviders:
+    gitlab.example.com: gitlab
+  gitTokens:
+    gitlab.example.com/source/team/widget: GITLAB_SOURCE_TOKEN
+    gitlab.example.com/explicit/forks/widget-cfr: GITLAB_FORK_TOKEN
+components:
+  widget:
+    tier: supporting
+    repo: https://gitlab.example.com/source/team/widget.git
+    forkRepo: https://gitlab.example.com/explicit/forks/widget-cfr.git
+YAML
+    export GITLAB_SOURCE_TOKEN="source-token"
+    export GITLAB_FORK_TOKEN="fork-token"
+
+    run bash "$CLONE_FORK_BIN" widget
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Fork import failed"* ]]
+    grep -Fq "projects/1/fork" "$glab_log"
+    grep -Fq "namespace_path=explicit/forks" "$glab_log"
+    grep -Fq "name=widget-cfr" "$glab_log"
+    grep -Fq "path=widget-cfr" "$glab_log"
+}


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @Cervator via [GDD](https://gitlab-master.nvidia.com/gni-cis/gdd).

## Summary

- Honor a renamed GitLab `forkRepo` basename when `ws clone-fork` creates the fork.
- Send explicit `name` and `path` fields only when the configured fork slug differs from upstream, preserving existing behavior for ordinary forks.
- Add a provider-level regression test that captures and verifies the GitLab fork API request.

## Test plan

- [x] `ws test yggdrasil`
- [x] `ws test yggdrasil tests/ws-clone-fork/derive.bats tests/ws-clone-fork/provider-parity.bats`
- [x] `bash -n scripts/ws-clone-fork.sh`
- [x] `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GitLab fork creation when a custom destination repository name or path is configured.
  * Ensured fork creation and follow-up operations consistently use the configured repository URL and project details.

* **Tests**
  * Added coverage for GitLab forks using overridden repository paths and names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->