### PR TITLE
feat(ws-test): auto-parallelize bats suite when a parallel backend is available

### DIFF
--- a/scripts/ws-test.sh
+++ b/scripts/ws-test.sh
@@ -238,6 +238,11 @@ for arg in "$@"; do
             # treats it as boolean (--recursive). Same swallow risk.
             -r)
                 [[ "$runner" == "python" ]] && expect_value=true ;;
+            # -j/--jobs takes a value for bats (parallel job count) and Go
+            # (-p N is Go's parallelism flag, already listed above; bats has
+            # no boolean flag spelled -j/--jobs, so this is unambiguous).
+            -j|--jobs)
+                [[ "$runner" == "bats" ]] && expect_value=true ;;
         esac
     else
         test_selectors+=("$arg")
@@ -416,6 +421,34 @@ case "$runner" in
         if [[ ${#test_selectors[@]} -eq 1 && "$bats_selectors_are_paths" != true ]]; then
             bats_argv+=(--filter "$test_filter")
         fi
+
+        # Auto-enable bats' parallel mode when a backend is on PATH and the
+        # caller didn't already pass -j/--jobs themselves. bats defaults to
+        # looking for a binary literally named "parallel" (GNU parallel);
+        # rush is preferred when both are present since it has no citation
+        # nag and no Perl dependency. Single-file runs skip this — the
+        # cross-process fan-out only pays off with multiple files.
+        _bats_user_set_jobs=false
+        for _a in "${runner_args[@]}"; do
+            case "$_a" in
+                -j|--jobs) _bats_user_set_jobs=true; break ;;
+            esac
+        done
+        if [[ "$_bats_user_set_jobs" != true && ${#bats_files[@]} -gt 1 ]]; then
+            _bats_parallel_bin=""
+            if command -v rush >/dev/null 2>&1; then
+                _bats_parallel_bin="rush"
+            elif command -v parallel >/dev/null 2>&1; then
+                _bats_parallel_bin="parallel"
+            fi
+            if [[ -n "$_bats_parallel_bin" ]]; then
+                _bats_jobs=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)
+                echo "(running ${#bats_files[@]} test files in parallel: --jobs $_bats_jobs via $_bats_parallel_bin)" >&2
+                bats_argv+=(--jobs "$_bats_jobs")
+                [[ "$_bats_parallel_bin" == "rush" ]] && bats_argv+=(--parallel-binary-name rush)
+            fi
+        fi
+
         bats_argv+=("${runner_args[@]}" "${bats_files[@]}")
         "${bats_argv[@]}"
         ;;

--- a/scripts/ws-test.sh
+++ b/scripts/ws-test.sh
@@ -209,11 +209,25 @@ fi
 test_selectors=()
 runner_args=()
 expect_value=false
+bats_user_set_jobs=false
+bats_user_set_backend=false
 for arg in "$@"; do
     if [[ "$expect_value" == true ]]; then
         runner_args+=("$arg")
         expect_value=false
         continue
+    fi
+    if [[ "$runner" == "bats" ]]; then
+        case "$arg" in
+            --jobs=*)
+                runner_args+=(--jobs "${arg#*=}")
+                bats_user_set_jobs=true
+                continue ;;
+            --parallel-binary-name=*)
+                runner_args+=(--parallel-binary-name "${arg#*=}")
+                bats_user_set_backend=true
+                continue ;;
+        esac
     fi
     if [[ "$arg" == -* ]]; then
         runner_args+=("$arg")
@@ -238,11 +252,16 @@ for arg in "$@"; do
             # treats it as boolean (--recursive). Same swallow risk.
             -r)
                 [[ "$runner" == "python" ]] && expect_value=true ;;
-            # -j/--jobs takes a value for bats (parallel job count) and Go
-            # (-p N is Go's parallelism flag, already listed above; bats has
-            # no boolean flag spelled -j/--jobs, so this is unambiguous).
             -j|--jobs)
-                [[ "$runner" == "bats" ]] && expect_value=true ;;
+                if [[ "$runner" == "bats" ]]; then
+                    expect_value=true
+                    bats_user_set_jobs=true
+                fi ;;
+            --parallel-binary-name)
+                if [[ "$runner" == "bats" ]]; then
+                    expect_value=true
+                    bats_user_set_backend=true
+                fi ;;
         esac
     else
         test_selectors+=("$arg")
@@ -265,6 +284,62 @@ reject_multiple_keyword_selectors() {
     echo "ERROR: Multiple positional selectors for $runner_name are not supported in this form." >&2
     echo "  Pass one keyword expression, or use the runner's native selector flag explicitly." >&2
     exit 1
+}
+
+_ws_bats_parallel_backend() {
+    local backend_name backend_path probe_output
+    for backend_name in rush parallel; do
+        backend_path="$(type -P "$backend_name" 2>/dev/null)" || continue
+        probe_output="$("$backend_path" --keep-order --jobs 1 -- 'printf "verified:%s\n" "{}"' <<< 'ws-bats-probe' 2>/dev/null)" || continue
+        [[ "$probe_output" == "verified:ws-bats-probe" ]] || continue
+        printf '%s\n' "$backend_name"
+        return 0
+    done
+    return 1
+}
+
+_ws_bats_job_count() {
+    local count=""
+    if type -P nproc >/dev/null 2>&1; then
+        count="$(nproc 2>/dev/null)" || count=""
+        if [[ "$count" =~ ^[1-9][0-9]*$ ]]; then
+            printf '%s\n' "$count"
+            return 0
+        fi
+    fi
+    if type -P sysctl >/dev/null 2>&1; then
+        count="$(sysctl -n hw.logicalcpu 2>/dev/null)" || count=""
+        if [[ "$count" =~ ^[1-9][0-9]*$ ]]; then
+            printf '%s\n' "$count"
+            return 0
+        fi
+    fi
+    printf '4\n'
+}
+
+_ws_bats_file_count() {
+    local recursive="$1"
+    shift
+    local count=0 path file
+    local extension="${BATS_FILE_EXTENSION:-bats}"
+    local -a direct_files=()
+    for path in "$@"; do
+        if [[ ! -d "$path" ]]; then
+            count=$((count + 1))
+            continue
+        fi
+        if [[ "$recursive" == true ]]; then
+            while IFS= read -r -d '' file; do
+                count=$((count + 1))
+            done < <(find -L "$path" -type f -name "*.$extension" -print0)
+        else
+            shopt -s nullglob
+            direct_files=("$path"/*."$extension")
+            shopt -u nullglob
+            count=$((count + ${#direct_files[@]}))
+        fi
+    done
+    printf '%s\n' "$count"
 }
 
 # --- Parse adapter command into an array for safe exec ---
@@ -422,30 +497,35 @@ case "$runner" in
             bats_argv+=(--filter "$test_filter")
         fi
 
-        # Auto-enable bats' parallel mode when a backend is on PATH and the
-        # caller didn't already pass -j/--jobs themselves. bats defaults to
-        # looking for a binary literally named "parallel" (GNU parallel);
-        # rush is preferred when both are present since it has no citation
-        # nag and no Perl dependency. Single-file runs skip this — the
-        # cross-process fan-out only pays off with multiple files.
-        _bats_user_set_jobs=false
-        for _a in "${runner_args[@]}"; do
-            case "$_a" in
-                -j|--jobs) _bats_user_set_jobs=true; break ;;
+        _bats_recursive=false
+        for _bats_arg in "${runner_args[@]}"; do
+            case "$_bats_arg" in
+                -r|--recursive) _bats_recursive=true ;;
             esac
         done
-        if [[ "$_bats_user_set_jobs" != true && ${#bats_files[@]} -gt 1 ]]; then
-            _bats_parallel_bin=""
-            if command -v rush >/dev/null 2>&1; then
-                _bats_parallel_bin="rush"
-            elif command -v parallel >/dev/null 2>&1; then
-                _bats_parallel_bin="parallel"
-            fi
+        _bats_file_count="$(_ws_bats_file_count "$_bats_recursive" "${bats_files[@]}")"
+
+        # A same-name executable is not enough: exercise the small command
+        # contract Bats relies on before selecting an optional backend.
+        _bats_parallel_bin=""
+        if [[ "$bats_user_set_backend" != true ]] && \
+           [[ "$bats_user_set_jobs" == true || $_bats_file_count -gt 1 ]]; then
+            _bats_parallel_bin="$(_ws_bats_parallel_backend)" || _bats_parallel_bin=""
             if [[ -n "$_bats_parallel_bin" ]]; then
-                _bats_jobs=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)
-                echo "(running ${#bats_files[@]} test files in parallel: --jobs $_bats_jobs via $_bats_parallel_bin)" >&2
-                bats_argv+=(--jobs "$_bats_jobs")
-                [[ "$_bats_parallel_bin" == "rush" ]] && bats_argv+=(--parallel-binary-name rush)
+                bats_argv+=(--parallel-binary-name "$_bats_parallel_bin")
+            fi
+        fi
+
+        # Automatic fan-out only applies across multiple files. An explicit
+        # job count is preserved for single-file, within-file parallelism.
+        if [[ "$bats_user_set_jobs" != true && $_bats_file_count -gt 1 ]] && \
+           [[ "$bats_user_set_backend" == true || -n "$_bats_parallel_bin" ]]; then
+            _bats_jobs="$(_ws_bats_job_count)"
+            bats_argv+=(--jobs "$_bats_jobs")
+            if [[ -n "$_bats_parallel_bin" ]]; then
+                echo "(running $_bats_file_count test files in parallel: --jobs $_bats_jobs via $_bats_parallel_bin)" >&2
+            else
+                echo "(running $_bats_file_count test files in parallel: --jobs $_bats_jobs via requested backend)" >&2
             fi
         fi
 

--- a/tests/ws-test/bats-parallel.bats
+++ b/tests/ws-test/bats-parallel.bats
@@ -1,0 +1,176 @@
+#!/usr/bin/env bats
+
+# Tests for optional Bats parallel-backend routing. The synthetic runner only
+# prints its argv; backend stubs prove the execution contract independently.
+
+load test_helper
+
+setup() {
+    setup_synthetic_realm
+    export FAKE_BIN="$BATS_TEST_TMPDIR/bin"
+    mkdir -p "$FAKE_BIN" "$ROOT_DIR/tests/vendor/bats-core/bin"
+    export PATH="$FAKE_BIN:$PATH"
+
+    cat > "$ROOT_DIR/tests/vendor/bats-core/bin/bats" <<'EOF'
+#!/usr/bin/env bash
+printf 'BATS_ARG=<%s>\n' "$@"
+EOF
+    chmod +x "$ROOT_DIR/tests/vendor/bats-core/bin/bats"
+
+    printf '#!/usr/bin/env bats\n@test "one" { true; }\n' > "$ROOT_DIR/tests/one.bats"
+    printf '#!/usr/bin/env bats\n@test "two" { true; }\n' > "$ROOT_DIR/tests/two.bats"
+
+    write_incompatible_backend rush
+    write_incompatible_backend parallel
+}
+
+write_incompatible_backend() {
+    local name="$1"
+    cat > "$FAKE_BIN/$name" <<'EOF'
+#!/usr/bin/env bash
+exit 64
+EOF
+    chmod +x "$FAKE_BIN/$name"
+}
+
+write_compatible_backend() {
+    local name="$1"
+    cat > "$FAKE_BIN/$name" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$1" != "--keep-order" || "$2" != "--jobs" || "$3" != "1" || "$4" != "--" || "$5" != 'printf "verified:%s\n" "{}"' ]]; then
+    exit 64
+fi
+IFS= read -r input
+printf 'verified:%s\n' "$input"
+EOF
+    chmod +x "$FAKE_BIN/$name"
+}
+
+write_passthrough_backend() {
+    local name="$1"
+    cat > "$FAKE_BIN/$name" <<'EOF'
+#!/usr/bin/env bash
+IFS= read -r input
+printf '%s\n' "$input"
+EOF
+    chmod +x "$FAKE_BIN/$name"
+}
+
+write_invalid_cpu_probes() {
+    cat > "$FAKE_BIN/nproc" <<'EOF'
+#!/usr/bin/env bash
+printf 'many\n'
+EOF
+    chmod +x "$FAKE_BIN/nproc"
+
+    cat > "$FAKE_BIN/sysctl" <<'EOF'
+#!/usr/bin/env bash
+printf '0\n'
+EOF
+    chmod +x "$FAKE_BIN/sysctl"
+}
+
+@test "bats runner stays serial when same-name backends are incompatible" {
+    run_ws_test yggdrasil
+
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"BATS_ARG=<--jobs>"* ]]
+    [[ "$output" != *"BATS_ARG=<--parallel-binary-name>"* ]]
+}
+
+@test "bats runner rejects a backend that ignores the supplied command" {
+    write_passthrough_backend rush
+
+    run_ws_test yggdrasil
+
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"BATS_ARG=<--jobs>"* ]]
+    [[ "$output" != *"BATS_ARG=<--parallel-binary-name>"* ]]
+}
+
+@test "bats runner prefers a compatible rush backend" {
+    write_compatible_backend rush
+    write_compatible_backend parallel
+
+    run_ws_test yggdrasil
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"BATS_ARG=<--jobs>"* ]]
+    [[ "$output" == *$'BATS_ARG=<--parallel-binary-name>\nBATS_ARG=<rush>'* ]]
+}
+
+@test "bats runner falls back to compatible GNU parallel" {
+    write_compatible_backend parallel
+
+    run_ws_test yggdrasil
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *$'BATS_ARG=<--parallel-binary-name>\nBATS_ARG=<parallel>'* ]]
+}
+
+@test "bats runner selects rush for an explicit job count" {
+    write_compatible_backend rush
+
+    run_ws_test yggdrasil -j 2
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *$'BATS_ARG=<-j>\nBATS_ARG=<2>'* ]]
+    [[ "$output" == *$'BATS_ARG=<--parallel-binary-name>\nBATS_ARG=<rush>'* ]]
+}
+
+@test "bats runner normalizes an equals-form job count" {
+    write_compatible_backend rush
+
+    run_ws_test yggdrasil --jobs=2
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *$'BATS_ARG=<--jobs>\nBATS_ARG=<2>'* ]]
+    [[ "$output" != *"BATS_ARG=<--jobs=2>"* ]]
+}
+
+@test "bats runner preserves an explicit equals-form backend" {
+    run_ws_test yggdrasil --parallel-binary-name=custom
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *$'BATS_ARG=<--parallel-binary-name>\nBATS_ARG=<custom>'* ]]
+    [[ "$output" != *"BATS_ARG=<--parallel-binary-name=custom>"* ]]
+    [[ "$output" != *$'BATS_ARG=<--parallel-binary-name>\nBATS_ARG=<rush>'* ]]
+}
+
+@test "bats runner consumes a split-form backend value" {
+    run_ws_test yggdrasil --parallel-binary-name custom
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *$'BATS_ARG=<--parallel-binary-name>\nBATS_ARG=<custom>'* ]]
+    [[ "$output" != *"BATS_ARG=<--filter>"* ]]
+}
+
+@test "bats runner falls back to four jobs when CPU probes are invalid" {
+    write_compatible_backend rush
+    write_invalid_cpu_probes
+
+    run_ws_test yggdrasil
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *$'BATS_ARG=<--jobs>\nBATS_ARG=<4>'* ]]
+}
+
+@test "bats runner leaves an automatic single-file run serial" {
+    write_compatible_backend rush
+
+    run_ws_test yggdrasil tests/one.bats
+
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"BATS_ARG=<--jobs>"* ]]
+    [[ "$output" != *"BATS_ARG=<--parallel-binary-name>"* ]]
+}
+
+@test "bats runner parallelizes a directory containing multiple test files" {
+    write_compatible_backend rush
+
+    run_ws_test yggdrasil tests
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"BATS_ARG=<--jobs>"* ]]
+    [[ "$output" == *$'BATS_ARG=<--parallel-binary-name>\nBATS_ARG=<rush>'* ]]
+}


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @soloturn via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

- `ws test yggdrasil` ran all 987 bats tests serially (~3:48). `-j/--jobs` was never wired through the runner-arg classifier, and nothing enabled parallel execution by default.
- Fixed the classifier so `-j`/`--jobs` is recognized as a bats-specific value-consuming flag instead of being misparsed as a test selector.
- Auto-detect `rush` (shenwei356/rush) or GNU `parallel` on PATH and enable `--jobs <core-count>` when found and not already explicitly set; no-op when neither is installed, so this is fully backward compatible.

## Test plan

- [x] `ws test yggdrasil` with `rush` on PATH: 3:48 -> 1:10 wall time, same 987 tests, same pass/fail results as serial
- [x] `ws test yggdrasil` with neither backend on PATH: unchanged serial behavior (verified via a `PATH` without either binary)

## Related

- See #143 (unrelated to this change) — proposes converting `scripts/ws` and `scripts/ws-review.sh` to Python, tracked separately


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace test runs now automatically use parallel execution for multi-file runs when supported.
  * Automatically selects an available parallel execution tool and configures jobs based on CPU capacity.
  * Explicit job and backend settings are preserved and normalized, including `--jobs=<n>` and `--parallel-binary-name=<backend>` formats.

* **Bug Fixes**
  * Corrected handling of values supplied with `-j` and `--jobs` options.
  * Added safe serial fallback when parallel tools are unavailable or incompatible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->