### PR TITLE
feat(ci): full-suite GitHub Actions + Apache-2.0 license

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,8 +4,7 @@
 *.sh text eol=lf
 scripts/ws text eol=lf
 
-# The test suite has the same constraint: bats test files, the bats-core
-# library, and its extensionless launcher/libexec scripts all run in bash.
+# The test suite has the same constraint: bats test files, the bats-core library, and its extensionless launcher/libexec scripts all run in bash.
 *.bats text eol=lf
 *.bash text eol=lf
 tests/vendor/bats-core/bin/* text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,10 @@
 # "command not found" errors from invisible \r characters.
 *.sh text eol=lf
 scripts/ws text eol=lf
+
+# The test suite has the same constraint: bats test files, the bats-core
+# library, and its extensionless launcher/libexec scripts all run in bash.
+*.bats text eol=lf
+*.bash text eol=lf
+tests/vendor/bats-core/bin/* text eol=lf
+tests/vendor/bats-core/libexec/** text eol=lf

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,69 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    # Weekly cross-platform drift check (Monday 05:17 UTC) — the Windows job
+    # only runs here and on manual dispatch; Windows runners are slow and the
+    # suite is serial there, so per-PR Windows runs would cost more than they catch.
+    - cron: '17 5 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  linux:
+    name: Full suite — Ubuntu (parallel)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install GNU parallel
+        # flock ships with Ubuntu; adding GNU parallel activates ws test's
+        # auto-parallel bats path, so CI exercises the same code owners use.
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes parallel
+      - name: Ensure yq
+        # Runner images ship mikefarah yq; this is a pinned fallback in case
+        # an image revision drops it (ws target resolution requires yq).
+        run: |
+          if ! command -v yq >/dev/null 2>&1; then
+            sudo curl -sSL -o /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64
+            sudo chmod +x /usr/local/bin/yq
+          fi
+      - name: Run the full bats suite
+        run: bash scripts/ws test yggdrasil
+
+  windows:
+    name: Full suite — Windows Git Bash (serial)
+    # Guards the suite's green-on-Windows property (#133). Serial by design:
+    # bats parallelization requires flock/shlock, which Git Bash has neither of.
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: windows-latest
+    timeout-minutes: 90
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Force LF checkout
+        # The vendored bats scripts and *.bats files break under CRLF; pair
+        # with .gitattributes so both fresh clones and this runner stay LF.
+        run: git config --global core.autocrlf false
+      - uses: actions/checkout@v4
+      - name: Ensure yq
+        run: |
+          if ! command -v yq >/dev/null 2>&1; then
+            mkdir -p "$HOME/bin"
+            curl -sSL -o "$HOME/bin/yq.exe" https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_windows_amd64.exe
+            echo "$HOME/bin" >> "$GITHUB_PATH"
+          fi
+      - name: Run the full bats suite (serial)
+        run: bash scripts/ws test yggdrasil

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,9 +5,7 @@ on:
     branches: [main]
   pull_request:
   schedule:
-    # Weekly cross-platform drift check (Monday 05:17 UTC) — the Windows job
-    # only runs here and on manual dispatch; Windows runners are slow and the
-    # suite is serial there, so per-PR Windows runs would cost more than they catch.
+    # Weekly cross-platform drift check (Monday 05:17 UTC) — the Windows job only runs here and on manual dispatch; Windows runners are slow and the suite is serial there, so per-PR Windows runs would cost more than they catch.
     - cron: '17 5 * * 1'
   workflow_dispatch:
 
@@ -15,7 +13,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: tests-${{ github.ref }}
+  # event_name in the group keeps a push to main from cancelling an in-flight scheduled Windows run on the same ref.
+  group: tests-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -25,27 +24,27 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Install GNU parallel
-        # flock ships with Ubuntu; adding GNU parallel activates ws test's
-        # auto-parallel bats path, so CI exercises the same code owners use.
+        # flock ships with Ubuntu; adding GNU parallel activates ws test's auto-parallel bats path, so CI exercises the same code owners use.
         run: |
           sudo apt-get update
           sudo apt-get install --yes parallel
       - name: Ensure yq
-        # Runner images ship mikefarah yq; this is a pinned fallback in case
-        # an image revision drops it (ws target resolution requires yq).
+        # Runner images ship mikefarah yq; this is a pinned, checksum-verified fallback in case an image revision drops it (ws target resolution requires yq).
         run: |
           if ! command -v yq >/dev/null 2>&1; then
-            sudo curl -sSL -o /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64
-            sudo chmod +x /usr/local/bin/yq
+            curl -fsSL -o /tmp/yq https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64
+            echo "a2c097180dd884a8d50c956ee16a9cec070f30a7947cf4ebf87d5f36213e9ed7  /tmp/yq" | sha256sum -c -
+            sudo install -m 0755 /tmp/yq /usr/local/bin/yq
           fi
       - name: Run the full bats suite
         run: bash scripts/ws test yggdrasil
 
   windows:
     name: Full suite — Windows Git Bash (serial)
-    # Guards the suite's green-on-Windows property (#133). Serial by design:
-    # bats parallelization requires flock/shlock, which Git Bash has neither of.
+    # Guards the suite's green-on-Windows property (#133). Serial by design: bats parallelization requires flock/shlock, which Git Bash has neither of.
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: windows-latest
     timeout-minutes: 90
@@ -54,15 +53,17 @@ jobs:
         shell: bash
     steps:
       - name: Force LF checkout
-        # The vendored bats scripts and *.bats files break under CRLF; pair
-        # with .gitattributes so both fresh clones and this runner stay LF.
+        # The vendored bats scripts and *.bats files break under CRLF; pairs with .gitattributes so both fresh clones and this runner stay LF.
         run: git config --global core.autocrlf false
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Ensure yq
         run: |
           if ! command -v yq >/dev/null 2>&1; then
             mkdir -p "$HOME/bin"
-            curl -sSL -o "$HOME/bin/yq.exe" https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_windows_amd64.exe
+            curl -fsSL -o "$HOME/bin/yq.exe" https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_windows_amd64.exe
+            echo "d509d51e6db30ebb7c9363b7ca8714224f93a456a421d7a7819ab564b868acc7 *$HOME/bin/yq.exe" | sha256sum -c -
             echo "$HOME/bin" >> "$GITHUB_PATH"
           fi
       - name: Run the full bats suite (serial)

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -43,4 +43,4 @@ This repo ships a Claude Code PreToolUse hook (`.claude/hooks/gdd-permission-hoo
 
 ## License
 
-Yggdrasil — the workspace, the `ws` CLI, the skills, and the documentation — is licensed under the [Apache License, Version 2.0](LICENSE). Components, realms, and hoards are independent repositories that carry their own licenses.
+Yggdrasil — the workspace, the `ws` CLI, the skills, and the documentation — is licensed under the [Apache License, Version 2.0](LICENSE). Components, realms, and hoards are independent repositories that carry their own licenses, but the general spirit is Apache 2 everywhere unless explicitly stated otherwise for whichever reason.

--- a/README.md
+++ b/README.md
@@ -40,3 +40,7 @@ This ecosystem is built with heavy AI assistance (Claude Code, among others). Ge
 ### The PreToolUse hook
 
 This repo ships a Claude Code PreToolUse hook (`.claude/hooks/gdd-permission-hook.sh`) that channels agent Bash calls toward the `ws` CLI and away from opaque shell composition. Corrective "deny" messages early in a session are the hook teaching conventions, not errors. Full details live in [`.claude/hooks/README.md`](.claude/hooks/README.md) (the technical spec) and [`docs/gdd/agent-training.md`](docs/gdd/agent-training.md) (why it exists, in plain terms). Opt out for a session with `WS_HOOK_DISABLE=1`.
+
+## License
+
+Yggdrasil — the workspace, the `ws` CLI, the skills, and the documentation — is licensed under the [Apache License, Version 2.0](LICENSE). Components, realms, and hoards are independent repositories that carry their own licenses.

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,3 +17,7 @@ How to get set up — whether you're here to contribute to SiliconSaga component
 
 ### [GDD Case Studies](gdd/case-studies/index.md)
 GDD on real work — [reviewing a contributor's PR one-handed from a phone](gdd/case-studies/terasology-contributor-review.md), a non-technical owner's campaign site, parallel-workspace development, a greenfield platform component end to end. [Early GDD](gdd/case-studies/early-gdd.md) preserves transcripts from GDD's first sessions.
+
+## License
+
+Yggdrasil — the workspace, the `ws` CLI, and these docs — is licensed under the [Apache License, Version 2.0](https://github.com/SiliconSaga/yggdrasil/blob/main/LICENSE). Components, realms, and hoards are independent repositories that carry their own licenses.

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,4 +20,4 @@ GDD on real work — [reviewing a contributor's PR one-handed from a phone](gdd/
 
 ## License
 
-Yggdrasil — the workspace, the `ws` CLI, and these docs — is licensed under the [Apache License, Version 2.0](https://github.com/SiliconSaga/yggdrasil/blob/main/LICENSE). Components, realms, and hoards are independent repositories that carry their own licenses.
+Yggdrasil — the workspace, the `ws` CLI, the skills, and these docs — is licensed under the [Apache License, Version 2.0](https://github.com/SiliconSaga/yggdrasil/blob/main/LICENSE). Components, realms, and hoards are independent repositories that carry their own licenses, but the general spirit is Apache 2 everywhere unless explicitly stated otherwise for whichever reason.

--- a/tests/ws-commit/test_helper.bash
+++ b/tests/ws-commit/test_helper.bash
@@ -27,11 +27,14 @@ WS_COMMIT_BIN="$REPO_ROOT/scripts/ws-commit.sh"
 init_synthetic_repo() {
     REPO_DIR="$BATS_TEST_TMPDIR/repo"
     git init -q "$REPO_DIR"
+    # Repo-level identity: the real (non-dry-run) commit path runs a plain
+    # `git commit`, which fails on hosts with no global identity (CI runners).
+    git -C "$REPO_DIR" config user.name "Test User"
+    git -C "$REPO_DIR" config user.email "test@example.local"
 
     echo "hello" > "$REPO_DIR/test.md"
     git -C "$REPO_DIR" add test.md
-    git -C "$REPO_DIR" -c user.name=seed -c user.email=seed@local \
-        commit -q -m "seed commit"
+    git -C "$REPO_DIR" commit -q -m "seed commit"
 
     export ROOT_DIR="$REPO_DIR"
 

--- a/tests/ws-push/test_helper.bash
+++ b/tests/ws-push/test_helper.bash
@@ -12,7 +12,9 @@ init_push_repo() {
     REPO_DIR="$BATS_TEST_TMPDIR/repo"
     REMOTE_DIR="$BATS_TEST_TMPDIR/remote.git"
 
-    git init -q "$REPO_DIR"
+    # -b main: tests push the literal branch "main", so the initial branch
+    # must not depend on the host's init.defaultBranch (unset on CI runners).
+    git init -q -b main "$REPO_DIR"
     git -C "$REPO_DIR" config user.name "Test User"
     git -C "$REPO_DIR" config user.email "test@example.local"
 


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @Cervator via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

- First CI for the workspace: a Tests workflow running the full bats suite on Ubuntu for every push/PR — with GNU parallel installed so the #144 auto-parallel path runs natively — plus a weekly serial Windows Git Bash job guarding the green-on-Windows property from #133.
- LF line-ending pins extended to the test suite (`*.bats`, `*.bash`, vendored bats scripts) so autocrlf checkouts can't break it; the Windows job also forces LF before checkout.
- Adds the previously missing Apache-2.0 LICENSE, with README and docs-front-page notes scoping it to the workspace itself (components/realms/hoards carry their own licenses).

## Test plan

- [x] `yq` parses the workflow; smoke suite green locally on the branch
- [ ] Ubuntu job green on this PR (first live run of the workflow)
- [ ] Windows job green via manual `workflow_dispatch` after merge
- [ ] GitHub repo page shows the Apache-2.0 license badge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated test runs for pushes, pull requests, scheduled checks, and manual execution across supported environments.
  * Standardized line endings for test and shell script files to improve consistency.
  * Improved test repository setup for consistent branch and commit behavior.

* **Documentation**
  * Added Apache License 2.0 terms to the project.
  * Documented licensing details and clarified that related components may have separate licenses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->