### PR TITLE
fix: validate command boundaries

### DIFF
--- a/scripts/git-cr.sh
+++ b/scripts/git-cr.sh
@@ -41,27 +41,210 @@ fi
 # Provider CLI output is untrusted terminal input. Keep ordinary text, tabs,
 # and newlines intact while removing C0 controls that could ring bells, rewrite
 # the current line, or introduce terminal escape sequences.
+# Strip whole terminal control strings before deleting their control bytes, so
+# a hidden payload cannot become ordinary text. The pre-iconv pass also treats
+# standalone C1 bytes as controls while preserving strictly valid UTF-8.
+_strip_terminal_sequences() {
+  local recognize_raw_c1="${1:-false}"
+  local state="normal" osc_string="false" char="" reprocess="false"
+  local pending_index=0 pending_count=0 utf8_remaining=0 utf8_position=0 i=0
+  local LC_ALL=C
+  local esc=$'\033' bel=$'\007' c2=$'\302' backslash=$'\\'
+  local e0=$'\340' ed=$'\355' f0=$'\360' f4=$'\364'
+  local cont_min=$'\200' cont_max=$'\277'
+  local utf8_second_min="$cont_min" utf8_second_max="$cont_max"
+  local raw_dcs=$'\220' raw_sos=$'\230' raw_csi=$'\233' raw_st=$'\234'
+  local raw_osc=$'\235' raw_pm=$'\236' raw_apc=$'\237'
+  local -a pending=() utf8_chars=()
+
+  while true; do
+    if [[ "$pending_index" -lt "$pending_count" ]]; then
+      char="${pending[$pending_index]}"
+      pending_index=$((pending_index + 1))
+    else
+      pending=()
+      pending_index=0
+      pending_count=0
+      char=""
+      if IFS= read -r -n 1 char; then
+        :
+      elif [[ -n "$char" ]]; then
+        :
+      else
+        break
+      fi
+      [[ -n "$char" ]] || char=$'\n'
+    fi
+
+    reprocess="true"
+    while [[ "$reprocess" == "true" ]]; do
+      reprocess="false"
+      case "$state" in
+        normal)
+          if [[ "$recognize_raw_c1" == "true" && "$char" > "$c2" && "$char" < "$e0" ]]; then
+            state="utf8"
+            utf8_chars=("$char")
+            utf8_remaining=1
+            utf8_position=2
+            utf8_second_min="$cont_min"
+            utf8_second_max="$cont_max"
+          elif [[ "$recognize_raw_c1" == "true" && "$char" == "$e0" ]]; then
+            state="utf8"
+            utf8_chars=("$char")
+            utf8_remaining=2
+            utf8_position=2
+            utf8_second_min=$'\240'
+            utf8_second_max="$cont_max"
+          elif [[ "$recognize_raw_c1" == "true" && "$char" > "$e0" && "$char" < "$ed" ]]; then
+            state="utf8"
+            utf8_chars=("$char")
+            utf8_remaining=2
+            utf8_position=2
+            utf8_second_min="$cont_min"
+            utf8_second_max="$cont_max"
+          elif [[ "$recognize_raw_c1" == "true" && "$char" == "$ed" ]]; then
+            state="utf8"
+            utf8_chars=("$char")
+            utf8_remaining=2
+            utf8_position=2
+            utf8_second_min="$cont_min"
+            utf8_second_max=$'\237'
+          elif [[ "$recognize_raw_c1" == "true" && "$char" > "$ed" && "$char" < "$f0" ]]; then
+            state="utf8"
+            utf8_chars=("$char")
+            utf8_remaining=2
+            utf8_position=2
+            utf8_second_min="$cont_min"
+            utf8_second_max="$cont_max"
+          elif [[ "$recognize_raw_c1" == "true" && "$char" == "$f0" ]]; then
+            state="utf8"
+            utf8_chars=("$char")
+            utf8_remaining=3
+            utf8_position=2
+            utf8_second_min=$'\220'
+            utf8_second_max="$cont_max"
+          elif [[ "$recognize_raw_c1" == "true" && "$char" > "$f0" && "$char" < "$f4" ]]; then
+            state="utf8"
+            utf8_chars=("$char")
+            utf8_remaining=3
+            utf8_position=2
+            utf8_second_min="$cont_min"
+            utf8_second_max="$cont_max"
+          elif [[ "$recognize_raw_c1" == "true" && "$char" == "$f4" ]]; then
+            state="utf8"
+            utf8_chars=("$char")
+            utf8_remaining=3
+            utf8_position=2
+            utf8_second_min="$cont_min"
+            utf8_second_max=$'\217'
+          else
+            case "$char" in
+              "$esc") state="esc" ;;
+              "$c2") state="c2" ;;
+              "$raw_csi")
+                if [[ "$recognize_raw_c1" == "true" ]]; then state="csi"; else printf '%s' "$char"; fi
+                ;;
+              "$raw_dcs"|"$raw_sos"|"$raw_osc"|"$raw_pm"|"$raw_apc")
+                if [[ "$recognize_raw_c1" == "true" ]]; then
+                  state="string"
+                  if [[ "$char" == "$raw_osc" ]]; then osc_string="true"; else osc_string="false"; fi
+                else
+                  printf '%s' "$char"
+                fi
+                ;;
+              "$raw_st")
+                [[ "$recognize_raw_c1" == "true" ]] || printf '%s' "$char"
+                ;;
+              *) printf '%s' "$char" ;;
+            esac
+          fi
+          ;;
+        esc)
+          state="normal"
+          case "$char" in
+            '[') state="csi" ;;
+            ']') state="string"; osc_string="true" ;;
+            'P'|'X'|'^'|'_') state="string"; osc_string="false" ;;
+            "$backslash") ;;
+            *) reprocess="true" ;;
+          esac
+          ;;
+        c2)
+          state="normal"
+          case "$char" in
+            "$raw_csi") state="csi" ;;
+            "$raw_dcs"|"$raw_sos"|"$raw_osc"|"$raw_pm"|"$raw_apc")
+              state="string"
+              if [[ "$char" == "$raw_osc" ]]; then osc_string="true"; else osc_string="false"; fi
+              ;;
+            "$raw_st") ;;
+            *) printf '%s' "$c2"; reprocess="true" ;;
+          esac
+          ;;
+        csi)
+          if [[ "$char" == [@-~] ]]; then state="normal"; fi
+          ;;
+        string)
+          if [[ "$osc_string" == "true" && "$char" == "$bel" ]]; then
+            state="normal"
+          elif [[ "$char" == "$esc" ]]; then
+            state="string_esc"
+          elif [[ "$char" == "$c2" ]]; then
+            state="string_c2"
+          elif [[ "$recognize_raw_c1" == "true" && "$char" == "$raw_st" ]]; then
+            state="normal"
+          fi
+          ;;
+        string_esc)
+          if [[ "$char" == "$backslash" ]]; then
+            state="normal"
+          else
+            state="string"
+            reprocess="true"
+          fi
+          ;;
+        string_c2)
+          if [[ "$char" == "$raw_st" ]]; then
+            state="normal"
+          else
+            state="string"
+            reprocess="true"
+          fi
+          ;;
+        utf8)
+          if { [[ "$utf8_position" -eq 2 ]] &&
+                { [[ "$char" < "$utf8_second_min" ]] || [[ "$char" > "$utf8_second_max" ]]; }; } ||
+              { [[ "$utf8_position" -ne 2 ]] &&
+                { [[ "$char" < "$cont_min" ]] || [[ "$char" > "$cont_max" ]]; }; }; then
+            pending=()
+            pending_count=0
+            for ((i = 1; i < ${#utf8_chars[@]}; i++)); do
+              pending[$pending_count]="${utf8_chars[$i]}"
+              pending_count=$((pending_count + 1))
+            done
+            pending[$pending_count]="$char"
+            pending_count=$((pending_count + 1))
+            pending_index=0
+            state="normal"
+          else
+            utf8_chars[${#utf8_chars[@]}]="$char"
+            utf8_remaining=$((utf8_remaining - 1))
+            utf8_position=$((utf8_position + 1))
+            if [[ "$utf8_remaining" -eq 0 ]]; then
+              printf '%s' "${utf8_chars[@]}"
+              state="normal"
+            fi
+          fi
+          ;;
+      esac
+    done
+  done
+}
+
 _sanitize_provider_text() {
-  local sequence_stripped="" utf8_text=""
-  # Remove complete common terminal sequences before deleting individual
-  # controls, or their printable payload (for example "[0m" or an OSC-8 URL)
-  # would survive after only the introducer/terminator bytes were removed.
-  sequence_stripped="$(LC_ALL=C sed -E \
-    -e $'s/\033\\][^\033]*\033\\\\//g' \
-    -e $'s/\033\\][^\234]*\234//g' \
-    -e $'s/\033\\](\302[^\234]|[^\302])*\302\234//g' \
-    -e $'s/\033\\][^\007]*\007//g' \
-    -e $'s/\235[^\234]*\234//g' \
-    -e $'s/\235[^\033]*\033\\\\//g' \
-    -e $'s/\235(\302[^\234]|[^\302])*\302\234//g' \
-    -e $'s/\235[^\007]*\007//g' \
-    -e $'s/\302\235(\302[^\234]|[^\302])*\302\234//g' \
-    -e $'s/\302\235[^\033]*\033\\\\//g' \
-    -e $'s/\302\235[^\234]*\234//g' \
-    -e $'s/\302\235[^\007]*\007//g' \
-    -e $'s/\033\\[[0-?]*[ -\\/]*[@-~]//g' \
-    -e $'s/\233[0-?]*[ -\\/]*[@-~]//g' \
-    -e $'s/\302\233[0-?]*[ -\\/]*[@-~]//g')" || return 1
+  local provider_text="" sequence_stripped="" utf8_text=""
+  provider_text="$(LC_ALL=C sed -e '')" || return 1
+  sequence_stripped="$(printf '%s' "$provider_text" | _strip_terminal_sequences true)" || return 1
   # Invalid standalone bytes, including raw 8-bit C1 controls, are discarded
   # without corrupting valid UTF-8 text whose continuation bytes overlap that
   # range. C0 controls and DEL then drop byte-wise; UTF-8-encoded C1 controls
@@ -70,7 +253,8 @@ _sanitize_provider_text() {
   # continuation bytes share the 0x80–0x9F range) is untouched.
   if command -v iconv >/dev/null 2>&1 &&
       utf8_text="$(printf '%s' "$sequence_stripped" | LC_ALL=C iconv -f UTF-8 -t UTF-8 -c 2>/dev/null)"; then
-    printf '%s' "$utf8_text" |
+    sequence_stripped="$(printf '%s' "$utf8_text" | _strip_terminal_sequences false)" || return 1
+    printf '%s' "$sequence_stripped" |
       LC_ALL=C tr -d '\000-\010\013-\037\177' |
       LC_ALL=C sed -e $'s/\xc2[\x80-\x9f]//g'
     return

--- a/scripts/git-cr.sh
+++ b/scripts/git-cr.sh
@@ -182,7 +182,23 @@ _strip_terminal_sequences() {
           esac
           ;;
         csi)
-          if [[ "$char" == [@-~] ]]; then state="normal"; fi
+          case "$char" in
+            "$esc") state="esc" ;;
+            "$c2") state="c2" ;;
+            "$raw_csi")
+              [[ "$recognize_raw_c1" == "true" ]] && state="csi"
+              ;;
+            "$raw_dcs"|"$raw_sos"|"$raw_osc"|"$raw_pm"|"$raw_apc")
+              if [[ "$recognize_raw_c1" == "true" ]]; then
+                state="string"
+                if [[ "$char" == "$raw_osc" ]]; then osc_string="true"; else osc_string="false"; fi
+              fi
+              ;;
+            "$raw_st")
+              [[ "$recognize_raw_c1" == "true" ]] && state="normal"
+              ;;
+            [@-~]) state="normal" ;;
+          esac
           ;;
         string)
           if [[ "$osc_string" == "true" && "$char" == "$bel" ]]; then

--- a/scripts/ws-hoard.sh
+++ b/scripts/ws-hoard.sh
@@ -90,6 +90,23 @@ ws_resolve_machine_name() {
     echo "$sanitized"
 }
 
+ws_require_hoard_name_available() {
+    local name="$1" kind conflicts=""
+
+    ws_classify_target_name "$name" || return 1
+    for kind in "${WS_TARGET_MATCH_KINDS[@]}"; do
+        [[ "$kind" == "hoard" ]] && continue
+        [[ -z "$conflicts" ]] || conflicts+=", "
+        conflicts+="$kind"
+    done
+
+    if [[ -n "$conflicts" ]]; then
+        echo "ERROR: Hoard name '$name' conflicts with existing target kind(s): $conflicts." >&2
+        echo "  Choose a different --name so ws commands remain unambiguous." >&2
+        return 1
+    fi
+}
+
 # Detect the active thalami hoard.
 # Returns the hoard directory name (not full path), or empty.
 #
@@ -722,6 +739,7 @@ ws_hoard_init() {
         echo "  Remove it first if you want to start over." >&2
         exit 1
     fi
+    ws_require_hoard_name_available "$hoard_name" || exit 1
 
     # thalami-specific validation
     case "$template" in
@@ -902,6 +920,7 @@ ws_hoard_clone_url() {
         echo "ERROR: Hoard '$repo_name' already exists at $target." >&2
         exit 1
     fi
+    ws_require_hoard_name_available "$repo_name" || exit 1
 
     mkdir -p "$HOARDS_DIR"
     echo "CLONE: hoard -> $target"

--- a/scripts/ws-realm.sh
+++ b/scripts/ws-realm.sh
@@ -132,12 +132,14 @@ WS_TARGET_MATCH_KINDS=()
 # still goes through ws_resolve_ecosystem and its realm-trust gate.
 ws_component_name_is_declared_for_collision() {
     local name="$1" active_realm="" local_file="${ECOSYSTEM_LOCAL:-$ROOT_DIR/ecosystem.local.yaml}"
-    local file="" declared="false"
+    local file="" realm_file="" realm_trust_state="missing" declared="false"
     local -a layer_files=("${ECOSYSTEM:-$ROOT_DIR/ecosystem.yaml}")
 
     active_realm="$(ws_detect_realm)" || return 2
     if [[ -n "$active_realm" ]]; then
-        layer_files+=("$REALMS_DIR/$active_realm/ecosystem.yaml")
+        realm_file="$REALMS_DIR/$active_realm/ecosystem.yaml"
+        realm_trust_state="$(ws_realm_trust_state "$active_realm")"
+        layer_files+=("$realm_file")
     fi
     layer_files+=("$local_file")
 
@@ -150,6 +152,11 @@ ws_component_name_is_declared_for_collision() {
         if COMPONENT_NAME="$name" yq -e '(((.components // {}) | select(kind == "map") | has(strenv(COMPONENT_NAME))) // false)' "$file" >/dev/null 2>&1; then
             if COMPONENT_NAME="$name" yq -e '.components[strenv(COMPONENT_NAME)] != null' "$file" >/dev/null 2>&1; then
                 declared="true"
+            elif [[ "$file" == "$realm_file" && "$realm_trust_state" != "current" ]]; then
+                # Untrusted realm additions count as possible collisions, but
+                # removals cannot erase a trusted declaration before the
+                # executable resolver reaches the realm-trust gate.
+                continue
             else
                 declared="false"
             fi

--- a/scripts/ws-realm.sh
+++ b/scripts/ws-realm.sh
@@ -118,6 +118,87 @@ ws_validate_component_keys() {
     fi
 }
 
+# Classify every workspace target kind matched by a name before choosing a
+# directory. Callers use the flags and ordered kind list below to reject
+# ambiguity instead of silently applying resolver precedence.
+WS_TARGET_MATCH_WORKSPACE=false
+WS_TARGET_MATCH_REALM=false
+WS_TARGET_MATCH_HOARD=false
+WS_TARGET_MATCH_COMPONENT=false
+WS_TARGET_MATCH_KINDS=()
+
+# Read configuration layers without granting authority from them. This helper
+# is only for detecting namespace collisions; executable component resolution
+# still goes through ws_resolve_ecosystem and its realm-trust gate.
+ws_component_name_is_declared_for_collision() {
+    local name="$1" active_realm="" local_file="${ECOSYSTEM_LOCAL:-$ROOT_DIR/ecosystem.local.yaml}"
+    local file="" declared="false"
+    local -a layer_files=("${ECOSYSTEM:-$ROOT_DIR/ecosystem.yaml}")
+
+    active_realm="$(ws_detect_realm)" || return 2
+    if [[ -n "$active_realm" ]]; then
+        layer_files+=("$REALMS_DIR/$active_realm/ecosystem.yaml")
+    fi
+    layer_files+=("$local_file")
+
+    for file in "${layer_files[@]}"; do
+        [[ -f "$file" ]] || continue
+        if ! yq '.' "$file" >/dev/null 2>&1; then
+            echo "ERROR: Cannot inspect component declarations in malformed ecosystem config: $file" >&2
+            return 2
+        fi
+        if COMPONENT_NAME="$name" yq -e '(((.components // {}) | select(kind == "map") | has(strenv(COMPONENT_NAME))) // false)' "$file" >/dev/null 2>&1; then
+            if COMPONENT_NAME="$name" yq -e '.components[strenv(COMPONENT_NAME)] != null' "$file" >/dev/null 2>&1; then
+                declared="true"
+            else
+                declared="false"
+            fi
+        fi
+    done
+
+    [[ "$declared" == "true" ]]
+}
+
+ws_classify_target_name() {
+    local name="$1" declaration_status=0
+
+    WS_TARGET_MATCH_WORKSPACE=false
+    WS_TARGET_MATCH_REALM=false
+    WS_TARGET_MATCH_HOARD=false
+    WS_TARGET_MATCH_COMPONENT=false
+    WS_TARGET_MATCH_KINDS=()
+
+    if [[ "$name" == "yggdrasil" ]]; then
+        WS_TARGET_MATCH_WORKSPACE=true
+        WS_TARGET_MATCH_KINDS+=("workspace")
+    fi
+
+    if [[ "$name" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
+        if [[ -d "$REALMS_DIR/$name/.git" ]]; then
+            WS_TARGET_MATCH_REALM=true
+            WS_TARGET_MATCH_KINDS+=("realm")
+        fi
+        if [[ -d "$HOARDS_DIR/$name/.git" ]]; then
+            WS_TARGET_MATCH_HOARD=true
+            WS_TARGET_MATCH_KINDS+=("hoard")
+        fi
+    fi
+
+    if ws_component_name_is_valid "$name"; then
+        if ! type -P yq &>/dev/null; then
+            echo "ERROR: yq (v4+) is required. Install: https://github.com/mikefarah/yq" >&2
+            return 1
+        fi
+        if ws_component_name_is_declared_for_collision "$name"; then
+            WS_TARGET_MATCH_COMPONENT=true
+            WS_TARGET_MATCH_KINDS+=("component")
+        else
+            declaration_status=$?
+            [[ "$declaration_status" -eq 1 ]] || return 1
+        fi
+    fi
+}
+
 # Resolve a workspace target name to its directory.
 # Usage: ws_resolve_target <name>
 # Sets: COMPONENT_DIR to the resolved path.
@@ -127,21 +208,30 @@ ws_validate_component_keys() {
 ws_resolve_target() {
     local name="$1"
 
-    # "yggdrasil" refers to the workspace root, not a component
-    if [[ "$name" == "yggdrasil" ]]; then
+    ws_classify_target_name "$name" || exit 1
+
+    if [[ "${#WS_TARGET_MATCH_KINDS[@]}" -gt 1 ]]; then
+        local kind kinds=""
+        for kind in "${WS_TARGET_MATCH_KINDS[@]}"; do
+            [[ -z "$kinds" ]] || kinds+=", "
+            kinds+="$kind"
+        done
+        echo "ERROR: Ambiguous target name '$name' matches: $kinds." >&2
+        echo "  Rename the colliding realm or hoard before running a target command." >&2
+        exit 1
+    fi
+
+    if [[ "$WS_TARGET_MATCH_WORKSPACE" == "true" ]]; then
         COMPONENT_DIR="$ROOT_DIR"
         return 0
     fi
 
-    # Check if name is a realm directory (uses broader name pattern)
-    if [[ "$name" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]] && [[ -d "$REALMS_DIR/$name/.git" ]]; then
+    if [[ "$WS_TARGET_MATCH_REALM" == "true" ]]; then
         COMPONENT_DIR="$REALMS_DIR/$name"
         return 0
     fi
 
-    # Check if name is a hoard directory (same broader name pattern as realms,
-    # since hoards are personal containers cloned with arbitrary repo names).
-    if [[ "$name" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]] && [[ -d "$HOARDS_DIR/$name/.git" ]]; then
+    if [[ "$WS_TARGET_MATCH_HOARD" == "true" ]]; then
         COMPONENT_DIR="$HOARDS_DIR/$name"
         return 0
     fi
@@ -154,18 +244,19 @@ ws_resolve_target() {
         exit 1
     fi
 
-    # Check yq is available
-    if ! type -P yq &>/dev/null; then
-        echo "ERROR: yq (v4+) is required. Install: https://github.com/mikefarah/yq" >&2
-        exit 1
+    if [[ "$WS_TARGET_MATCH_COMPONENT" == "true" ]]; then
+        local eco="" component_declared="false"
+        eco="$(ws_resolve_ecosystem)" || exit 1
+        if ! component_declared="$(COMPONENT_NAME="$name" yq -r '(((.components // {}) | select(kind == "map") | has(strenv(COMPONENT_NAME))) // false)' "$eco" 2>/dev/null)"; then
+            echo "ERROR: Cannot inspect component declarations in ecosystem config." >&2
+            exit 1
+        fi
+        if [[ "$component_declared" != "true" ]]; then
+            WS_TARGET_MATCH_COMPONENT=false
+        fi
     fi
 
-    # Check component exists in merged ecosystem config
-    local eco
-    eco="$(ws_resolve_ecosystem)"
-    local exists
-    exists=$(COMPONENT_NAME="$name" yq '.components[strenv(COMPONENT_NAME)] // "missing"' "$eco")
-    if [[ "$exists" == "missing" ]]; then
+    if [[ "$WS_TARGET_MATCH_COMPONENT" != "true" ]]; then
         echo "ERROR: no such target '$name' (looked for a component, realm, or hoard)." >&2
         echo "  Components must be declared in ecosystem config — run 'ws list'." >&2
         echo "  Realms live under realms/, hoards under hoards/ (must be cloned)." >&2

--- a/scripts/ws-realm.sh
+++ b/scripts/ws-realm.sh
@@ -224,7 +224,7 @@ ws_resolve_target() {
             kinds+="$kind"
         done
         echo "ERROR: Ambiguous target name '$name' matches: $kinds." >&2
-        echo "  Rename the colliding realm or hoard before running a target command." >&2
+        echo "  Rename or remove one of the colliding targets before running a target command." >&2
         exit 1
     fi
 

--- a/tests/ws-cr/remote-override.bats
+++ b/tests/ws-cr/remote-override.bats
@@ -128,6 +128,7 @@ case "${1:-} ${2:-}" in
       printf 'provider CSI to UTF-8 OSC: \033[\302\2358;;https://github.com/alt/project/pull/974\302\234\n'
       printf 'userinfo decoy: https://attacker.example@github.com/alt/project/pull/666\n'
       printf 'https://unrelated.example/not-the-created-pr\n'
+      # Keep this last: an unterminated string control consumes every later byte.
       printf 'provider unterminated APC: \033_https://github.com/alt/project/pull/978\n'
     else
       echo "https://github.com/alt/project/pull/1"

--- a/tests/ws-cr/remote-override.bats
+++ b/tests/ws-cr/remote-override.bats
@@ -103,15 +103,29 @@ case "${1:-} ${2:-}" in
     if [[ "${GH_PR_CREATE_ADVERSARIAL_OUTPUT:-}" == "1" ]]; then
       printf 'provider printable diagnostic\n'
       printf 'provider controls: ESC\033[31mred\033[0m BEL\007 C1\302\23331mgreen\302\2330m\n'
-      printf 'provider raw C1 controls: DCS\220 APC\237 PM\236 SOS\230\n'
+      printf 'provider raw C1 controls: DCS\220\234 APC\237\234 PM\236\234 SOS\230\234\n'
       printf 'provider Unicode diagnostic: “quoted text”\n'
       printf 'selected: <https://github.com/alt/project/pull/1\033[0m\047\042>.\n'
       printf 'provider BEL hyperlink: \033]8;;https://github.com/alt/project/pull/999\007visible BEL link\033]8;;\007\n'
       printf 'provider ST hyperlink: \033]8;;https://github.com/alt/project/pull/998\033\\visible café ST link\033]8;;\033\\\n'
       printf 'provider UTF-8 C1 hyperlink: \302\2358;;https://github.com/alt/project/pull/997\302\234visible C1 link\302\2358;;\302\234\n'
       printf 'provider mixed C1 hyperlink: \2358;;https://github.com/alt/project/pull/996\033\\visible mixed C1 link\2358;;\033\\\n'
+      printf 'provider ESC DCS: \033Phttps://github.com/alt/project/pull/990\033\\\n'
+      printf 'provider raw DCS: \220https://github.com/alt/project/pull/989\234\n'
+      printf 'provider UTF-8 DCS: \302\220https://github.com/alt/project/pull/988\302\234\n'
+      printf 'provider ESC SOS: \033Xhttps://github.com/alt/project/pull/987\033\\\n'
+      printf 'provider raw SOS: \230https://github.com/alt/project/pull/986\234\n'
+      printf 'provider UTF-8 SOS: \302\230https://github.com/alt/project/pull/985\302\234\n'
+      printf 'provider ESC PM: \033^https://github.com/alt/project/pull/984\033\\\n'
+      printf 'provider raw PM: \236https://github.com/alt/project/pull/983\234\n'
+      printf 'provider UTF-8 PM: \302\236https://github.com/alt/project/pull/982\302\234\n'
+      printf 'provider ESC APC: \033_https://github.com/alt/project/pull/981\033\\\n'
+      printf 'provider raw APC: \237https://github.com/alt/project/pull/980\234\n'
+      printf 'provider UTF-8 APC: \302\237https://github.com/alt/project/pull/979\302\234\n'
+      printf 'provider malformed UTF-8 before raw APC: \355\237xhttps://github.com/alt/project/pull/977\234\n'
       printf 'userinfo decoy: https://attacker.example@github.com/alt/project/pull/666\n'
       printf 'https://unrelated.example/not-the-created-pr\n'
+      printf 'provider unterminated APC: \033_https://github.com/alt/project/pull/978\n'
     else
       echo "https://github.com/alt/project/pull/1"
     fi
@@ -189,6 +203,10 @@ SH
     [[ "$output" != *"/pull/998"* ]] || failures="${failures} ST-hidden-target-replayed"
     [[ "$output" != *"/pull/997"* ]] || failures="${failures} C1-hidden-target-replayed"
     [[ "$output" != *"/pull/996"* ]] || failures="${failures} mixed-C1-hidden-target-replayed"
+    local hidden_id
+    for hidden_id in {977..990}; do
+        [[ "$output" != *"/pull/$hidden_id"* ]] || failures="${failures} string-control-target-$hidden_id-replayed"
+    done
     [[ "$output" == *"✓ CR ready: https://github.com/alt/project/pull/1" ]] || failures="${failures} clean-selected-host-URL-missing"
     [[ "$output" != *"✓ CR ready: https://github.com/alt/project/pull/1[0m)."* ]] || failures="${failures} decorated-URL-promoted"
     [[ "$output" != *"✓ CR ready: https://github.com/alt/project/pull/1)."* ]] || failures="${failures} trailing-punctuation-promoted"

--- a/tests/ws-cr/remote-override.bats
+++ b/tests/ws-cr/remote-override.bats
@@ -123,6 +123,9 @@ case "${1:-} ${2:-}" in
       printf 'provider raw APC: \237https://github.com/alt/project/pull/980\234\n'
       printf 'provider UTF-8 APC: \302\237https://github.com/alt/project/pull/979\302\234\n'
       printf 'provider malformed UTF-8 before raw APC: \355\237xhttps://github.com/alt/project/pull/977\234\n'
+      printf 'provider CSI to ESC OSC: \033[\033]8;;https://github.com/alt/project/pull/976\033\\\n'
+      printf 'provider CSI to raw OSC: \033[\2358;;https://github.com/alt/project/pull/975\234\n'
+      printf 'provider CSI to UTF-8 OSC: \033[\302\2358;;https://github.com/alt/project/pull/974\302\234\n'
       printf 'userinfo decoy: https://attacker.example@github.com/alt/project/pull/666\n'
       printf 'https://unrelated.example/not-the-created-pr\n'
       printf 'provider unterminated APC: \033_https://github.com/alt/project/pull/978\n'
@@ -204,7 +207,7 @@ SH
     [[ "$output" != *"/pull/997"* ]] || failures="${failures} C1-hidden-target-replayed"
     [[ "$output" != *"/pull/996"* ]] || failures="${failures} mixed-C1-hidden-target-replayed"
     local hidden_id
-    for hidden_id in {977..990}; do
+    for hidden_id in {974..990}; do
         [[ "$output" != *"/pull/$hidden_id"* ]] || failures="${failures} string-control-target-$hidden_id-replayed"
     done
     [[ "$output" == *"✓ CR ready: https://github.com/alt/project/pull/1" ]] || failures="${failures} clean-selected-host-URL-missing"

--- a/tests/ws-hoard-init/init.bats
+++ b/tests/ws-hoard-init/init.bats
@@ -169,6 +169,41 @@ setup() {
     [ "$(cat "$HOARDS_DIR/already-here/sentinel.txt")" = "preserved" ]
 }
 
+@test "init refuses a hoard name declared as a component" {
+    declare_component widget
+
+    run_hoard_init basic --name widget
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Hoard name 'widget' conflicts"* ]]
+    [[ "$output" == *"component"* ]]
+    [ ! -e "$HOARDS_DIR/widget" ]
+}
+
+@test "init refuses a hoard name used by a realm" {
+    create_realm community
+
+    run_hoard_init basic --name community
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Hoard name 'community' conflicts"* ]]
+    [[ "$output" == *"realm"* ]]
+    [ ! -e "$HOARDS_DIR/community" ]
+}
+
+@test "URL clone refuses a component collision before invoking Git" {
+    declare_component widget
+    install_failing_git
+
+    run_hoard_clone https://example.invalid/widget.git --name widget
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Hoard name 'widget' conflicts"* ]]
+    [[ "$output" == *"component"* ]]
+    [[ "$output" != *"UNEXPECTED GIT INVOCATION"* ]]
+    [ ! -e "$HOARDS_DIR/widget" ]
+}
+
 # ---------------------------------------------------------------------------
 # Unknown template
 # ---------------------------------------------------------------------------

--- a/tests/ws-hoard-init/test_helper.bash
+++ b/tests/ws-hoard-init/test_helper.bash
@@ -24,13 +24,15 @@ FIXTURES_DIR="$BATS_TEST_DIRNAME/fixtures"
 #   $HOARDS_DIR, $TEMPLATES_DIR, $ECOSYSTEM, $ECOSYSTEM_LOCAL — exported
 init_workspace() {
     WORK="$BATS_TEST_TMPDIR/work"
-    mkdir -p "$WORK/hoards"
+    mkdir -p "$WORK/components" "$WORK/hoards" "$WORK/realms"
 
     # Default to the real templates dir so the standard cp -R flow can
     # be tested against the actually-shipped obsidian-vault template.
     # Tests that need synthetic templates overwrite TEMPLATES_DIR after
     # calling init_workspace.
     export HOARDS_DIR="$WORK/hoards"
+    export COMPONENTS_DIR="$WORK/components"
+    export REALMS_DIR="$WORK/realms"
     export TEMPLATES_DIR="$REPO_ROOT/templates"
     export ROOT_DIR="$WORK"
 
@@ -40,7 +42,7 @@ init_workspace() {
     cat > "$ECOSYSTEM" <<'YAML'
 identity:
   human_account: ""
-components: []
+components: {}
 YAML
 
     # Local override providing identity.human_account
@@ -101,4 +103,29 @@ bare_head_for_url() {
 # Run ws-hoard.sh init with the propagating env. Args are forwarded.
 run_hoard_init() {
     run bash "$WS_HOARD_BIN" init "$@"
+}
+
+declare_component() {
+    local name="$1"
+    COMPONENT_NAME="$name" yq -i '.components[strenv(COMPONENT_NAME)] = {"repo": "https://example.invalid/repo.git"}' "$ECOSYSTEM"
+}
+
+create_realm() {
+    mkdir -p "$REALMS_DIR/$1/.git"
+}
+
+install_failing_git() {
+    local fake_bin="$BATS_TEST_TMPDIR/fake-bin"
+    mkdir -p "$fake_bin"
+    cat > "$fake_bin/git" <<'SH'
+#!/usr/bin/env bash
+echo "UNEXPECTED GIT INVOCATION: $*" >&2
+exit 99
+SH
+    chmod +x "$fake_bin/git"
+    export PATH="$fake_bin:$PATH"
+}
+
+run_hoard_clone() {
+    run bash "$WS_HOARD_BIN" "$@"
 }

--- a/tests/ws-target-resolution/ambiguity.bats
+++ b/tests/ws-target-resolution/ambiguity.bats
@@ -17,6 +17,7 @@ setup() {
     [[ "$output" == *"Ambiguous target name 'widget'"* ]]
     [[ "$output" == *"component"* ]]
     [[ "$output" == *"hoard"* ]]
+    [[ "$output" == *"Rename or remove one of the colliding targets"* ]]
     [[ "$output" != *"$HOARDS_DIR/widget"* ]]
 }
 

--- a/tests/ws-target-resolution/ambiguity.bats
+++ b/tests/ws-target-resolution/ambiguity.bats
@@ -59,6 +59,36 @@ YAML
     [[ "$output" != *"$COMPONENTS_DIR/widget"* ]]
 }
 
+@test "an unapproved realm tombstone cannot erase a component collision" {
+    declare_component widget
+    create_realm community
+    cat > "$REALMS_DIR/community/ecosystem.yaml" <<'YAML'
+components:
+  widget: null
+YAML
+    printf 'realm: community\n' > "$ECOSYSTEM_LOCAL"
+    create_hoard widget
+
+    run_ws exec widget pwd
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Ambiguous target name 'widget'"* ]]
+    [[ "$output" == *"component"* ]]
+    [[ "$output" == *"hoard"* ]]
+    [[ "$output" != *"$HOARDS_DIR/widget"* ]]
+}
+
+@test "a local tombstone can remove a base component collision" {
+    declare_component widget
+    COMPONENT_NAME=widget yq -i '.components[strenv(COMPONENT_NAME)] = null' "$ECOSYSTEM_LOCAL"
+    create_hoard widget
+
+    run_ws exec widget pwd
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"$HOARDS_DIR/widget"* ]]
+}
+
 @test "ws exec still resolves a unique realm" {
     create_realm community
 

--- a/tests/ws-target-resolution/ambiguity.bats
+++ b/tests/ws-target-resolution/ambiguity.bats
@@ -1,0 +1,78 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+    init_workspace
+}
+
+@test "ws exec rejects a cloned hoard that shadows a cloned component" {
+    declare_component widget
+    clone_component widget
+    create_hoard widget
+
+    run_ws exec widget pwd
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Ambiguous target name 'widget'"* ]]
+    [[ "$output" == *"component"* ]]
+    [[ "$output" == *"hoard"* ]]
+    [[ "$output" != *"$HOARDS_DIR/widget"* ]]
+}
+
+@test "ws exec rejects a cloned hoard that shadows an uncloned declared component" {
+    declare_component widget
+    create_hoard widget
+
+    run_ws exec widget pwd
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Ambiguous target name 'widget'"* ]]
+    [[ "$output" == *"component"* ]]
+    [[ "$output" == *"hoard"* ]]
+}
+
+@test "ws exec still resolves a unique declared component" {
+    declare_component widget
+    clone_component widget
+
+    run_ws exec widget pwd
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"$COMPONENTS_DIR/widget"* ]]
+}
+
+@test "ws exec does not treat an unapproved realm declaration as component authority" {
+    clone_component widget
+    create_realm community
+    cat > "$REALMS_DIR/community/ecosystem.yaml" <<'YAML'
+components:
+  widget:
+    repo: https://example.invalid/realm-widget.git
+YAML
+    printf 'realm: community\n' > "$ECOSYSTEM_LOCAL"
+
+    run_ws exec widget pwd
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"trust reapproval is required"* ]]
+    [[ "$output" != *"$COMPONENTS_DIR/widget"* ]]
+}
+
+@test "ws exec still resolves a unique realm" {
+    create_realm community
+
+    run_ws exec community pwd
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"$REALMS_DIR/community"* ]]
+}
+
+@test "ws exec still resolves a unique hoard" {
+    create_hoard notes
+
+    run_ws exec notes pwd
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"$HOARDS_DIR/notes"* ]]
+}

--- a/tests/ws-target-resolution/test_helper.bash
+++ b/tests/ws-target-resolution/test_helper.bash
@@ -1,0 +1,42 @@
+REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+WS_BIN="$REPO_ROOT/scripts/ws"
+
+init_workspace() {
+    WORK="$BATS_TEST_TMPDIR/work"
+    mkdir -p "$WORK/components" "$WORK/realms" "$WORK/hoards"
+
+    export ROOT_DIR="$WORK"
+    export COMPONENTS_DIR="$WORK/components"
+    export REALMS_DIR="$WORK/realms"
+    export HOARDS_DIR="$WORK/hoards"
+    export ECOSYSTEM="$WORK/ecosystem.yaml"
+    export ECOSYSTEM_LOCAL="$WORK/ecosystem.local.yaml"
+    export WS_FOOTER_DISABLE=1
+
+    cat > "$ECOSYSTEM" <<'YAML'
+identity: {}
+components: {}
+YAML
+    printf '{}\n' > "$ECOSYSTEM_LOCAL"
+}
+
+declare_component() {
+    local name="$1"
+    COMPONENT_NAME="$name" yq -i '.components[strenv(COMPONENT_NAME)] = {"repo": "https://example.invalid/repo.git"}' "$ECOSYSTEM"
+}
+
+clone_component() {
+    mkdir -p "$COMPONENTS_DIR/$1"
+}
+
+create_realm() {
+    mkdir -p "$REALMS_DIR/$1/.git"
+}
+
+create_hoard() {
+    mkdir -p "$HOARDS_DIR/$1/.git"
+}
+
+run_ws() {
+    run bash "$WS_BIN" "$@"
+}


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @Cervator via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

- Fail closed when workspace target kinds share a name, preventing commands from silently reaching the wrong checkout.
- Neutralize terminal string controls before provider output is displayed or considered as a review URL.

## Test plan

- [x] `ws test yggdrasil -j 4` — 1,211 tests
- [x] `ws exec yggdrasil git diff --check siliconsaga/main...HEAD`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text sanitization to remove terminal control sequences, including malformed and incomplete payloads, while preserving valid text.
  * Prevented hoard creation or cloning when names conflict with existing components, realms, or other target types.
  * Added clear errors for ambiguous target names instead of selecting one by precedence.
  * Ensured target resolution uses trusted component configuration.

* **Tests**
  * Expanded coverage for control-sequence sanitization, name collisions, ambiguous targets, and trust-related behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->