### PR TITLE
fix: k8s floor first-party exemption, ws cr stale-base preflight, wrap-guard extension

### DIFF
--- a/.claude/hooks/gdd-permission-hook.sh
+++ b/.claude/hooks/gdd-permission-hook.sh
@@ -1634,14 +1634,25 @@ fi
 if [[ "$_k8s_floor_enabled" == "1" ]] && declare -F k8s_guard_evaluate >/dev/null 2>&1; then
     _k8s_match_cmd="$(k8s_guard_normalize_command "$match_cmd")"
     _k8s_script_file="$(k8s_guard_script_path "$cwd" "$cmd" 2>/dev/null || true)"
-    # The reviewed ws dispatcher mentions kubectl for its `ws k8s` verb, so a
-    # pre-PATH `bash scripts/ws <verb>` invocation would otherwise read as an
-    # opaque kubectl-bearing script and force-ask on every newcomer ws call.
-    # Its k8s flows are classified by the explicit `ws k8s` arms above; only
-    # the dispatcher itself (same inode) is exempt — any other script keeps
-    # the content inspection.
-    if [[ -n "$_k8s_script_file" && "$_k8s_script_file" -ef "$_trusted_root/scripts/ws" ]]; then
-        _k8s_script_file=""
+    # First-party workspace scripts mention kubectl legitimately — the
+    # dispatcher's `ws k8s` routing, the guard implementation itself, and
+    # audit PATTERN STRINGS in ws-audit-permissions.sh — so content-grepping
+    # them for the word produced false asks on read-only tools (a
+    # Codex-workspace session hit this on `bash scripts/ws-audit-permissions.sh`;
+    # direct script-path invocation is that harness's habitual form). Their
+    # real k8s flows are classified by the explicit `ws k8s` arms above.
+    # Exempt exactly the files that physically reside in the reviewed
+    # scripts/ directory: the file must not itself be a symlink (a link
+    # placed in scripts/ pointing elsewhere must keep inspection) and its
+    # PHYSICAL parent must be the workspace scripts/ dir (-ef compares
+    # inodes, so path spelling and symlinked ancestors can't spoof it).
+    # Everything else — scratch scripts, component scripts — keeps the
+    # content inspection.
+    if [[ -n "$_k8s_script_file" && ! -L "$_k8s_script_file" ]]; then
+        _k8s_script_parent="$(cd "$(dirname "$_k8s_script_file")" 2>/dev/null && pwd -P)" || _k8s_script_parent=""
+        if [[ -n "$_k8s_script_parent" && "$_k8s_script_parent" -ef "$_trusted_root/scripts" ]]; then
+            _k8s_script_file=""
+        fi
     fi
     k8s_guard_inline_shell_contains_kubectl "$match_cmd" && _k8s_inline_shell=1
     _k8s_floor_ctx="$(_sr_get GDD_K8S_CONTEXT)"

--- a/.claude/hooks/gdd-permission-hook.sh
+++ b/.claude/hooks/gdd-permission-hook.sh
@@ -1634,25 +1634,11 @@ fi
 if [[ "$_k8s_floor_enabled" == "1" ]] && declare -F k8s_guard_evaluate >/dev/null 2>&1; then
     _k8s_match_cmd="$(k8s_guard_normalize_command "$match_cmd")"
     _k8s_script_file="$(k8s_guard_script_path "$cwd" "$cmd" 2>/dev/null || true)"
-    # First-party workspace scripts mention kubectl legitimately — the
-    # dispatcher's `ws k8s` routing, the guard implementation itself, and
-    # audit PATTERN STRINGS in ws-audit-permissions.sh — so content-grepping
-    # them for the word produced false asks on read-only tools (a
-    # Codex-workspace session hit this on `bash scripts/ws-audit-permissions.sh`;
-    # direct script-path invocation is that harness's habitual form). Their
-    # real k8s flows are classified by the explicit `ws k8s` arms above.
-    # Exempt exactly the files that physically reside in the reviewed
-    # scripts/ directory: the file must not itself be a symlink (a link
-    # placed in scripts/ pointing elsewhere must keep inspection) and its
-    # PHYSICAL parent must be the workspace scripts/ dir (-ef compares
-    # inodes, so path spelling and symlinked ancestors can't spoof it).
-    # Everything else — scratch scripts, component scripts — keeps the
-    # content inspection.
-    if [[ -n "$_k8s_script_file" && ! -L "$_k8s_script_file" ]]; then
-        _k8s_script_parent="$(cd "$(dirname "$_k8s_script_file")" 2>/dev/null && pwd -P)" || _k8s_script_parent=""
-        if [[ -n "$_k8s_script_parent" && "$_k8s_script_parent" -ef "$_trusted_root/scripts" ]]; then
-            _k8s_script_file=""
-        fi
+    # The dispatcher and permission audit entrypoint legitimately mention
+    # kubectl while handling unrelated commands. Keep this carve-out exact and
+    # shared with Codex; every other script remains content-inspected.
+    if k8s_guard_script_content_exempt "$_trusted_root" "$_k8s_script_file"; then
+        _k8s_script_file=""
     fi
     k8s_guard_inline_shell_contains_kubectl "$match_cmd" && _k8s_inline_shell=1
     _k8s_floor_ctx="$(_sr_get GDD_K8S_CONTEXT)"

--- a/.codex/hooks/gdd-k8s-hook.sh
+++ b/.codex/hooks/gdd-k8s-hook.sh
@@ -94,12 +94,22 @@ normalize_for_match() {
 match_cmd="$(normalize_for_match "$cmd")"
 k8s_match_cmd="$(k8s_guard_normalize_command "$match_cmd")"
 script_path="$(k8s_guard_script_path "$cwd" "$cmd" 2>/dev/null || true)"
+if k8s_guard_script_content_exempt "$GDD_PROJECT_ROOT" "$script_path"; then
+    script_path=""
+fi
 inline_shell=0
 k8s_guard_inline_shell_contains_kubectl "$match_cmd" && inline_shell=1
 
 if [[ "$k8s_match_cmd" == "$K8S_GUARD_UNSAFE_COMMAND_SENTINEL" ]]; then
-    if [[ "$match_cmd" =~ (^|[^[:alnum:]_])kubectl([^[:alnum:]_]|$) ]] \
-        || [[ "$match_cmd" == *"ws k8s"* || "$match_cmd" == *"scripts/ws k8s"* ]]; then
+    masked_match_cmd="$(normalize_for_match "$(k8s_guard_mask_inert_quotes "$cmd")")"
+    unsafe_inline_shell=0
+    if [[ "$match_cmd" =~ ^[[:space:]]*([^[:space:]]*/)?(bash|sh)[[:space:]].*-[^[:space:]]*c([[:space:]]|$) ]] \
+        && [[ "$match_cmd" =~ (^|[^[:alnum:]_])kubectl([^[:alnum:]_]|$) ]]; then
+        unsafe_inline_shell=1
+    fi
+    if [[ "$masked_match_cmd" =~ (^|[^[:alnum:]_])kubectl([^[:alnum:]_]|$) ]] \
+        || [[ "$masked_match_cmd" == *"ws k8s"* || "$masked_match_cmd" == *"scripts/ws k8s"* ]] \
+        || [[ "$unsafe_inline_shell" == "1" ]]; then
         deny "Kubernetes commands must be issued as one composition-free command. This compound or multiline form cannot be evaluated safely."
     fi
     exit 0

--- a/.codex/hooks/gdd-k8s-hook.sh
+++ b/.codex/hooks/gdd-k8s-hook.sh
@@ -102,8 +102,15 @@ k8s_guard_inline_shell_contains_kubectl "$match_cmd" && inline_shell=1
 
 if [[ "$k8s_match_cmd" == "$K8S_GUARD_UNSAFE_COMMAND_SENTINEL" ]]; then
     masked_match_cmd="$(normalize_for_match "$(k8s_guard_mask_inert_quotes "$cmd")")"
+    # Compound forms defeat the tokenized inline-shell helper (word 0 is the
+    # first command, not the wrapped shell), so a regex stands in here. It
+    # tolerates assignment/env/command wrapper prefixes and requires -c as
+    # its own option word — a path operand like /tmp/build-abc must not
+    # read as command-string mode. Sentinel context, so over-matching a
+    # weird shape costs a deny that teaches one-command-at-a-time.
     unsafe_inline_shell=0
-    if [[ "$match_cmd" =~ ^[[:space:]]*([^[:space:]]*/)?(bash|sh)[[:space:]].*-[^[:space:]]*c([[:space:]]|$) ]] \
+    unsafe_inline_re='(^|[;&|[:space:]]|\()(([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*|env|command)[[:space:]]+)*([^[:space:]]*/)?(bash|sh|dash|ash|ksh|ksh93|mksh|zsh)[[:space:]]([^[:space:]]+[[:space:]])*-[A-Za-z]*c([[:space:]]|$)'
+    if [[ "$match_cmd" =~ $unsafe_inline_re ]] \
         && [[ "$match_cmd" =~ (^|[^[:alnum:]_])kubectl([^[:alnum:]_]|$) ]]; then
         unsafe_inline_shell=1
     fi

--- a/scripts/git-cr.sh
+++ b/scripts/git-cr.sh
@@ -313,6 +313,7 @@ check_base_branch_fresh() {
   if [[ "$_bs" -eq 2 ]]; then
     echo "ERROR: target branch '$base_branch' is not known on remote '$remote'." >&2
     echo "  Check the repository default branch and remote selection, then retry." >&2
+    echo "  If the detected default branch is intentionally absent here, --stale-base-ok skips this preflight." >&2
     exit 1
   elif [[ "$_bs" -ne 0 ]]; then
     echo "ERROR: could not verify target branch '$base_branch' on '$remote' — git ls-remote failed (see above); check connectivity and auth." >&2

--- a/scripts/git-cr.sh
+++ b/scripts/git-cr.sh
@@ -366,7 +366,11 @@ if [[ -n "$UPSTREAM" ]]; then
     fi
   fi
   UPSTREAM_REMOTE="${UPSTREAM_REMOTES[0]}"
-  UPSTREAM_URL=$(git remote get-url "$UPSTREAM_REMOTE" 2>/dev/null)
+  # Raw config read for the same reason as FORK_URL above: every consumer is
+  # logical (provider detect, host compare, token mapping) and must see the
+  # canonical configured URL, not a url.insteadOf rewrite. Transport addresses
+  # the remote by NAME, so git still applies rewrites where they belong.
+  UPSTREAM_URL=$(git config --get-all "remote.$UPSTREAM_REMOTE.url" 2>/dev/null | head -n1) || true
 
   # Verify both remotes use the same provider
   UPSTREAM_PROVIDER=$(gp_detect "$UPSTREAM_URL" "$_ECO" 2>/dev/null) || {

--- a/scripts/git-cr.sh
+++ b/scripts/git-cr.sh
@@ -300,8 +300,8 @@ fi
 # fails with a rebase pointer. --stale-base-ok (or GIT_CR_STALE_BASE_OK=1)
 # skips the check for deliberate cases like stacked CRs. Same exit-code
 # discipline as the source-branch verification above: ls-remote exit 2 =
-# ref absent (let CR creation surface the provider's own error), other
-# nonzero = transport/auth failure.
+# ref absent, other nonzero = transport/auth failure. Both fail closed before
+# handing an ambiguous base to the provider.
 check_base_branch_fresh() {
   local remote="$1" remote_url="$2" base_branch="$3"
   [[ "$STALE_BASE_OK" == "1" ]] && return 0
@@ -311,7 +311,9 @@ check_base_branch_fresh() {
   local _bs=0 _out _tip
   _out=$(env ${GIT_AUTH_ENV[@]+"${GIT_AUTH_ENV[@]}"} git ls-remote --exit-code "$remote" "refs/heads/$base_branch") || _bs=$?
   if [[ "$_bs" -eq 2 ]]; then
-    return 0
+    echo "ERROR: target branch '$base_branch' is not known on remote '$remote'." >&2
+    echo "  Check the repository default branch and remote selection, then retry." >&2
+    exit 1
   elif [[ "$_bs" -ne 0 ]]; then
     echo "ERROR: could not verify target branch '$base_branch' on '$remote' — git ls-remote failed (see above); check connectivity and auth." >&2
     exit 1

--- a/scripts/git-cr.sh
+++ b/scripts/git-cr.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # git-cr.sh — open a change request (PR/MR) from the current branch
 #
-# Usage: git-cr.sh [--remote REMOTE] [--source-branch BRANCH] [--upstream] TITLE BODYFILE
+# Usage: git-cr.sh [--remote REMOTE] [--source-branch BRANCH] [--upstream] [--stale-base-ok] TITLE BODYFILE
 #   --remote REMOTE — use this git remote as the fork/head remote.
 #                     Defaults to GIT_CR_REMOTE, then identity.forkRemote.
 #   --source-branch BRANCH — submit this local, remote-tracked branch instead
@@ -80,10 +80,15 @@ _create_pr_with_prominent_url() {
 UPSTREAM=""
 CR_REMOTE="${GIT_CR_REMOTE:-}"
 SOURCE_BRANCH="${GIT_CR_SOURCE_BRANCH:-}"
+STALE_BASE_OK="${GIT_CR_STALE_BASE_OK:-}"
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --upstream)
       UPSTREAM="1"
+      shift
+      ;;
+    --stale-base-ok)
+      STALE_BASE_OK="1"
       shift
       ;;
     --remote)
@@ -141,7 +146,7 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 mkdir -p "$REPO_ROOT/.crs"
 
 if [[ -z "$TITLE" || -z "$BODYFILE" || $# -ne 2 ]]; then
-  echo "Usage: $0 [--remote REMOTE] [--source-branch BRANCH] [--upstream] TITLE BODYFILE" >&2
+  echo "Usage: $0 [--remote REMOTE] [--source-branch BRANCH] [--upstream] [--stale-base-ok] TITLE BODYFILE" >&2
   echo "  See templates/change.md for a ready-to-copy bodyfile template. CR bodyfiles conventionally live in .crs/." >&2
   exit 1
 fi
@@ -288,6 +293,44 @@ if [[ -n "$EXPLICIT_SOURCE_BRANCH" ]]; then
   fi
 fi
 
+# Stale-base preflight. With multiple contributors, the target branch's tip
+# routinely moves between branching and CR time — the bots then review a
+# stale diff and conflicts surface only after the CR opens. Verify the live
+# base tip is contained in the source branch before creating; a moved base
+# fails with a rebase pointer. --stale-base-ok (or GIT_CR_STALE_BASE_OK=1)
+# skips the check for deliberate cases like stacked CRs. Same exit-code
+# discipline as the source-branch verification above: ls-remote exit 2 =
+# ref absent (let CR creation surface the provider's own error), other
+# nonzero = transport/auth failure.
+check_base_branch_fresh() {
+  local remote="$1" remote_url="$2" base_branch="$3"
+  [[ "$STALE_BASE_OK" == "1" ]] && return 0
+  declare -a GIT_AUTH_ENV=()
+  local GIT_AUTH_LABEL="" GIT_AUTH_PROVIDER=""
+  git_auth_env_for_url "$remote_url"
+  local _bs=0 _out _tip
+  _out=$(env ${GIT_AUTH_ENV[@]+"${GIT_AUTH_ENV[@]}"} git ls-remote --exit-code "$remote" "refs/heads/$base_branch") || _bs=$?
+  if [[ "$_bs" -eq 2 ]]; then
+    return 0
+  elif [[ "$_bs" -ne 0 ]]; then
+    echo "ERROR: could not verify target branch '$base_branch' on '$remote' — git ls-remote failed (see above); check connectivity and auth." >&2
+    exit 1
+  fi
+  _tip="${_out%%[[:space:]]*}"
+  if ! git cat-file -e "${_tip}^{commit}" 2>/dev/null; then
+    env ${GIT_AUTH_ENV[@]+"${GIT_AUTH_ENV[@]}"} git fetch --quiet "$remote" "refs/heads/$base_branch" || {
+      echo "ERROR: could not fetch target branch '$base_branch' from '$remote' for the stale-base check." >&2
+      exit 1
+    }
+  fi
+  if ! git merge-base --is-ancestor "$_tip" "refs/heads/$BRANCH"; then
+    echo "ERROR: target branch '$base_branch' on '$remote' has moved — tip ${_tip:0:12} is not contained in '$BRANCH'." >&2
+    echo "  Rebase first (git fetch $remote && git rebase $remote/$base_branch, or ws pull), re-push, then re-run ws cr." >&2
+    echo "  Submitting against the moved base deliberately (e.g. a stacked CR)? Re-run with --stale-base-ok." >&2
+    exit 1
+  fi
+}
+
 # Detect provider and load implementation; set token before auth check
 gp_detect_and_load "$FORK_URL" "$_ECO"
 gp_set_token_for_url "$FORK_URL" "$_AUTH_ECO"
@@ -364,6 +407,8 @@ if [[ -n "$UPSTREAM" ]]; then
   gp_set_token_for_url "$UPSTREAM_URL" "$_AUTH_ECO"
   UPSTREAM_DEFAULT=$(gp_default_branch "$UPSTREAM_SLUG")
 
+  check_base_branch_fresh "$UPSTREAM_REMOTE" "$UPSTREAM_URL" "$UPSTREAM_DEFAULT"
+
   echo "Opening cross-fork CR: $FORK_SLUG:$BRANCH → $UPSTREAM_SLUG:$UPSTREAM_DEFAULT"
   echo "  Title: $TITLE"
   echo "  Body : $BODYFILE ($(wc -l < "$BODYFILE") lines)"
@@ -384,6 +429,8 @@ else
   gp_set_token_for_url "$FORK_URL" "$_AUTH_ECO"
 
   DEFAULT_BRANCH=$(gp_default_branch "$FORK_SLUG")
+
+  check_base_branch_fresh "$FORK_REMOTE" "$FORK_URL" "$DEFAULT_BRANCH"
 
   echo "Opening CR for $FORK_SLUG/$BRANCH → $DEFAULT_BRANCH"
   echo "  Title: $TITLE"

--- a/scripts/providers/gitlab.sh
+++ b/scripts/providers/gitlab.sh
@@ -244,6 +244,12 @@ gp_review_threads_status() {
 # Usage: gp_review_thread_reply SLUG MR_NUM DISCUSSION_ID MESSAGE
 _gl_validate_discussion_id() {
     local discussion_id="$1"
+    # "." and ".." pass the character allowlist but are path segments —
+    # URL normalization can steer them to a different API endpoint.
+    if [[ "$discussion_id" == "." || "$discussion_id" == ".." ]]; then
+        echo "ERROR: Invalid GitLab discussion ID." >&2
+        return 1
+    fi
     if [[ ! "$discussion_id" =~ ^[A-Za-z0-9._~-]+$ ]]; then
         echo "ERROR: Invalid GitLab discussion ID." >&2
         return 1

--- a/scripts/providers/gitlab.sh
+++ b/scripts/providers/gitlab.sh
@@ -242,8 +242,17 @@ gp_review_threads_status() {
 
 # Reply to a discussion thread.
 # Usage: gp_review_thread_reply SLUG MR_NUM DISCUSSION_ID MESSAGE
+_gl_validate_discussion_id() {
+    local discussion_id="$1"
+    if [[ ! "$discussion_id" =~ ^[A-Za-z0-9._~-]+$ ]]; then
+        echo "ERROR: Invalid GitLab discussion ID." >&2
+        return 1
+    fi
+}
+
 gp_review_thread_reply() {
     local slug="$1" mr_num="$2" discussion_id="$3" message="$4"
+    _gl_validate_discussion_id "$discussion_id" || return 1
     local encoded; encoded=$(_gl_encode "$slug")
     glab api --method POST "projects/$encoded/merge_requests/$mr_num/discussions/$discussion_id/notes" \
         -f body="$message" >/dev/null 2>&1
@@ -253,6 +262,7 @@ gp_review_thread_reply() {
 # Usage: gp_review_thread_resolve SLUG MR_NUM DISCUSSION_ID
 gp_review_thread_resolve() {
     local slug="$1" mr_num="$2" discussion_id="$3"
+    _gl_validate_discussion_id "$discussion_id" || return 1
     local encoded; encoded=$(_gl_encode "$slug")
     glab api --method PUT "projects/$encoded/merge_requests/$mr_num/discussions/$discussion_id" \
         -f resolved=true >/dev/null 2>&1

--- a/scripts/ws
+++ b/scripts/ws
@@ -243,8 +243,9 @@ Usage: ws cr <component> [--remote <remote>] [--source-branch <branch>] [--upstr
 
 Opens a code-review request via git-cr.sh. The current branch is used unless
 --source-branch selects another pushed branch from the same repository. Before
-creating, the live target-branch tip is verified to be contained in the source
-branch — a moved target fails with a rebase pointer unless --stale-base-ok.
+creating, the live target-branch tip is verified to exist and be contained in
+the source branch — a moved target fails with a rebase pointer, a missing
+target fails closed; --stale-base-ok skips the preflight either way.
 HELP
             return 0
         fi

--- a/scripts/ws
+++ b/scripts/ws
@@ -228,25 +228,29 @@ ws_cr() {
     for _arg in "$@"; do
         if [[ "$_arg" == "--help" || "$_arg" == "-h" ]]; then
             cat <<'HELP'
-Usage: ws cr <component> [--remote <remote>] [--source-branch <branch>] [--upstream] <title> <bodyfile>
+Usage: ws cr <component> [--remote <remote>] [--source-branch <branch>] [--upstream] [--stale-base-ok] <title> <bodyfile>
 
   component   Component, realm, or hoard to open the CR against
   --remote    Use this git remote as the fork/head remote for this CR
   --source-branch
               Submit this local, remote-tracked branch instead of current HEAD
   --upstream  Target the upstream repo instead of the fork remote
+  --stale-base-ok
+              Skip the stale-base preflight (deliberate stacked CRs etc.)
   title       CR (PR / MR) title
   bodyfile    Path (relative to workspace root) to a change bodyfile
               — see templates/change.md
 
 Opens a code-review request via git-cr.sh. The current branch is used unless
---source-branch selects another pushed branch from the same repository.
+--source-branch selects another pushed branch from the same repository. Before
+creating, the live target-branch tip is verified to be contained in the source
+branch — a moved target fails with a rebase pointer unless --stale-base-ok.
 HELP
             return 0
         fi
     done
-    if [[ $# -lt 3 || $# -gt 8 ]]; then
-        echo "Usage: ws cr <component> [--remote <remote>] [--source-branch <branch>] [--upstream] <title> <bodyfile>" >&2
+    if [[ $# -lt 3 || $# -gt 9 ]]; then
+        echo "Usage: ws cr <component> [--remote <remote>] [--source-branch <branch>] [--upstream] [--stale-base-ok] <title> <bodyfile>" >&2
         exit 1
     fi
     local comp="$1"
@@ -295,8 +299,8 @@ HELP
                 ;;
         esac
     done
-    if [[ ${#args[@]} -lt 2 || ${#args[@]} -gt 3 ]]; then
-        echo "Usage: ws cr <component> [--remote <remote>] [--source-branch <branch>] [--upstream] <title> <bodyfile>" >&2
+    if [[ ${#args[@]} -lt 2 || ${#args[@]} -gt 4 ]]; then
+        echo "Usage: ws cr <component> [--remote <remote>] [--source-branch <branch>] [--upstream] [--stale-base-ok] <title> <bodyfile>" >&2
         exit 1
     fi
     # Resolve bodyfile path before cd (last arg is always the bodyfile)

--- a/scripts/ws-k8s-guard.sh
+++ b/scripts/ws-k8s-guard.sh
@@ -224,10 +224,16 @@ k8s_guard_mask_inert_quotes() {
         segment="${input:start:i-start}"
         if [[ "$at_command_start" == "1" ]]; then
             output+="$segment"
+            # Track the span's INNER text as word content: a quoted wrapper
+            # word ("env", "command") must still match the wrapper case when
+            # the word completes. A placeholder here flipped command position
+            # off and let the NEXT quoted command word be blanked — a
+            # compound `then "env" "kubectl" …` slipped the deny floor.
+            word+="${segment:1:${#segment}-2}"
         else
             output+="${segment//?/ }"
+            word+="q"
         fi
-        word+="q"
     done
     printf '%s' "$output"
 }
@@ -499,11 +505,11 @@ k8s_guard_evaluate() {
                         ;;
                 esac
                 ;;
-            --kubeconfig|--server|--token|--as|--as-group|--as-uid|--user|--cluster|--client-certificate|--client-key|--certificate-authority)
+            --kubeconfig|--server|--token|--as|--as-group|--as-uid|--as-user-extra|--user|--cluster|--client-certificate|--client-key|--certificate-authority)
                 printf 'BLOCK:context:%s cannot override the guarded Kubernetes connection or credentials' "$a"
                 return 0
                 ;;
-            --kubeconfig=*|--server=*|--token=*|--as=*|--as-group=*|--as-uid=*|--user=*|--cluster=*|--client-certificate=*|--client-key=*|--certificate-authority=*)
+            --kubeconfig=*|--server=*|--token=*|--as=*|--as-group=*|--as-uid=*|--as-user-extra=*|--user=*|--cluster=*|--client-certificate=*|--client-key=*|--certificate-authority=*)
                 printf 'BLOCK:context:%s cannot override the guarded Kubernetes connection or credentials' "${a%%=*}"
                 return 0
                 ;;

--- a/scripts/ws-k8s-guard.sh
+++ b/scripts/ws-k8s-guard.sh
@@ -117,6 +117,106 @@ k8s_guard_script_path() {
     printf '%s' "$path"
 }
 
+# True only for the two reviewed workspace entrypoints whose source text
+# legitimately mentions kubectl while dispatching or auditing other commands.
+# Exact inode comparison tolerates alternate path spellings; rejecting symlinks
+# prevents an exempt name from becoming an alias to different content.
+k8s_guard_script_content_exempt() {
+    local root="$1" path="$2" candidate
+    [[ -n "$root" && -n "$path" && ! -L "$path" ]] || return 1
+    for candidate in \
+        "$root/scripts/ws" \
+        "$root/scripts/ws-audit-permissions.sh"; do
+        if [[ -f "$candidate" && "$path" -ef "$candidate" ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Mask inert single- and double-quoted spans before deciding whether an unsafe
+# compound command is Kubernetes-related. Shell operators and words inside a
+# quoted search pattern are data, not executable syntax. Double-quoted spans
+# containing expansion syntax and malformed quoting retain the original input
+# so callers continue to fail closed.
+k8s_guard_mask_inert_quotes() {
+    local input="$1" output="" char quote segment word=""
+    local i=0 start length=${#1} closed live at_command_start=1 wrapper_operand=0
+    while [[ $i -lt $length ]]; do
+        char="${input:i:1}"
+        if [[ "$char" != "'" && "$char" != '"' ]]; then
+            output+="$char"
+            case "$char" in
+                $'\n'|$'\r'|';'|'|'|'&')
+                    word=""
+                    at_command_start=1
+                    ;;
+                ' '|$'\t')
+                    if [[ -n "$word" ]]; then
+                        if [[ "$at_command_start" == "1" ]]; then
+                            if [[ "$wrapper_operand" == "1" ]]; then
+                                wrapper_operand=0
+                            else
+                                case "$word" in
+                                    [A-Za-z_][A-Za-z0-9_]*=*|env|*/env|command|*/command|--|-i|--ignore-environment|-p)
+                                        ;;
+                                    -u|--unset)
+                                        wrapper_operand=1
+                                        ;;
+                                    --unset=*)
+                                        ;;
+                                    *)
+                                        at_command_start=0
+                                        ;;
+                                esac
+                            fi
+                        fi
+                        word=""
+                    fi
+                    ;;
+                *) word+="$char" ;;
+            esac
+            i=$((i + 1))
+            continue
+        fi
+
+        quote="$char"
+        start=$i
+        i=$((i + 1))
+        closed=0
+        live=0
+        while [[ $i -lt $length ]]; do
+            char="${input:i:1}"
+            if [[ "$quote" == '"' && "$char" == '\' ]]; then
+                i=$((i + 2))
+                continue
+            fi
+            if [[ "$char" == "$quote" ]]; then
+                i=$((i + 1))
+                closed=1
+                break
+            fi
+            if [[ "$quote" == '"' && ( "$char" == '$' || "$char" == '`' ) ]]; then
+                live=1
+            fi
+            i=$((i + 1))
+        done
+        if [[ "$closed" != "1" || "$live" == "1" ]]; then
+            printf '%s' "$input"
+            return 0
+        fi
+
+        segment="${input:start:i-start}"
+        if [[ "$at_command_start" == "1" ]]; then
+            output+="$segment"
+        else
+            output+="${segment//?/ }"
+        fi
+        word+="q"
+    done
+    printf '%s' "$output"
+}
+
 # True when a shell's inline-command option carries a literal kubectl call.
 k8s_guard_inline_shell_contains_kubectl() {
     local command="$1" normalized runner token
@@ -358,7 +458,7 @@ k8s_guard_evaluate() {
     else
         printf 'NOT_K8S'; return 0
     fi
-    local verb="" verb2="" ctx_arg="" ns_arg="" all_ns=0 raw_api=0 a
+    local verb="" verb2="" ctx_arg="" ns_arg="" all_ns=0 raw_api=0 a all_ns_value
     local ffiles=()
     local kdirs=()
     local rest_pos=()   # positional resource names after verb + resource-type
@@ -373,6 +473,25 @@ k8s_guard_evaluate() {
             -n=*|--namespace=*) ns_arg="${a#*=}";;
             -n?*) ns_arg="${a#-n}";;        # attached short form: -n<ns>
             -A|--all-namespaces) all_ns=1 ;;
+            --all-namespaces=*)
+                all_ns_value="${a#*=}"
+                case "$all_ns_value" in
+                    true|True|TRUE|1|t|T) all_ns=1 ;;
+                    false|False|FALSE|0|f|F) all_ns=0 ;;
+                    *)
+                        printf 'BLOCK:precondition:invalid --all-namespaces boolean value'
+                        return 0
+                        ;;
+                esac
+                ;;
+            --kubeconfig|--server|--token)
+                printf 'BLOCK:context:%s cannot override the guarded Kubernetes connection or credentials' "$a"
+                return 0
+                ;;
+            --kubeconfig=*|--server=*|--token=*)
+                printf 'BLOCK:context:%s cannot override the guarded Kubernetes connection or credentials' "${a%%=*}"
+                return 0
+                ;;
             -f|--filename) ffiles+=("${args[$((i+1))]:-}"); i=$((i+2)); continue ;;
             -f=*|--filename=*) ffiles+=("${a#*=}");;
             -f?*) ffiles+=("${a#-f}");;      # attached short form: -f<file>
@@ -444,7 +563,45 @@ k8s_guard_evaluate() {
     # deletes prod regardless). Fail closed before any namespace logic.
     case "$verb" in
         cordon|uncordon|drain) printf 'BLOCK:unbounded:kubectl %s operates on a node (cluster-scoped); not namespace-scope-bounded' "$verb"; return 0 ;;
+        certificate)
+            case "$verb2" in
+                approve|deny)
+                    printf 'BLOCK:unbounded:kubectl certificate %s changes a cluster-scoped certificate request' "$verb2"
+                    return 0
+                    ;;
+            esac
+            ;;
     esac
+
+    # `kubectl cp` accepts [namespace/]pod:path on either side. An explicit
+    # operand namespace overrides the context default, so inspect both operands
+    # before falling back to the ordinary -n/default-namespace check.
+    if [[ "$verb" == "cp" ]]; then
+        local cp_operand cp_remote cp_ns cp_explicit=0
+        local -a cp_operands=("$verb2")
+        [[ ${#rest_pos[@]} -gt 0 ]] && cp_operands+=("${rest_pos[@]}")
+        for cp_operand in "${cp_operands[@]}"; do
+            [[ "$cp_operand" == *:* ]] || continue
+            cp_remote="${cp_operand%%:*}"
+            [[ "$cp_remote" == */* ]] || continue
+            cp_ns="${cp_remote%%/*}"
+            [[ -n "$cp_ns" ]] || continue
+            cp_explicit=1
+            if ! _k8s_ns_in_csv "$cp_ns" "$scope_ns_csv"; then
+                printf 'BLOCK:scope:kubectl cp operand namespace %s is outside the guard scope (%s)' "$cp_ns" "$scope_ns_csv"
+                return 0
+            fi
+        done
+        if [[ "$cp_explicit" == "1" ]]; then
+            if [[ -n "$ns_arg" ]] && ! _k8s_ns_in_csv "$ns_arg" "$scope_ns_csv"; then
+                printf 'BLOCK:scope:kubectl cp -n namespace %s is outside the guard scope (%s)' "$ns_arg" "$scope_ns_csv"
+                return 0
+            fi
+            printf 'WRITE_IN_SCOPE'
+            return 0
+        fi
+    fi
+
     # In-scope namespace lifecycle: create/delete of a namespace whose NAME is
     # itself within the guard scope is allowed — it lets a practitioner create
     # (or delete and recreate) their own scoped namespace(s). The namespace name

--- a/scripts/ws-k8s-guard.sh
+++ b/scripts/ws-k8s-guard.sh
@@ -30,6 +30,16 @@ k8s_guard_normalize_command() {
             return 0
             ;;
     esac
+    # Subshell parens are compound forms too, but only OUTSIDE quotes — a
+    # label selector like -l 'env in (prod)' is a single command. Check the
+    # inert-quote-masked form: quoted parens vanish, live ones classify
+    # unsafe (and a malformed-quote input returns unmasked, failing closed).
+    case "$(k8s_guard_mask_inert_quotes "$command")" in
+        *"("*|*")"*)
+            printf '%s' "$K8S_GUARD_UNSAFE_COMMAND_SENTINEL"
+            return 0
+            ;;
+    esac
     local -a words=()
     read -r -a words <<< "$command"
     [[ ${#words[@]} -gt 0 ]] || return 0
@@ -147,7 +157,7 @@ k8s_guard_mask_inert_quotes() {
         if [[ "$char" != "'" && "$char" != '"' ]]; then
             output+="$char"
             case "$char" in
-                $'\n'|$'\r'|';'|'|'|'&')
+                $'\n'|$'\r'|';'|'|'|'&'|'('|')')
                     word=""
                     at_command_start=1
                     ;;
@@ -159,6 +169,11 @@ k8s_guard_mask_inert_quotes() {
                             else
                                 case "$word" in
                                     [A-Za-z_][A-Za-z0-9_]*=*|env|*/env|command|*/command|--|-i|--ignore-environment|-p)
+                                        ;;
+                                    # Control-flow words keep the NEXT word in
+                                    # command position — `if true; then "kubectl"
+                                    # …` must not mask the quoted command word.
+                                    if|then|else|elif|fi|while|until|do|done|case|esac|'!'|'{'|'}')
                                         ;;
                                     -u|--unset)
                                         wrapper_operand=1
@@ -484,11 +499,11 @@ k8s_guard_evaluate() {
                         ;;
                 esac
                 ;;
-            --kubeconfig|--server|--token)
+            --kubeconfig|--server|--token|--as|--as-group|--as-uid|--user|--cluster|--client-certificate|--client-key|--certificate-authority)
                 printf 'BLOCK:context:%s cannot override the guarded Kubernetes connection or credentials' "$a"
                 return 0
                 ;;
-            --kubeconfig=*|--server=*|--token=*)
+            --kubeconfig=*|--server=*|--token=*|--as=*|--as-group=*|--as-uid=*|--user=*|--cluster=*|--client-certificate=*|--client-key=*|--certificate-authority=*)
                 printf 'BLOCK:context:%s cannot override the guarded Kubernetes connection or credentials' "${a%%=*}"
                 return 0
                 ;;

--- a/tests/hook/codex-k8s-hook.bats
+++ b/tests/hook/codex-k8s-hook.bats
@@ -98,6 +98,14 @@ assert_denied() {
     assert_denied
 }
 
+@test "quoted wrapper word cannot blank the following quoted kubectl" {
+    seed_scope codex-test kind-practice alice-sandbox
+
+    run_codex_hook 'if true; then "env" "kubectl" delete namespace prod; fi'
+
+    assert_denied
+}
+
 @test "quoted kubectl search pattern defers to normal Codex routing" {
     seed_scope codex-test kind-practice alice-sandbox
 

--- a/tests/hook/codex-k8s-hook.bats
+++ b/tests/hook/codex-k8s-hook.bats
@@ -74,6 +74,49 @@ assert_denied() {
     [[ "$(jq -r '.hookSpecificOutput.permissionDecisionReason' <<< "$output")" == *"compound or multiline"* ]]
 }
 
+@test "quoted kubectl search pattern defers to normal Codex routing" {
+    seed_scope codex-test kind-practice alice-sandbox
+
+    run_codex_hook 'rg -n "all-namespaces|kubectl|WRITE" scripts/ws-k8s-guard.sh'
+
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "quoted Kubernetes-looking shell data defers to normal Codex routing" {
+    seed_scope codex-test kind-practice alice-sandbox
+    local command
+    for command in \
+        "rg -n 'all-namespaces|kubectl|WRITE' scripts/ws-k8s-guard.sh" \
+        'printf "kubectl; this is inert data"'; do
+        run_codex_hook "$command"
+        [ "$status" -eq 0 ]
+        [ -z "$output" ]
+    done
+}
+
+@test "quoted kubectl command words in unsafe forms remain denied" {
+    seed_scope codex-test kind-practice alice-sandbox
+    local command
+    for command in \
+        'echo safe; "kubectl" delete namespace prod' \
+        'VAR=value "kubectl" delete namespace prod; echo unsafe' \
+        'env "kubectl" delete namespace prod; echo unsafe'; do
+        run_codex_hook "$command"
+        assert_denied
+        [[ "$(jq -r '.hookSpecificOutput.permissionDecisionReason' <<< "$output")" == *"compound or multiline"* ]]
+    done
+}
+
+@test "unsafe inline shell containing kubectl is denied before partial evaluation" {
+    seed_scope codex-test kind-practice alice-sandbox
+
+    run_codex_hook "bash -c 'echo safe; kubectl delete namespace prod'"
+
+    assert_denied
+    [[ "$(jq -r '.hookSpecificOutput.permissionDecisionReason' <<< "$output")" == *"compound or multiline"* ]]
+}
+
 @test "unrelated multiline command still defers to normal Codex routing" {
     seed_scope codex-test kind-practice alice-sandbox
 
@@ -128,6 +171,46 @@ assert_denied() {
     reason="$(jq -r '.hookSpecificOutput.permissionDecisionReason' <<< "$output")"
     [[ "${reason,,}" == *"no kubernetes guard scope is active"* ]]
     [[ "$reason" == *"calls raw kubectl"* ]]
+}
+
+@test "reviewed ws dispatcher is exempt from script content inspection" {
+    printf '#!/usr/bin/env bash\n# ws k8s eventually dispatches to kubectl\n' > "$WORK/scripts/ws"
+
+    run_codex_hook 'bash scripts/ws review yggdrasil 142' no-scope
+
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "reviewed permission audit script is exempt from script content inspection" {
+    printf '#!/usr/bin/env bash\necho "Bash(kubectl:*)|high|blanket kubectl allow"\n' > "$WORK/scripts/ws-audit-permissions.sh"
+
+    run_codex_hook 'bash scripts/ws-audit-permissions.sh' no-scope
+
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "other first-party scripts remain subject to content inspection" {
+    printf '#!/usr/bin/env bash\nkubectl apply -k overlays/plain\n' > "$WORK/scripts/other.sh"
+
+    run_codex_hook 'bash scripts/other.sh' no-scope
+
+    assert_denied
+    [[ "$(jq -r '.hookSpecificOutput.permissionDecisionReason' <<< "$output")" == *"calls raw kubectl"* ]]
+}
+
+@test "symlink to an exempt script remains subject to content inspection" {
+    printf '#!/usr/bin/env bash\nkubectl apply -k overlays/plain\n' > "$WORK/scripts/ws-audit-permissions.sh"
+    ln -s "$WORK/scripts/ws-audit-permissions.sh" "$WORK/scripts/ws-audit-linked.sh" 2>/dev/null || true
+    if [[ ! -L "$WORK/scripts/ws-audit-linked.sh" ]]; then
+        skip "symlinks unavailable on this platform"
+    fi
+
+    run_codex_hook 'bash scripts/ws-audit-linked.sh' no-scope
+
+    assert_denied
+    [[ "$(jq -r '.hookSpecificOutput.permissionDecisionReason' <<< "$output")" == *"calls raw kubectl"* ]]
 }
 
 @test "slash-relative script containing kubectl is denied when no scope is active" {

--- a/tests/hook/codex-k8s-hook.bats
+++ b/tests/hook/codex-k8s-hook.bats
@@ -74,6 +74,30 @@ assert_denied() {
     [[ "$(jq -r '.hookSpecificOutput.permissionDecisionReason' <<< "$output")" == *"compound or multiline"* ]]
 }
 
+@test "quoted kubectl after a subshell open is still denied, not masked away" {
+    seed_scope codex-test kind-practice alice-sandbox
+
+    run_codex_hook '( "kubectl" delete namespace prod )'
+
+    assert_denied
+}
+
+@test "quoted kubectl after control-flow words is still denied, not masked away" {
+    seed_scope codex-test kind-practice alice-sandbox
+
+    run_codex_hook 'if true; then "kubectl" delete namespace prod; fi'
+
+    assert_denied
+}
+
+@test "env-wrapped inline shell in a compound command is still denied" {
+    seed_scope codex-test kind-practice alice-sandbox
+
+    run_codex_hook "echo safe; env FOO=1 bash -c 'kubectl delete namespace prod'"
+
+    assert_denied
+}
+
 @test "quoted kubectl search pattern defers to normal Codex routing" {
     seed_scope codex-test kind-practice alice-sandbox
 

--- a/tests/hook/gdd-permission-hook.bats
+++ b/tests/hook/gdd-permission-hook.bats
@@ -2620,6 +2620,44 @@ BASH
     [ "$status" -eq 0 ]
     [[ "$output" == *"\"permissionDecision\":\"ask\""* ]]
 }
+@test "k8s safety floor: first-party scripts/ file with kubectl as data does not ask" {
+    # ws-audit-permissions.sh carries "kubectl" in audit PATTERN STRINGS;
+    # content-grepping it produced false asks on a read-only tool (hit by
+    # a Codex-workspace session via direct script-path invocation). Files
+    # physically residing in the reviewed scripts/ dir are exempt.
+    write_project_hook_rules "$(printf '[scoped-redirect-commands]\nk8s | kubectl* | GDD_K8S_CONTEXT | Use ws k8s\n')"
+    mkdir -p "$WORK/scripts"
+    printf '#!/bin/bash\necho "Bash(kubectl:*)|high|blanket kubectl allow"\n' > "$WORK/scripts/ws-audit-fake.sh"
+    run_hook_with_session "bash $WORK/scripts/ws-audit-fake.sh" "no-scope-sess"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"\"permissionDecision\":\"ask\""* ]]
+}
+
+@test "k8s safety floor: symlink inside scripts/ keeps the content inspection" {
+    write_project_hook_rules "$(printf '[scoped-redirect-commands]\nk8s | kubectl* | GDD_K8S_CONTEXT | Use ws k8s\n')"
+    mkdir -p "$WORK/scripts"
+    printf '#!/bin/bash\nkubectl apply -k overlays/plain\n' > "$WORK/outside.sh"
+    ln -s "$WORK/outside.sh" "$WORK/scripts/ws-linked.sh" 2>/dev/null || true
+    if [[ ! -L "$WORK/scripts/ws-linked.sh" ]]; then
+        # MSYS ln -s silently copies when symlinks are unavailable — a copy
+        # inside scripts/ is legitimately first-party, so nothing to test.
+        skip "symlinks unavailable on this platform"
+    fi
+    run_hook_with_session "bash $WORK/scripts/ws-linked.sh" "no-scope-sess"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"\"permissionDecision\":\"ask\""* ]]
+}
+
+@test "k8s scoped: first-party scripts/ file with kubectl as data is not denied" {
+    write_project_hook_rules "$(printf '[scoped-redirect-commands]\nk8s | kubectl* | GDD_K8S_CONTEXT | Use ws k8s\n')"
+    seed_k8s_scope "sk8s" "kind-practice" "alice-sandbox"
+    mkdir -p "$WORK/scripts"
+    printf '#!/bin/bash\necho "Bash(kubectl:*)|high|blanket kubectl allow"\n' > "$WORK/scripts/ws-audit-fake.sh"
+    run_hook_with_session "bash $WORK/scripts/ws-audit-fake.sh" "sk8s"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"\"permissionDecision\":\"deny\""* ]]
+}
+
 @test "k8s safety floor: unscoped script containing kubectl force-asks" {
     write_project_hook_rules "$(printf '[scoped-redirect-commands]\nk8s | kubectl* | GDD_K8S_CONTEXT | Use ws k8s\n')"
     printf '#!/bin/bash\nkubectl apply -k overlays/plain\n' > "$WORK/danger.sh"
@@ -2639,10 +2677,13 @@ BASH
     [[ "$output" != *"Kubernetes"* ]]
 }
 @test "k8s safety floor: slash-relative script containing kubectl force-asks" {
+    # Slash-relative invocation must resolve against cwd for the content
+    # scan. Placed OUTSIDE scripts/ — first-party scripts/ files are
+    # exempt by design (covered by the first-party exemption tests).
     write_project_hook_rules "$(printf '[scoped-redirect-commands]\nk8s | kubectl* | GDD_K8S_CONTEXT | Use ws k8s\n')"
-    mkdir -p "$WORK/scripts"
-    printf '#!/bin/bash\nkubectl run script-test --image=pause -n gdd-practice\n' > "$WORK/scripts/direct-danger.sh"
-    run_hook_with_session 'scripts/direct-danger.sh' "no-scope-sess" "$WORK"
+    mkdir -p "$WORK/tools"
+    printf '#!/bin/bash\nkubectl run script-test --image=pause -n gdd-practice\n' > "$WORK/tools/direct-danger.sh"
+    run_hook_with_session 'tools/direct-danger.sh' "no-scope-sess" "$WORK"
     [ "$status" -eq 0 ]
     [[ "$output" == *"\"permissionDecision\":\"ask\""* ]]
 }

--- a/tests/hook/gdd-permission-hook.bats
+++ b/tests/hook/gdd-permission-hook.bats
@@ -2620,17 +2620,25 @@ BASH
     [ "$status" -eq 0 ]
     [[ "$output" == *"\"permissionDecision\":\"ask\""* ]]
 }
-@test "k8s safety floor: first-party scripts/ file with kubectl as data does not ask" {
+@test "k8s safety floor: reviewed permission audit script with kubectl as data does not ask" {
     # ws-audit-permissions.sh carries "kubectl" in audit PATTERN STRINGS;
     # content-grepping it produced false asks on a read-only tool (hit by
-    # a Codex-workspace session via direct script-path invocation). Files
-    # physically residing in the reviewed scripts/ dir are exempt.
+    # a Codex-workspace session via direct script-path invocation).
     write_project_hook_rules "$(printf '[scoped-redirect-commands]\nk8s | kubectl* | GDD_K8S_CONTEXT | Use ws k8s\n')"
     mkdir -p "$WORK/scripts"
-    printf '#!/bin/bash\necho "Bash(kubectl:*)|high|blanket kubectl allow"\n' > "$WORK/scripts/ws-audit-fake.sh"
-    run_hook_with_session "bash $WORK/scripts/ws-audit-fake.sh" "no-scope-sess"
+    printf '#!/bin/bash\necho "Bash(kubectl:*)|high|blanket kubectl allow"\n' > "$WORK/scripts/ws-audit-permissions.sh"
+    run_hook_with_session "bash $WORK/scripts/ws-audit-permissions.sh" "no-scope-sess"
     [ "$status" -eq 0 ]
     [[ "$output" != *"\"permissionDecision\":\"ask\""* ]]
+}
+
+@test "k8s safety floor: another first-party script containing kubectl still asks" {
+    write_project_hook_rules "$(printf '[scoped-redirect-commands]\nk8s | kubectl* | GDD_K8S_CONTEXT | Use ws k8s\n')"
+    mkdir -p "$WORK/scripts"
+    printf '#!/bin/bash\nkubectl apply -k overlays/plain\n' > "$WORK/scripts/other.sh"
+    run_hook_with_session "bash $WORK/scripts/other.sh" "no-scope-sess"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"\"permissionDecision\":\"ask\""* ]]
 }
 
 @test "k8s safety floor: symlink inside scripts/ keeps the content inspection" {
@@ -2648,12 +2656,12 @@ BASH
     [[ "$output" == *"\"permissionDecision\":\"ask\""* ]]
 }
 
-@test "k8s scoped: first-party scripts/ file with kubectl as data is not denied" {
+@test "k8s scoped: reviewed permission audit script with kubectl as data is not denied" {
     write_project_hook_rules "$(printf '[scoped-redirect-commands]\nk8s | kubectl* | GDD_K8S_CONTEXT | Use ws k8s\n')"
     seed_k8s_scope "sk8s" "kind-practice" "alice-sandbox"
     mkdir -p "$WORK/scripts"
-    printf '#!/bin/bash\necho "Bash(kubectl:*)|high|blanket kubectl allow"\n' > "$WORK/scripts/ws-audit-fake.sh"
-    run_hook_with_session "bash $WORK/scripts/ws-audit-fake.sh" "sk8s"
+    printf '#!/bin/bash\necho "Bash(kubectl:*)|high|blanket kubectl allow"\n' > "$WORK/scripts/ws-audit-permissions.sh"
+    run_hook_with_session "bash $WORK/scripts/ws-audit-permissions.sh" "sk8s"
     [ "$status" -eq 0 ]
     [[ "$output" != *"\"permissionDecision\":\"deny\""* ]]
 }
@@ -2678,8 +2686,7 @@ BASH
 }
 @test "k8s safety floor: slash-relative script containing kubectl force-asks" {
     # Slash-relative invocation must resolve against cwd for the content
-    # scan. Placed OUTSIDE scripts/ — first-party scripts/ files are
-    # exempt by design (covered by the first-party exemption tests).
+    # scan. Only the two reviewed dispatcher/audit entrypoints are exempt.
     write_project_hook_rules "$(printf '[scoped-redirect-commands]\nk8s | kubectl* | GDD_K8S_CONTEXT | Use ws k8s\n')"
     mkdir -p "$WORK/tools"
     printf '#!/bin/bash\nkubectl run script-test --image=pause -n gdd-practice\n' > "$WORK/tools/direct-danger.sh"

--- a/tests/templates/line-wrap.bats
+++ b/tests/templates/line-wrap.bats
@@ -1,29 +1,33 @@
 #!/usr/bin/env bats
 
-# Guard: top-level templates must not hard-wrap prose. Templates are the
-# demonstration layer — an agent drafting a commit or CR body copies the
-# shape it sees, so a wrapped template quietly reteaches the wrapped habit
-# no matter what AGENTS.md says (demonstration beats instruction). One
-# line per paragraph and per bullet; renderers handle the wrapping.
+# Guard: prose in agent-facing markdown must not be hard-wrapped. Templates
+# and skills are the demonstration layer — an agent drafting a commit or CR
+# body copies the shape it sees, so a wrapped file quietly reteaches the
+# wrapped habit no matter what AGENTS.md says (demonstration beats
+# instruction). One line per paragraph and per bullet; renderers wrap.
 #
-# Exempt, matching the AGENTS.md rule: YAML frontmatter, fenced code
-# blocks, tables, headings, HTML comments, and list STRUCTURE (one line
-# per item) — a bullet's own text is still a single line.
+# Exempt, matching the AGENTS.md rule: YAML frontmatter, fenced code blocks
+# (including fences indented inside list items), tables, headings, HTML
+# comments, and list STRUCTURE (one line per item) — a bullet's own text is
+# still a single line.
 #
-# Detection: two consecutive non-empty lines where the first is prose and
-# the second is not a structural marker means a wrapped paragraph — in a
-# one-line-per-paragraph file every prose line is followed by a blank
-# line or structure. POSIX awk only (workspace convention; see
-# scripts/ws-orient.sh for the precedent).
+# Detection: two consecutive non-empty lines where the first is prose (a
+# list item counts as prose for the NEXT line) and the second is not a
+# structural marker means a wrapped paragraph. POSIX awk only (workspace
+# convention; see scripts/ws-orient.sh for the precedent).
+#
+# Coverage grows in rings: templates/*.md and docs/gdd/*.md are fully
+# clean and locked; .agent/skills/ locks the clean files while the
+# GRANDFATHERED list carries the legacy-wrapped ones (per the doc-writing
+# convention, existing wrapped prose stays wrapped until deliberately
+# reflowed). Shrink the list as files get cleaned — never add to it.
 
-@test "top-level templates contain no hard-wrapped prose" {
-    local repo_root
-    repo_root="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
-    run awk '
+_wrap_detect() {
+    awk '
         FNR == 1 { fm = 0; fence = 0; prev = 0 }
         FNR == 1 && $0 == "---" { fm = 1; next }
         fm { if ($0 == "---") fm = 0; next }
-        /^```/ { fence = 1 - fence; prev = 0; next }
+        /^[[:space:]]*```/ { fence = 1 - fence; prev = 0; next }
         fence { next }
         /^[[:space:]]*$/ { prev = 0; next }
         /^[[:space:]]*[-*][[:space:]]/ || /^[[:space:]]*[0-9]+\.[[:space:]]/ { prev = 1; next }
@@ -33,9 +37,59 @@
             prev = 1
         }
         END { exit bad }
-    ' "$repo_root"/templates/*.md
+    ' "$@"
+}
+
+# Legacy-wrapped skills awaiting deliberate reflow. Shrink-only.
+GRANDFATHERED="gdd gdd-bdd gdd-bdd-pytest gdd-branch-workflow gdd-doc-writing gdd-flow gdd-github-issues gdd-housekeeping gdd-mcp gdd-mentoring gdd-permissions gdd-quick gdd-review-triage gdd-scribe gdd-workflow-audit gdd-zen"
+
+@test "top-level templates contain no hard-wrapped prose" {
+    local repo_root
+    repo_root="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    run _wrap_detect "$repo_root"/templates/*.md
     if [ "$status" -ne 0 ]; then
         printf '%s\n' "$output"
         return 1
     fi
+}
+
+@test "docs/gdd pages contain no hard-wrapped prose" {
+    local repo_root
+    repo_root="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    run _wrap_detect "$repo_root"/docs/gdd/*.md
+    if [ "$status" -ne 0 ]; then
+        printf '%s\n' "$output"
+        return 1
+    fi
+}
+
+@test "non-grandfathered skills contain no hard-wrapped prose" {
+    local repo_root skill_file skill_name checked=0
+    repo_root="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    for skill_file in "$repo_root"/.agent/skills/*/SKILL.md; do
+        skill_name="$(basename "$(dirname "$skill_file")")"
+        case " $GRANDFATHERED " in
+            *" $skill_name "*) continue ;;
+        esac
+        checked=$((checked + 1))
+        run _wrap_detect "$skill_file"
+        if [ "$status" -ne 0 ]; then
+            printf '%s\n' "$output"
+            return 1
+        fi
+    done
+    [ "$checked" -gt 0 ]
+}
+
+@test "grandfather list only names skills that still exist" {
+    # A renamed or deleted skill must not linger as a phantom exemption a
+    # future file could silently inherit.
+    local repo_root name
+    repo_root="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    for name in $GRANDFATHERED; do
+        [ -f "$repo_root/.agent/skills/$name/SKILL.md" ] || {
+            echo "grandfathered skill missing: $name"
+            return 1
+        }
+    done
 }

--- a/tests/templates/line-wrap.bats
+++ b/tests/templates/line-wrap.bats
@@ -24,22 +24,29 @@
 
 _wrap_detect() {
     awk '
-        FNR == 1 { fm = 0; fence = ""; prev = 0 }
+        FNR == 1 { fm = 0; fence_char = ""; fence_len = 0; prev = 0 }
         FNR == 1 && $0 == "---" { fm = 1; next }
         fm { if ($0 == "---") fm = 0; next }
         /^[[:space:]]*(```|~~~)/ {
             line = $0
             sub(/^[[:space:]]*/, "", line)
-            marker = substr(line, 1, 3)
-            if (fence == "") {
-                fence = marker
-            } else if (fence == marker) {
-                fence = ""
+            marker_char = substr(line, 1, 1)
+            marker_len = 0
+            while (substr(line, marker_len + 1, 1) == marker_char) {
+                marker_len++
+            }
+            suffix = substr(line, marker_len + 1)
+            if (fence_char == "") {
+                fence_char = marker_char
+                fence_len = marker_len
+            } else if (marker_char == fence_char && marker_len >= fence_len && suffix ~ /^[[:space:]]*$/) {
+                fence_char = ""
+                fence_len = 0
             }
             prev = 0
             next
         }
-        fence != "" { next }
+        fence_char != "" { next }
         /^[[:space:]]*$/ { prev = 0; next }
         /^[[:space:]]*[-*][[:space:]]/ || /^[[:space:]]*[0-9]+\.[[:space:]]/ { prev = 1; next }
         /^#/ || /^>/ || /^\|/ || /^<!--/ { prev = 0; next }
@@ -103,4 +110,22 @@ GRANDFATHERED="gdd gdd-bdd gdd-bdd-pytest gdd-branch-workflow gdd-doc-writing gd
             return 1
         }
     done
+}
+
+@test "a shorter fence does not close a longer opening fence" {
+    local fixture="$BATS_TEST_TMPDIR/long-fence.md"
+    printf '````shell\n```\ncode line one\ncode line two\n````\n' > "$fixture"
+
+    run _wrap_detect "$fixture"
+
+    [ "$status" -eq 0 ]
+}
+
+@test "a fence with an info suffix does not close an existing fence" {
+    local fixture="$BATS_TEST_TMPDIR/info-suffix.md"
+    printf '```shell\n```typescript\ncode line one\ncode line two\n```\n' > "$fixture"
+
+    run _wrap_detect "$fixture"
+
+    [ "$status" -eq 0 ]
 }

--- a/tests/templates/line-wrap.bats
+++ b/tests/templates/line-wrap.bats
@@ -24,11 +24,22 @@
 
 _wrap_detect() {
     awk '
-        FNR == 1 { fm = 0; fence = 0; prev = 0 }
+        FNR == 1 { fm = 0; fence = ""; prev = 0 }
         FNR == 1 && $0 == "---" { fm = 1; next }
         fm { if ($0 == "---") fm = 0; next }
-        /^[[:space:]]*```/ { fence = 1 - fence; prev = 0; next }
-        fence { next }
+        /^[[:space:]]*(```|~~~)/ {
+            line = $0
+            sub(/^[[:space:]]*/, "", line)
+            marker = substr(line, 1, 3)
+            if (fence == "") {
+                fence = marker
+            } else if (fence == marker) {
+                fence = ""
+            }
+            prev = 0
+            next
+        }
+        fence != "" { next }
         /^[[:space:]]*$/ { prev = 0; next }
         /^[[:space:]]*[-*][[:space:]]/ || /^[[:space:]]*[0-9]+\.[[:space:]]/ { prev = 1; next }
         /^#/ || /^>/ || /^\|/ || /^<!--/ { prev = 0; next }

--- a/tests/ws-cr/remote-override.bats
+++ b/tests/ws-cr/remote-override.bats
@@ -70,6 +70,10 @@ MD
     git -C "$WORK" push -q "$ALT_BARE" refs/heads/feature/from-linked-worktree
     git -C "$WORK" push -q "$ALT_BARE" "$BASE_COMMIT:refs/heads/feature/diverged"
     git -C "$WORK" push -q "$ALT_BARE" "$BASE_COMMIT:refs/heads/feature/stale-fetch"
+    # Target branch for the stale-base preflight: parked at the base commit,
+    # which every fixture branch contains — the check passes unless a test
+    # deliberately moves it.
+    git -C "$WORK" push -q "$ALT_BARE" "$BASE_COMMIT:refs/heads/main"
     git -C "$WORK" update-ref refs/remotes/alt/feature/from-linked-worktree refs/heads/feature/from-linked-worktree
     git -C "$WORK" update-ref refs/remotes/alt/feature/diverged "$BASE_COMMIT"
     git -C "$WORK" update-ref refs/remotes/alt/feature/stale-fetch refs/heads/feature/stale-fetch
@@ -232,4 +236,58 @@ YAML
     [[ "$output" == *"github.com"* ]]
     [[ "$output" == *"github.enterprise.test"* ]]
     [[ ! -f "$GH_LOG" ]]
+}
+
+# ─── stale-base preflight ───────────────────────────────────────────
+
+# Advance the bare repo's main past the fixture branches from a scratch
+# clone, so the moved tip's commit object does NOT exist in $WORK — this
+# exercises the check's fetch-before-compare path as well as the compare.
+_move_remote_main() {
+    local scratch="$BATS_TEST_TMPDIR/mover"
+    git clone -q "$ALT_BARE" "$scratch"
+    git -C "$scratch" config user.name "Mover"
+    git -C "$scratch" config user.email "mover@example.local"
+    git -C "$scratch" checkout -q main
+    echo moved > "$scratch/moved.txt"
+    git -C "$scratch" add moved.txt
+    git -C "$scratch" commit -q -m "someone else's merge"
+    git -C "$scratch" push -q origin main
+}
+
+@test "stale-base: fresh target branch passes the preflight" {
+    run bash "$WS_BIN" cr yggdrasil --remote alt "test: fresh base" .crs/body.md
+
+    [ "$status" -eq 0 ]
+    [[ "$(cat "$GH_LOG")" == *"--repo alt/project"* ]]
+}
+
+@test "stale-base: moved target branch fails with a rebase pointer" {
+    _move_remote_main
+
+    run bash "$WS_BIN" cr yggdrasil --remote alt "test: moved base" .crs/body.md
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"has moved"* ]]
+    [[ "$output" == *"Rebase first"* ]]
+    [[ "$output" == *"--stale-base-ok"* ]]
+    [[ ! -f "$GH_LOG" ]]
+}
+
+@test "stale-base: --stale-base-ok submits against the moved base" {
+    _move_remote_main
+
+    run bash "$WS_BIN" cr yggdrasil --remote alt --stale-base-ok "test: stacked CR" .crs/body.md
+
+    [ "$status" -eq 0 ]
+    [[ "$(cat "$GH_LOG")" == *"--repo alt/project"* ]]
+}
+
+@test "stale-base: GIT_CR_STALE_BASE_OK env form also skips the preflight" {
+    _move_remote_main
+
+    run bash -c 'cd "$1" || exit 1; GIT_CR_REMOTE=alt GIT_CR_STALE_BASE_OK=1 bash "$2" "test: stacked CR" "$3"' bash "$WORK" "$GIT_CR_BIN" "$BODYFILE"
+
+    [ "$status" -eq 0 ]
+    [[ "$(cat "$GH_LOG")" == *"--repo alt/project"* ]]
 }

--- a/tests/ws-cr/remote-override.bats
+++ b/tests/ws-cr/remote-override.bats
@@ -274,6 +274,16 @@ _move_remote_main() {
     [[ ! -f "$GH_LOG" ]]
 }
 
+@test "stale-base: missing target branch fails closed before CR creation" {
+    git -C "$ALT_BARE" update-ref -d refs/heads/main
+
+    run bash "$WS_BIN" cr yggdrasil --remote alt "test: missing base" .crs/body.md
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"target branch 'main' is not known on remote 'alt'"* ]]
+    [[ ! -f "$GH_LOG" ]]
+}
+
 @test "stale-base: --stale-base-ok submits against the moved base" {
     _move_remote_main
 

--- a/tests/ws-cr/remote-override.bats
+++ b/tests/ws-cr/remote-override.bats
@@ -291,3 +291,25 @@ _move_remote_main() {
     [ "$status" -eq 0 ]
     [[ "$(cat "$GH_LOG")" == *"--repo alt/project"* ]]
 }
+
+@test "stale-base: --upstream path passes the preflight against a fresh upstream" {
+    # fork remote = 'fork' (identity.forkRemote), so 'alt' is the detected
+    # upstream — its bare-repo backing exercises the same preflight on the
+    # cross-fork path.
+    run bash -c 'cd "$1" || exit 1; GIT_CR_REMOTE=fork bash "$2" --upstream "test: upstream CR" "$3"' bash "$WORK" "$GIT_CR_BIN" "$BODYFILE"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Opening cross-fork CR"* ]]
+    [[ "$(cat "$GH_LOG")" == *"--repo alt/project"* ]]
+}
+
+@test "stale-base: --upstream path fails when the upstream default branch moved" {
+    _move_remote_main
+
+    run bash -c 'cd "$1" || exit 1; GIT_CR_REMOTE=fork bash "$2" --upstream "test: upstream CR" "$3"' bash "$WORK" "$GIT_CR_BIN" "$BODYFILE"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"has moved"* ]]
+    [[ "$output" == *"--stale-base-ok"* ]]
+    [[ ! -f "$GH_LOG" ]]
+}

--- a/tests/ws-k8s/guard.bats
+++ b/tests/ws-k8s/guard.bats
@@ -143,6 +143,23 @@ EOF
     run_guard "kind-practice" "alice-sandbox" kubectl delete pods --all-namespaces=false -n alice-sandbox
     [ "$output" = "WRITE_IN_SCOPE" ]
 }
+@test "an invalid --all-namespaces value BLOCKs instead of defaulting" {
+    run_guard "kind-practice" "alice-sandbox" kubectl delete pods --all-namespaces=yes -n alice-sandbox
+    [[ "$output" == BLOCK:precondition:* ]]
+}
+@test "quoted parens in a label selector stay tokenizable (not the unsafe sentinel)" {
+    run_guard "kind-practice" "alice-sandbox" kubectl get pods -l 'environment in (production)' -n alice-sandbox
+    [ "$output" = "READ_IN_SCOPE" ]
+}
+@test "impersonation and identity flags are blocked (split and equals forms)" {
+    local flag
+    for flag in --as=system:admin --user=other --cluster=prod-cluster --client-certificate=/tmp/c.crt; do
+        run_guard "kind-practice" "alice-sandbox" kubectl get pods "$flag" -n alice-sandbox
+        [[ "$output" == BLOCK:context:* ]]
+    done
+    run_guard "kind-practice" "alice-sandbox" kubectl get pods --as system:admin -n alice-sandbox
+    [[ "$output" == BLOCK:context:* ]]
+}
 @test "alternate connection flags are blocked in split and equals forms" {
     local flag
     for flag in --kubeconfig --server --token; do

--- a/tests/ws-k8s/guard.bats
+++ b/tests/ws-k8s/guard.bats
@@ -153,11 +153,13 @@ EOF
 }
 @test "impersonation and identity flags are blocked (split and equals forms)" {
     local flag
-    for flag in --as=system:admin --user=other --cluster=prod-cluster --client-certificate=/tmp/c.crt; do
+    for flag in --as=system:admin --user=other --cluster=prod-cluster --client-certificate=/tmp/c.crt --as-user-extra=scope=admin; do
         run_guard "kind-practice" "alice-sandbox" kubectl get pods "$flag" -n alice-sandbox
         [[ "$output" == BLOCK:context:* ]]
     done
     run_guard "kind-practice" "alice-sandbox" kubectl get pods --as system:admin -n alice-sandbox
+    [[ "$output" == BLOCK:context:* ]]
+    run_guard "kind-practice" "alice-sandbox" kubectl get pods --as-user-extra scope=admin -n alice-sandbox
     [[ "$output" == BLOCK:context:* ]]
 }
 @test "alternate connection flags are blocked in split and equals forms" {

--- a/tests/ws-k8s/guard.bats
+++ b/tests/ws-k8s/guard.bats
@@ -135,6 +135,23 @@ EOF
     run_guard "kind-practice" "alice-sandbox" kubectl delete pods --all-namespaces
     [[ "$output" == BLOCK:* ]]
 }
+@test "--all-namespaces=true on a write BLOCKs" {
+    run_guard "kind-practice" "alice-sandbox" kubectl delete pods --all-namespaces=true
+    [[ "$output" == BLOCK:unbounded:* ]]
+}
+@test "--all-namespaces=false does not broaden an in-scope write" {
+    run_guard "kind-practice" "alice-sandbox" kubectl delete pods --all-namespaces=false -n alice-sandbox
+    [ "$output" = "WRITE_IN_SCOPE" ]
+}
+@test "alternate connection flags are blocked in split and equals forms" {
+    local flag
+    for flag in --kubeconfig --server --token; do
+        run_guard "kind-practice" "alice-sandbox" kubectl get pods "$flag" attacker-controlled
+        [[ "$output" == BLOCK:context:* ]]
+        run_guard "kind-practice" "alice-sandbox" kubectl get pods "${flag}=attacker-controlled"
+        [[ "$output" == BLOCK:context:* ]]
+    done
+}
 @test "unknown verb is treated as write (fail-safe)" {
     run_guard "kind-practice" "alice-sandbox" kubectl frobnicate -n prod
     [[ "$output" == BLOCK:* ]]
@@ -395,6 +412,28 @@ YAML
 @test "cordon node is blocked (node-level verb)" {
     run_guard "kind-practice" "alice-sandbox" kubectl cordon node1
     [[ "$output" == BLOCK:* ]]
+}
+@test "certificate approval is blocked as a cluster-scoped write" {
+    local decision
+    for decision in approve deny; do
+        run_guard "kind-practice" "alice-sandbox" kubectl certificate "$decision" node-request
+        [[ "$output" == BLOCK:unbounded:* ]]
+    done
+}
+@test "kubectl cp blocks an explicit out-of-scope source namespace" {
+    make_kubectl_stub "alice-sandbox"
+    run_guard "kind-practice" "alice-sandbox" kubectl cp prod/source-pod:/tmp/data ./data
+    [[ "$output" == BLOCK:scope:* ]]
+}
+@test "kubectl cp blocks an explicit out-of-scope destination namespace" {
+    make_kubectl_stub "alice-sandbox"
+    run_guard "kind-practice" "alice-sandbox" kubectl cp ./data prod/destination-pod:/tmp/data
+    [[ "$output" == BLOCK:scope:* ]]
+}
+@test "kubectl cp honors an explicit in-scope namespace over the context default" {
+    make_kubectl_stub "default"
+    run_guard "kind-practice" "alice-sandbox" kubectl cp alice-sandbox/source-pod:/tmp/data ./data
+    [ "$output" = "WRITE_IN_SCOPE" ]
 }
 @test "apply -f a cluster-scoped Kind is blocked even with in-scope -n" {
     printf 'apiVersion: rbac.authorization.k8s.io/v1\nkind: ClusterRole\nmetadata:\n  name: x\n' > "$BATS_TEST_TMPDIR/cr.yaml"

--- a/tests/ws-review/review-remote.bats
+++ b/tests/ws-review/review-remote.bats
@@ -156,6 +156,26 @@ probe_csi() { printf '\302\233'; }
     [ ! -e "$BODY_LOG" ]
 }
 
+@test "GitLab provider rejects bare dot-segment thread IDs" {
+    # "." and ".." pass the character allowlist yet normalize to a
+    # different API path — must be rejected as exact values.
+    local id
+    for id in '.' '..'; do
+        run_ws_review app reply 1 "$id" 'dot probe' --remote fork
+        [ "$status" -ne 0 ]
+        [[ "$output" == *"Failed to reply to thread"* ]]
+    done
+    [ ! -e "$BODY_LOG" ]
+}
+
+@test "GitLab provider rejects an invalid thread ID during resolve" {
+    run_ws_review app threads 1 --resolve 'thread/../../notes' --remote fork
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Failed to resolve thread"* ]]
+    [ ! -e "$BODY_LOG" ]
+}
+
 @test "review --reviewer matches literal login instead of regex wildcard" {
     run_ws_review app 1 --remote fork --reviewer a.b --compact
 

--- a/tests/ws-review/review-remote.bats
+++ b/tests/ws-review/review-remote.bats
@@ -148,6 +148,14 @@ probe_csi() { printf '\302\233'; }
     [ "$(cat "$BODY_LOG")" = "--remote=spoof" ]
 }
 
+@test "GitLab provider rejects a thread ID that can steer the API path" {
+    run_ws_review app reply 1 'thread/../../notes' 'unsafe path probe' --remote fork
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Failed to reply to thread"* ]]
+    [ ! -e "$BODY_LOG" ]
+}
+
 @test "review --reviewer matches literal login instead of regex wildcard" {
     run_ws_review app 1 --remote fork --reviewer a.b --compact
 


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @Cervator via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

- k8s floor stops false-asking on first-party `scripts/` files that carry "kubectl" as data (audit pattern strings, the guard itself) — exemption covers files physically residing in the reviewed scripts/ dir, symlink-guarded; scratch/component scripts keep the content scan. Field-reported from a Codex workspace.
- `ws cr` gains a stale-base preflight: the live target-branch tip must be contained in the source branch, else it fails with the exact rebase commands. `--stale-base-ok` / `GIT_CR_STALE_BASE_OK=1` covers deliberate stacked CRs — the class that bit #139.
- The line-wrap guard extends beyond templates: `docs/gdd/*.md` locks fully clean, 4 clean skills lock, 16 legacy-wrapped skills ride a shrink-only grandfather list with a phantom-exemption check. Detector now handles fences indented in list items.

## Test plan

- [x] Hook suite green (first-party exemption, symlink keep-inspection, scoped + unscoped paths; slash-relative regression re-anchored outside scripts/)
- [x] ws-cr suite 17/17 (fresh base, moved base, both override forms, fetch-before-compare path)
- [x] Extended line-wrap guard 4/4

## Related

- Implements the three arcs parked in the Dionysus Thalamus 2026-07-28/30; stacked-CR override motivated by #139/#140.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added stale-target validation before creating change requests to help prevent submissions based on outdated branches.
  - Added `--stale-base-ok` and `GIT_CR_STALE_BASE_OK` options to bypass this validation when appropriate.
  - Updated command-line help and argument validation for the new option.

- **Bug Fixes**
  - Strengthened Kubernetes command safety checks for namespaces, credentials, certificates, copy operations, and embedded commands.
  - Trusted local scripts are handled correctly while symlinked or external scripts remain inspected.
  - Added validation to prevent unsafe discussion identifiers in GitLab operations.
  - Expanded coverage for command safety and template formatting checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->