### PR TITLE
feat(ws-review): enforce GDD attribution on reply/comment, add branch-drift check

### DIFF
--- a/.agent/skills/gdd-review-triage/SKILL.md
+++ b/.agent/skills/gdd-review-triage/SKILL.md
@@ -85,7 +85,10 @@ bash scripts/ws review <comp> comment <cr#> <bodyfile>   # top-level comment, no
 `reply` and `comment` both prepend the GDD AI-attribution banner automatically
 — don't hand-type it, and don't fall back to raw `gh`/`glab` for a top-level
 PR/MR comment (that bypasses the banner). `ws review <comp> <cr#>` (the "run
-this first" command) also warns if the CR's base branch has moved ahead since
+this first" command) also warns if the locally checked-out branch isn't
+actually this CR's head branch (committing/pushing there would create an
+unrelated branch instead of updating the CR — a real mistake this check now
+catches), and separately warns if the CR's base branch has moved ahead since
 the branch was cut — rebase per `gdd-branch-workflow` if it does.
 
 Thread resolution is a Side-effect operation (prompts for approval).

--- a/.agent/skills/gdd-review-triage/SKILL.md
+++ b/.agent/skills/gdd-review-triage/SKILL.md
@@ -79,7 +79,14 @@ bash scripts/ws review <comp> threads <cr#>             # unresolved thread list
 bash scripts/ws review <comp> threads <cr#> --resolve-all
 bash scripts/ws review <comp> threads <cr#> --resolve <id>
 bash scripts/ws review <comp> reply <cr#> <id> "message" --resolve
+bash scripts/ws review <comp> comment <cr#> <bodyfile>   # top-level comment, not tied to a thread
 ```
+
+`reply` and `comment` both prepend the GDD AI-attribution banner automatically
+— don't hand-type it, and don't fall back to raw `gh`/`glab` for a top-level
+PR/MR comment (that bypasses the banner). `ws review <comp> <cr#>` (the "run
+this first" command) also warns if the CR's base branch has moved ahead since
+the branch was cut — rebase per `gdd-branch-workflow` if it does.
 
 Thread resolution is a Side-effect operation (prompts for approval).
 

--- a/.agent/skills/gdd-review-triage/SKILL.md
+++ b/.agent/skills/gdd-review-triage/SKILL.md
@@ -82,14 +82,9 @@ bash scripts/ws review <comp> reply <cr#> <id> "message" --resolve
 bash scripts/ws review <comp> comment <cr#> <bodyfile>   # top-level comment, not tied to a thread
 ```
 
-`reply` and `comment` both prepend the GDD AI-attribution banner automatically
-— don't hand-type it, and don't fall back to raw `gh`/`glab` for a top-level
-PR/MR comment (that bypasses the banner). `ws review <comp> <cr#>` (the "run
-this first" command) also warns if the locally checked-out branch isn't
-actually this CR's head branch (committing/pushing there would create an
-unrelated branch instead of updating the CR — a real mistake this check now
-catches), and separately warns if the CR's base branch has moved ahead since
-the branch was cut — rebase per `gdd-branch-workflow` if it does.
+`reply` and `comment` auto-add the GDD banner — don't hand-type it or use raw `gh`/`glab`.
+
+`ws review <comp> <cr#>` also warns if you're on the wrong branch (not the CR's head) or if the base branch drifted ahead — rebase per `gdd-branch-workflow`.
 
 Thread resolution is a Side-effect operation (prompts for approval).
 

--- a/scripts/providers/github.sh
+++ b/scripts/providers/github.sh
@@ -245,6 +245,20 @@ gp_review_threads_status() {
     '
 }
 
+# Post a top-level PR comment (not attached to a diff thread).
+# Usage: gp_review_post_comment SLUG PR_NUM MESSAGE
+gp_review_post_comment() {
+    local slug="$1" pr_num="$2" message="$3"
+    gh api "repos/$slug/issues/$pr_num/comments" -f body="$message" >/dev/null
+}
+
+# Get the PR's base (target) branch name.
+# Usage: gp_review_base_branch SLUG PR_NUM
+gp_review_base_branch() {
+    local slug="$1" pr_num="$2"
+    gh api "repos/$slug/pulls/$pr_num" --jq '.base.ref' 2>/dev/null
+}
+
 # Reply to a review thread.
 # Usage: gp_review_thread_reply SLUG PR_NUM THREAD_ID MESSAGE
 gp_review_thread_reply() {

--- a/scripts/providers/gitlab.sh
+++ b/scripts/providers/gitlab.sh
@@ -240,6 +240,23 @@ gp_review_threads_status() {
     '
 }
 
+# Post a top-level MR comment (not attached to a diff discussion).
+# Usage: gp_review_post_comment SLUG MR_NUM MESSAGE
+gp_review_post_comment() {
+    local slug="$1" mr_num="$2" message="$3"
+    local encoded; encoded=$(_gl_encode "$slug")
+    glab api --method POST "projects/$encoded/merge_requests/$mr_num/notes" \
+        -f body="$message" >/dev/null
+}
+
+# Get the MR's target branch name.
+# Usage: gp_review_base_branch SLUG MR_NUM
+gp_review_base_branch() {
+    local slug="$1" mr_num="$2"
+    local encoded; encoded=$(_gl_encode "$slug")
+    glab api "projects/$encoded/merge_requests/$mr_num" 2>/dev/null | jq -r '.target_branch' 2>/dev/null
+}
+
 # Reply to a discussion thread.
 # Usage: gp_review_thread_reply SLUG MR_NUM DISCUSSION_ID MESSAGE
 _gl_validate_discussion_id() {

--- a/scripts/ws-realm.sh
+++ b/scripts/ws-realm.sh
@@ -677,14 +677,7 @@ ws_resolve_token_var() {
     printf '%s\n' "$token_var"
 }
 
-# Resolve the GDD AI-attribution banner line, shared by any script that posts
-# agent-authored text to an external tracker (CR/issue bodies, review replies
-# and comments). git-cr.sh / git-issue.sh enforce this line's presence in a
-# user-supplied template instead of calling this — they predate it and their
-# bodies are already template-sourced, so re-deriving here would just be a
-# second copy of the same logic with no behavior change. New callers (like
-# ws-review.sh's reply/comment) that build short messages ad hoc, without a
-# template to copy from, should call this instead of typing the line by hand.
+# Resolve the GDD AI-attribution banner line, shared by any script that posts agent-authored text to an external tracker (CR/issue bodies, review replies and comments). git-cr.sh / git-issue.sh enforce this line's presence in a user-supplied template instead of calling this — they predate it and their bodies are already template-sourced, so re-deriving here would just be a second copy of the same logic with no behavior change. New callers (like ws-review.sh's reply/comment) that build short messages ad hoc, without a template to copy from, should call this instead of typing the line by hand.
 # Usage: ws_gdd_attribution_line "<label>"   (label e.g. "comment", "reply")
 ws_gdd_attribution_line() {
     local label="$1"

--- a/scripts/ws-realm.sh
+++ b/scripts/ws-realm.sh
@@ -677,6 +677,35 @@ ws_resolve_token_var() {
     printf '%s\n' "$token_var"
 }
 
+# Resolve the GDD AI-attribution banner line, shared by any script that posts
+# agent-authored text to an external tracker (CR/issue bodies, review replies
+# and comments). git-cr.sh / git-issue.sh enforce this line's presence in a
+# user-supplied template instead of calling this — they predate it and their
+# bodies are already template-sourced, so re-deriving here would just be a
+# second copy of the same logic with no behavior change. New callers (like
+# ws-review.sh's reply/comment) that build short messages ad hoc, without a
+# template to copy from, should call this instead of typing the line by hand.
+# Usage: ws_gdd_attribution_line "<label>"   (label e.g. "comment", "reply")
+ws_gdd_attribution_line() {
+    local label="$1"
+    local eco
+    eco=$(ws_resolve_ecosystem 2>/dev/null) || eco=""
+    local human_account="" gdd_home="https://siliconsaga.github.io/yggdrasil/gdd/"
+    if [[ -n "$eco" ]]; then
+        human_account=$(yq '.identity.human_account // ""' "$eco" 2>/dev/null)
+        [[ "$human_account" == "null" ]] && human_account=""
+        local gdd_home_raw
+        gdd_home_raw=$(yq '.defaults.gddHome // ""' "$eco" 2>/dev/null)
+        [[ -n "$gdd_home_raw" && "$gdd_home_raw" != "null" ]] && gdd_home="$gdd_home_raw"
+    fi
+    if [[ -z "$human_account" ]]; then
+        echo "ERROR: identity.human_account not set in ecosystem config." >&2
+        echo "  Set it in ecosystem.local.yaml (see ecosystem.local.yaml.example)." >&2
+        return 1
+    fi
+    printf '> **AI-assisted %s.** Filed by agent driven by @%s via [GDD](%s).\n' "$label" "$human_account" "$gdd_home"
+}
+
 # ---------------------------------------------------------------------------
 # Subcommands — only run when called directly (not when sourced)
 # ---------------------------------------------------------------------------

--- a/scripts/ws-review.sh
+++ b/scripts/ws-review.sh
@@ -22,6 +22,7 @@ review_help() {
     echo "       ws review <comp> threads <cr#> [--remote <name>] [--status | --resolve <id> | --resolve-all]"
     echo "       ws review <comp> notes <cr#> [--remote <name>] [--reviewer <name>] [--since <time>]"
     echo "       ws review <comp> reply <cr#> <thread-id> <message> [--remote <name>] [--resolve]"
+    echo "       ws review <comp> comment <cr#> <bodyfile> [--remote <name>]"
     echo ""
     echo "CR review comments and thread management."
     echo ""
@@ -60,8 +61,15 @@ review_help() {
     echo "    --since <time>           Filter by time"
     echo ""
     echo "  reply <cr#> <thread-id> <message> [--resolve]"
-    echo "                             Reply to a review thread"
+    echo "                             Reply to a review thread. The GDD AI-attribution"
+    echo "                             banner is prepended automatically."
     echo "    --resolve                Also resolve the thread after replying"
+    echo ""
+    echo "  comment <cr#> <bodyfile>   Post a top-level PR/MR comment (not attached to"
+    echo "                             any diff thread) — for replying to a top-level"
+    echo "                             review note, or any comment not tied to an inline"
+    echo "                             thread. The GDD AI-attribution banner is"
+    echo "                             prepended automatically, same as reply."
     echo ""
     echo "Examples:"
     echo "  ws review yggdrasil 8                      # All review output (start here)"
@@ -77,6 +85,7 @@ review_help() {
     echo "  ws review yggdrasil threads 8 --resolve-all"
     echo "  ws review yggdrasil reply 8 THREAD_ID 'Addressed in abc123'"
     echo "  ws review yggdrasil reply 8 THREAD_ID 'Fixed' --resolve"
+    echo "  ws review yggdrasil comment 8 .crs/reply-notes.md"
     exit 0
 }
 
@@ -452,6 +461,27 @@ review_comments() {
     printf '%s\n' "$summary" | review_sanitize_provider_text
     echo ""
 
+    # Branch-drift check: warn if the CR's base branch has moved ahead of
+    # this branch since it was cut. Nothing else in the ws push/cr flow
+    # surfaces this, and review_comments is the command the workflow
+    # already recommends running after every push — piggyback here instead
+    # of adding a separate command to remember. Best-effort: an unresolvable
+    # base branch or a fetch failure degrades to silence, never a hard error.
+    if [[ -n "$_SELECTED_REMOTE" ]]; then
+        local base_ref=""
+        base_ref=$(gp_review_base_branch "$REPO_SLUG" "$pr_num" 2>/dev/null) || base_ref=""
+        if [[ -n "$base_ref" && "$base_ref" != "null" ]]; then
+            if git -C "$COMP_DIR" fetch --quiet "$_SELECTED_REMOTE" "$base_ref" 2>/dev/null; then
+                local behind_count=""
+                behind_count=$(git -C "$COMP_DIR" rev-list --count HEAD..FETCH_HEAD 2>/dev/null) || behind_count=""
+                if [[ -n "$behind_count" && "$behind_count" -gt 0 ]]; then
+                    echo "⚠ Base branch '$base_ref' is $behind_count commit(s) ahead of this branch — consider rebasing (see gdd-branch-workflow)."
+                    echo ""
+                fi
+            fi
+        fi
+    fi
+
     # === Phase 1: Fetch all three sections ===
     #
     # The fetches used to happen interleaved with prints. We now buffer
@@ -756,6 +786,10 @@ review_reply() {
         exit 1
     fi
 
+    local banner
+    banner=$(ws_gdd_attribution_line "reply") || exit 1
+    message="${banner}"$'\n\n'"${message}"
+
     gp_review_thread_reply "$REPO_SLUG" "$cr_num" "$thread_id" "$message" || {
         echo "ERROR: Failed to reply to thread $thread_id on CR #$cr_num." >&2
         exit 1
@@ -769,6 +803,41 @@ review_reply() {
         }
         echo "Thread resolved."
     fi
+}
+
+# Post a top-level PR/MR comment — not attached to any inline diff thread.
+# Bodyfile-based (like ws cr / ws issue) rather than an inline message
+# because top-level comments in practice run long (multi-paragraph
+# explanations, code blocks) — unlike `reply`, which is typically a short
+# one-liner and keeps its inline-message signature.
+review_comment() {
+    if [[ $# -ne 2 ]]; then
+        echo "Usage: ws review <comp> comment <cr#> <bodyfile> [--remote <name>]" >&2
+        exit 1
+    fi
+
+    local cr_num="$1" bodyfile="$2"
+
+    if [[ ! "$cr_num" =~ ^[0-9]+$ ]]; then
+        echo "ERROR: CR number must be numeric, got '$cr_num'" >&2
+        exit 1
+    fi
+
+    if [[ ! -f "$bodyfile" ]]; then
+        echo "ERROR: body file not found: $bodyfile" >&2
+        exit 1
+    fi
+
+    local banner
+    banner=$(ws_gdd_attribution_line "comment") || exit 1
+    local message
+    message="${banner}"$'\n\n'"$(cat "$bodyfile")"
+
+    gp_review_post_comment "$REPO_SLUG" "$cr_num" "$message" || {
+        echo "ERROR: Failed to post comment on CR #$cr_num." >&2
+        exit 1
+    }
+    echo "Posted comment on CR #$cr_num ($REPO_SLUG)."
 }
 
 # --- Shared setup ---
@@ -912,6 +981,8 @@ elif [[ "${1:-}" == "notes" && "${2:-}" =~ ^[0-9]+$ ]]; then
     _PEEK_CR="$2"
 elif [[ "${1:-}" == "reply" && "${2:-}" =~ ^[0-9]+$ ]]; then
     _PEEK_CR="$2"
+elif [[ "${1:-}" == "comment" && "${2:-}" =~ ^[0-9]+$ ]]; then
+    _PEEK_CR="$2"
 elif [[ "${1:-}" =~ ^[0-9]+$ ]]; then
     _PEEK_CR="$1"
 fi
@@ -922,12 +993,17 @@ _SELECTED_PROVIDER=""
 # alone is ambiguous when two remotes share owner/repo across hosts or provider
 # mappings — token setup below needs the precise URL, not "first slug match".
 _SELECTED_URL=""
+# Remote name (not just slug/URL) — needed to `git fetch` the base branch for
+# the drift check in review_comments(). Matching by slug/URL alone isn't
+# enough since fetch needs the local remote name, not the repo identity.
+_SELECTED_REMOTE=""
 if [[ -n "$REVIEW_REMOTE" ]]; then
     for i in "${!_CANDIDATE_REMOTES[@]}"; do
         if [[ "${_CANDIDATE_REMOTES[$i]}" == "$REVIEW_REMOTE" ]]; then
             REPO_SLUG="${_CANDIDATE_SLUGS[$i]}"
             _SELECTED_PROVIDER="${_CANDIDATE_PROVIDERS[$i]}"
             _SELECTED_URL="${_CANDIDATE_URLS[$i]}"
+            _SELECTED_REMOTE="${_CANDIDATE_REMOTES[$i]}"
             break
         fi
     done
@@ -944,6 +1020,7 @@ elif [[ ${#_CANDIDATE_SLUGS[@]} -eq 1 ]]; then
     REPO_SLUG="${_CANDIDATE_SLUGS[0]}"
     _SELECTED_PROVIDER="${_CANDIDATE_PROVIDERS[0]}"
     _SELECTED_URL="${_CANDIDATE_URLS[0]}"
+    _SELECTED_REMOTE="${_CANDIDATE_REMOTES[0]}"
 elif [[ -n "$_PEEK_CR" ]]; then
     # Try each slug — collect all matches (CR numbers aren't unique across repos)
     # Deduplicate: skip slug/provider pairs we've already probed. Carry the
@@ -1006,11 +1083,13 @@ elif [[ -n "$_PEEK_CR" ]]; then
     REPO_SLUG="${_MATCH_SLUGS[0]}"
     _SELECTED_PROVIDER="${_MATCH_PROVIDERS[0]}"
     _SELECTED_URL="${_MATCH_URLS[0]}"
+    _SELECTED_REMOTE="${_MATCH_REMOTES[0]}"
 else
     # Can't probe without a CR number — use first slug
     REPO_SLUG="${_CANDIDATE_SLUGS[0]}"
     _SELECTED_PROVIDER="${_CANDIDATE_PROVIDERS[0]}"
     _SELECTED_URL="${_CANDIDATE_URLS[0]}"
+    _SELECTED_REMOTE="${_CANDIDATE_REMOTES[0]}"
 fi
 
 # Ensure the selected provider is loaded and its API authority is pinned to the
@@ -1040,6 +1119,9 @@ elif [[ "${1:-}" == "notes" ]]; then
 elif [[ "${1:-}" == "reply" ]]; then
     shift
     review_reply "$@"
+elif [[ "${1:-}" == "comment" ]]; then
+    shift
+    review_comment "$@"
 else
     review_comments "$@"
 fi

--- a/scripts/ws-review.sh
+++ b/scripts/ws-review.sh
@@ -461,6 +461,29 @@ review_comments() {
     printf '%s\n' "$summary" | review_sanitize_provider_text
     echo ""
 
+    # Branch-identity check: warn if the locally checked-out branch isn't
+    # actually this CR's head branch. A local branch can share history with
+    # the real CR branch (e.g. checked out from the same commit under a
+    # different name) without being it — committing/pushing there creates an
+    # unrelated branch instead of updating this CR (the exact mistake that
+    # motivated this check: a branch named "soloturn" was pushed as a new
+    # branch instead of updating the PR's actual "soloturn-performance"
+    # head). Checked before the drift check below, since drift against the
+    # wrong branch isn't meaningful. Best-effort: an unresolvable head
+    # branch degrades to silence, never a hard error.
+    if [[ -n "$_SELECTED_REMOTE" ]]; then
+        local head_ref=""
+        head_ref=$(gp_review_head_branch "$REPO_SLUG" "$pr_num" 2>/dev/null) || head_ref=""
+        if [[ -n "$head_ref" && "$head_ref" != "null" ]]; then
+            local local_branch=""
+            local_branch=$(git -C "$COMP_DIR" rev-parse --abbrev-ref HEAD 2>/dev/null) || local_branch=""
+            if [[ -n "$local_branch" && "$local_branch" != "$head_ref" ]]; then
+                echo "⚠ Local branch '$local_branch' does not match this CR's head branch '$head_ref' — committing/pushing here won't update this CR."
+                echo ""
+            fi
+        fi
+    fi
+
     # Branch-drift check: warn if the CR's base branch has moved ahead of
     # this branch since it was cut. Nothing else in the ws push/cr flow
     # surfaces this, and review_comments is the command the workflow

--- a/scripts/ws-review.sh
+++ b/scripts/ws-review.sh
@@ -461,16 +461,7 @@ review_comments() {
     printf '%s\n' "$summary" | review_sanitize_provider_text
     echo ""
 
-    # Branch-identity check: warn if the locally checked-out branch isn't
-    # actually this CR's head branch. A local branch can share history with
-    # the real CR branch (e.g. checked out from the same commit under a
-    # different name) without being it — committing/pushing there creates an
-    # unrelated branch instead of updating this CR (the exact mistake that
-    # motivated this check: a branch named "soloturn" was pushed as a new
-    # branch instead of updating the PR's actual "soloturn-performance"
-    # head). Checked before the drift check below, since drift against the
-    # wrong branch isn't meaningful. Best-effort: an unresolvable head
-    # branch degrades to silence, never a hard error.
+    # Branch-identity check: warn if the locally checked-out branch isn't actually this CR's head branch. A local branch can share history with the real CR branch (e.g. checked out from the same commit under a different name) without being it — committing/pushing there creates an unrelated branch instead of updating this CR (the exact mistake that motivated this check: a branch named "soloturn" was pushed as a new branch instead of updating the PR's actual "soloturn-performance" head). Checked before the drift check below, since drift against the wrong branch isn't meaningful. Best-effort: an unresolvable head branch degrades to silence, never a hard error.
     if [[ -n "$_SELECTED_REMOTE" ]]; then
         local head_ref=""
         head_ref=$(gp_review_head_branch "$REPO_SLUG" "$pr_num" 2>/dev/null) || head_ref=""
@@ -484,12 +475,7 @@ review_comments() {
         fi
     fi
 
-    # Branch-drift check: warn if the CR's base branch has moved ahead of
-    # this branch since it was cut. Nothing else in the ws push/cr flow
-    # surfaces this, and review_comments is the command the workflow
-    # already recommends running after every push — piggyback here instead
-    # of adding a separate command to remember. Best-effort: an unresolvable
-    # base branch or a fetch failure degrades to silence, never a hard error.
+    # Branch-drift check: warn if the CR's base branch has moved ahead of this branch since it was cut. Nothing else in the ws push/cr flow surfaces this, and review_comments is the command the workflow already recommends running after every push — piggyback here instead of adding a separate command to remember. Best-effort: an unresolvable base branch or a fetch failure degrades to silence, never a hard error.
     if [[ -n "$_SELECTED_REMOTE" ]]; then
         local base_ref=""
         base_ref=$(gp_review_base_branch "$REPO_SLUG" "$pr_num" 2>/dev/null) || base_ref=""
@@ -828,11 +814,7 @@ review_reply() {
     fi
 }
 
-# Post a top-level PR/MR comment — not attached to any inline diff thread.
-# Bodyfile-based (like ws cr / ws issue) rather than an inline message
-# because top-level comments in practice run long (multi-paragraph
-# explanations, code blocks) — unlike `reply`, which is typically a short
-# one-liner and keeps its inline-message signature.
+# Post a top-level PR/MR comment — not attached to any inline diff thread. Bodyfile-based (like ws cr / ws issue) rather than an inline message because top-level comments in practice run long (multi-paragraph explanations, code blocks) — unlike `reply`, which is typically a short one-liner and keeps its inline-message signature.
 review_comment() {
     if [[ $# -ne 2 ]]; then
         echo "Usage: ws review <comp> comment <cr#> <bodyfile> [--remote <name>]" >&2
@@ -1016,9 +998,7 @@ _SELECTED_PROVIDER=""
 # alone is ambiguous when two remotes share owner/repo across hosts or provider
 # mappings — token setup below needs the precise URL, not "first slug match".
 _SELECTED_URL=""
-# Remote name (not just slug/URL) — needed to `git fetch` the base branch for
-# the drift check in review_comments(). Matching by slug/URL alone isn't
-# enough since fetch needs the local remote name, not the repo identity.
+# Remote name (not just slug/URL) — needed to `git fetch` the base branch for the drift check in review_comments(). Matching by slug/URL alone isn't enough since fetch needs the local remote name, not the repo identity.
 _SELECTED_REMOTE=""
 if [[ -n "$REVIEW_REMOTE" ]]; then
     for i in "${!_CANDIDATE_REMOTES[@]}"; do

--- a/tests/ws-review/review-remote.bats
+++ b/tests/ws-review/review-remote.bats
@@ -159,10 +159,7 @@ probe_csi() { printf '\302\233'; }
 }
 
 @test "reply preserves a message that begins with --remote" {
-    # The <message> positional is free-form; a message that starts with
-    # --remote must reach the API verbatim (after the GDD attribution banner
-    # ws_gdd_attribution_line prepends), not be consumed as the flag. The
-    # trailing --remote selects the remote (required: CR #1 exists on both).
+    # The <message> positional is free-form; a message that starts with --remote must reach the API verbatim (after the GDD attribution banner ws_gdd_attribution_line prepends), not be consumed as the flag. The trailing --remote selects the remote (required: CR #1 exists on both).
     run_ws_review app reply 1 abc123 '--remote=spoof' --remote fork
 
     [ "$status" -eq 0 ]

--- a/tests/ws-review/review-remote.bats
+++ b/tests/ws-review/review-remote.bats
@@ -12,6 +12,8 @@ setup() {
 defaults:
   gitProviders:
     gitlab.com: gitlab
+identity:
+  human_account: reviewer
 components:
   app:
     repo: https://gitlab.com/upstream-group/project.git
@@ -158,13 +160,15 @@ probe_csi() { printf '\302\233'; }
 
 @test "reply preserves a message that begins with --remote" {
     # The <message> positional is free-form; a message that starts with
-    # --remote must reach the API verbatim, not be consumed as the flag.
-    # The trailing --remote selects the remote (required: CR #1 exists on both).
+    # --remote must reach the API verbatim (after the GDD attribution banner
+    # ws_gdd_attribution_line prepends), not be consumed as the flag. The
+    # trailing --remote selects the remote (required: CR #1 exists on both).
     run_ws_review app reply 1 abc123 '--remote=spoof' --remote fork
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"Replied to thread on CR #1 (example-group/forked-project)"* ]]
-    [ "$(cat "$BODY_LOG")" = "--remote=spoof" ]
+    [[ "$(cat "$BODY_LOG")" == *$'\n\n'"--remote=spoof" ]]
+    [[ "$(cat "$BODY_LOG")" == "> "*"AI-assisted reply"* ]]
 }
 
 @test "GitLab provider rejects a thread ID that can steer the API path" {


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @soloturn via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

- Two gaps surfaced while working MovingBlocks/gestalt#167 and MovingBlocks/Terasology#5353: the GDD AI-attribution banner was only enforced in `ws cr`/`ws issue`, so a top-level PR comment (no thread to reply to) had no `ws` path and fell back to raw `ws gh pr comment` with no attribution — required hand-patching both comments afterward. And nothing ever flagged branch drift from base; both CRs needed a manual `git fetch` + `log base..HEAD` to discover they'd fallen behind.
- `ws review <comp> reply` now auto-prepends the banner; new `ws review <comp> comment <cr#> <bodyfile>` posts a top-level comment with the same banner, closing the gap that forced the raw fallback.
- `ws review <comp> <cr#>` now warns when the CR's base branch has moved ahead, reusing the fetch that command already needs.

## Test plan

- [x] `ws test yggdrasil` — full bats suite passes except two pre-existing failures confirmed unrelated (reproduced identically on a clean `origin/main` worktree with no changes applied): ambient `GH_TOKEN` leaking into `ws-push/push.bats`, and order-dependent flakiness in `ws-clone/security.bats` (passes standalone)
- [x] Manually verified end-to-end against live PRs: `ws review comment` posted a real comment with the banner correctly attached; `ws review <cr#>` showed no false-positive drift warning on freshly-rebased branches

## Related

- See MovingBlocks/gestalt#167, MovingBlocks/Terasology#5353 (where the gaps were found)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for posting top-level pull request and merge request comments from review workflows.
  * Added standardized AI-attribution banners to new comments and replies.
* **Bug Fixes**
  * Review output now warns when the selected base branch has advanced beyond the current branch.
  * Remote selection is preserved more reliably during review operations.
* **Documentation**
  * Updated review guidance and help text for commenting, attribution, and branch freshness warnings.
  * Expanded branch workflow guidance for rebasing after remote changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->