### PR TITLE
fix(env): load validator credentials as literal data

### DIFF
--- a/scripts/validate-agent-setup.sh
+++ b/scripts/validate-agent-setup.sh
@@ -2,7 +2,7 @@
 # validate-agent-setup.sh — verify agent tooling prerequisites are correctly configured
 #
 # Run at the start of any session where agent will push code or file issues:
-#   source .env && ./scripts/validate-agent-setup.sh
+#   ./scripts/validate-agent-setup.sh
 #
 # Checks:
 #   1. GH_TOKEN set and gh authenticated
@@ -12,11 +12,22 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=ws-env.sh
+source "$SCRIPT_DIR/ws-env.sh"
+ENV_FILE="$SCRIPT_DIR/../.env"
+
+if [[ -z "${GH_TOKEN:-}" && -f "$ENV_FILE" ]]; then
+  ws_load_env "$ENV_FILE"
+  ENV_FILE="$SCRIPT_DIR/../.env"
+  GH_TOKEN_LOAD_SOURCE="dotenv"
+else
+  GH_TOKEN_LOAD_SOURCE="environment"
+fi
+
 # Prevent MSYS / Git Bash from converting /api-style paths to C:/… filesystem paths
 export MSYS_NO_PATHCONV=1
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-ENV_FILE="$SCRIPT_DIR/../.env"
 PASS="✓"
 FAIL="✗"
 WARN="⚠"
@@ -36,14 +47,18 @@ check() {
 echo "[ gh auth ]"
 
 if [[ -z "${GH_TOKEN:-}" ]]; then
-  if [[ -f "$ENV_FILE" ]]; then
-    # shellcheck source=/dev/null
-    source "$ENV_FILE"
-    echo "  $WARN GH_TOKEN loaded from .env (not in environment — add 'source .env' to shell profile)"
+  if [[ "$GH_TOKEN_LOAD_SOURCE" == "dotenv" ]]; then
+    echo "  $FAIL GH_TOKEN missing or empty after loading $ENV_FILE"
   else
     echo "  $FAIL GH_TOKEN not set and $ENV_FILE not found"
-    ERRORS=$((ERRORS + 1))
   fi
+  echo ""
+  echo "Cannot continue without a nonempty GH_TOKEN. Set it in the environment or .env."
+  exit 1
+fi
+
+if [[ "$GH_TOKEN_LOAD_SOURCE" == "dotenv" ]]; then
+  echo "  $WARN GH_TOKEN loaded from .env as literal assignment data for this validation run"
 else
   echo "  $PASS GH_TOKEN set in environment"
 fi

--- a/scripts/ws-env.sh
+++ b/scripts/ws-env.sh
@@ -58,36 +58,40 @@ _ws_env_parse_value() {
 }
 
 ws_load_env() {
-    local env_file="$1"
-    [[ -f "$env_file" ]] || return 0
+    local __WS_ENV_FILE="$1"
+    [[ -f "$__WS_ENV_FILE" ]] || return 0
 
-    local line line_number=0 key raw_value value
-    local assignment_re='^[[:space:]]*(export[[:space:]]+)?([A-Za-z_][A-Za-z0-9_]*)=(.*)$'
-    while IFS= read -r line || [[ -n "$line" ]]; do
-        line_number=$((line_number + 1))
-        line="${line%$'\r'}"
-        [[ "$line" =~ ^[[:space:]]*$ || "$line" =~ ^[[:space:]]*# ]] && continue
+    local __WS_ENV_LINE __WS_ENV_LINE_NUMBER=0 __WS_ENV_KEY __WS_ENV_RAW_VALUE __WS_ENV_VALUE
+    local __WS_ENV_ASSIGNMENT_RE='^[[:space:]]*(export[[:space:]]+)?([A-Za-z_][A-Za-z0-9_]*)=(.*)$'
+    while IFS= read -r __WS_ENV_LINE || [[ -n "$__WS_ENV_LINE" ]]; do
+        __WS_ENV_LINE_NUMBER=$((__WS_ENV_LINE_NUMBER + 1))
+        __WS_ENV_LINE="${__WS_ENV_LINE%$'\r'}"
+        [[ "$__WS_ENV_LINE" =~ ^[[:space:]]*$ || "$__WS_ENV_LINE" =~ ^[[:space:]]*# ]] && continue
 
-        if [[ ! "$line" =~ $assignment_re ]]; then
-            echo "ERROR: invalid .env line $line_number in $env_file; expected KEY=value or export KEY=value." >&2
+        if [[ ! "$__WS_ENV_LINE" =~ $__WS_ENV_ASSIGNMENT_RE ]]; then
+            echo "ERROR: invalid .env line $__WS_ENV_LINE_NUMBER in $__WS_ENV_FILE; expected KEY=value or export KEY=value." >&2
             return 1
         fi
 
-        key="${BASH_REMATCH[2]}"
-        raw_value="${BASH_REMATCH[3]}"
-        case "$key" in
+        __WS_ENV_KEY="${BASH_REMATCH[2]}"
+        __WS_ENV_RAW_VALUE="${BASH_REMATCH[3]}"
+        case "$__WS_ENV_KEY" in
+            __WS_ENV_*)
+                echo "ERROR: refusing to set reserved variable '$__WS_ENV_KEY' from .env line $__WS_ENV_LINE_NUMBER in $__WS_ENV_FILE." >&2
+                return 1
+                ;;
             PATH|LD_PRELOAD|LD_LIBRARY_PATH|LD_AUDIT|DYLD_INSERT_LIBRARIES|DYLD_LIBRARY_PATH|BASH_ENV|ENV|IFS|PS4|PROMPT_COMMAND|SHELLOPTS|BASHOPTS|GIT_CONFIG*|GIT_SSH*|GIT_ASKPASS|SSH_ASKPASS|GIT_EXEC_PATH|GIT_EXTERNAL_DIFF|GIT_PROXY_COMMAND|GIT_TEMPLATE_DIR|GIT_COMMON_DIR|GIT_TRACE*|GIT_CURL_VERBOSE|GIT_ALLOW_PROTOCOL|GIT_DIR|GIT_WORK_TREE|GIT_INDEX_FILE|GIT_OBJECT_DIRECTORY|GIT_ALTERNATE_OBJECT_DIRECTORIES|GIT_NAMESPACE|GIT_EDITOR|GIT_SEQUENCE_EDITOR|GIT_PAGER|PAGER|EDITOR|VISUAL|LESSOPEN|LESSCLOSE|GH_PAGER|GLAB_PAGER|GH_DEBUG|GH_HOST|GH_CONFIG_DIR|GLAB_CONFIG_DIR|XDG_CONFIG_HOME|HOME|CDPATH|SCRIPT_DIR|ROOT_DIR|ECOSYSTEM|ECOSYSTEM_LOCAL|REALMS_DIR|COMPONENTS_DIR|HOARDS_DIR|TEMPLATES_DIR)
-                echo "ERROR: refusing to set reserved variable '$key' from .env line $line_number in $env_file." >&2
+                echo "ERROR: refusing to set reserved variable '$__WS_ENV_KEY' from .env line $__WS_ENV_LINE_NUMBER in $__WS_ENV_FILE." >&2
                 return 1
                 ;;
         esac
-        if ! value="$(_ws_env_parse_value "$raw_value" "$env_file" "$line_number")"; then
+        if ! __WS_ENV_VALUE="$(_ws_env_parse_value "$__WS_ENV_RAW_VALUE" "$__WS_ENV_FILE" "$__WS_ENV_LINE_NUMBER")"; then
             return 1
         fi
 
-        printf -v "$key" '%s' "$value"
-        export "$key"
-    done < "$env_file"
+        printf -v "$__WS_ENV_KEY" '%s' "$__WS_ENV_VALUE"
+        export "$__WS_ENV_KEY"
+    done < "$__WS_ENV_FILE"
 }
 
 # Provider-token names are prefix-allowlisted: a gitTokens mapping may only

--- a/tests/ws-env/load.bats
+++ b/tests/ws-env/load.bats
@@ -33,6 +33,36 @@ EOF
     [ ! -e "$marker" ]
 }
 
+@test "ws_load_env keeps ordinary local-name assignments literal across lines" {
+    local env_file="$BATS_TEST_TMPDIR/local-name.env"
+    local marker="$BATS_TEST_TMPDIR/local-name-command-ran"
+    local payload="REPO_ERRORS[\$(touch $marker)0]"
+    local REPO_ERRORS=0
+    local line_number=""
+    cat > "$env_file" <<EOF
+line_number=$payload
+GH_TOKEN=token
+EOF
+
+    source "$ENV_LIB"
+    ws_load_env "$env_file"
+
+    [ ! -e "$marker" ]
+    [ "$line_number" = "$payload" ]
+    [ "$GH_TOKEN" = "token" ]
+}
+
+@test "ws_load_env rejects assignments in its reserved internal namespace" {
+    local env_file="$BATS_TEST_TMPDIR/internal-name.env"
+    echo "__WS_ENV_LINE=attacker-controlled" > "$env_file"
+
+    source "$ENV_LIB"
+    run ws_load_env "$env_file"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"refusing to set reserved variable '__WS_ENV_LINE'"* ]]
+}
+
 @test "ws_load_env strips whitespace-delimited inline comments from unquoted values" {
     local env_file="$BATS_TEST_TMPDIR/inline-comments.env"
     cat > "$env_file" <<'EOF'

--- a/tests/ws-validate-agent-setup/literal-env.bats
+++ b/tests/ws-validate-agent-setup/literal-env.bats
@@ -1,0 +1,196 @@
+#!/usr/bin/env bats
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    WORK="$BATS_TEST_TMPDIR/workspace"
+    BIN="$BATS_TEST_TMPDIR/bin"
+    CALL_LOG="$BATS_TEST_TMPDIR/external-calls.log"
+    GH_MARKER="$BATS_TEST_TMPDIR/gh-token-command-ran"
+    ERRORS_MARKER="$BATS_TEST_TMPDIR/errors-command-ran"
+    LOADER_MARKER="$BATS_TEST_TMPDIR/loader-local-command-ran"
+
+    mkdir -p "$WORK/scripts" "$BIN"
+    cp "$REPO_ROOT/scripts/validate-agent-setup.sh" "$WORK/scripts/"
+    cp "$REPO_ROOT/scripts/ws-env.sh" "$WORK/scripts/"
+
+    cat > "$BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+printf 'gh' >> "$EXTERNAL_CALL_LOG"
+for arg in "$@"; do
+    printf ' <%s>' "$arg" >> "$EXTERNAL_CALL_LOG"
+done
+printf '\n' >> "$EXTERNAL_CALL_LOG"
+
+if [[ "${GH_TOKEN-}" != "${EXPECTED_GH_TOKEN-}" ]]; then
+    echo "unexpected GH_TOKEN value seen by gh" >&2
+    exit 96
+fi
+
+if [[ "$#" -eq 2 && "$1" == "auth" && "$2" == "status" ]]; then
+    exit 0
+fi
+
+if [[ "$#" -eq 4 && "$1" == "api" && "$2" == "/user" && "$3" == "--jq" && "$4" == ".login" ]]; then
+    echo "test-user"
+    exit 0
+fi
+
+if [[ "$#" -eq 4 && "$1" == "api" && "$3" == "--jq" && "$4" == '[.permissions.push, .permissions.pull] | @csv' ]]; then
+    case "$2" in
+        /repos/SiliconSaga/nordri|/repos/SiliconSaga/nidavellir|/repos/SiliconSaga/mimir|/repos/SiliconSaga/yggdrasil|/repos/SiliconSaga/vordu)
+            echo "true,true"
+            exit 0
+            ;;
+    esac
+fi
+
+if [[ "$#" -eq 4 && "$1" == "api" && "$3" == "--jq" && "$4" == ".protected" ]]; then
+    case "$2" in
+        /repos/SiliconSaga/nordri/branches/main|/repos/SiliconSaga/nidavellir/branches/main|/repos/SiliconSaga/mimir/branches/main|/repos/SiliconSaga/yggdrasil/branches/main|/repos/SiliconSaga/vordu/branches/main)
+            echo "true"
+            exit 0
+            ;;
+    esac
+fi
+
+echo "unexpected gh invocation" >&2
+exit 97
+EOF
+
+    cat > "$BIN/git" <<'EOF'
+#!/usr/bin/env bash
+printf 'git' >> "$EXTERNAL_CALL_LOG"
+for arg in "$@"; do
+    printf ' <%s>' "$arg" >> "$EXTERNAL_CALL_LOG"
+done
+printf '\n' >> "$EXTERNAL_CALL_LOG"
+
+if [[ "$#" -eq 2 && "$1" == "config" && "$2" == "--list" ]]; then
+    echo "credential.https://github.com.helper=!gh auth git-credential"
+    exit 0
+fi
+
+echo "unexpected git invocation" >&2
+exit 98
+EOF
+
+    chmod +x "$BIN/gh" "$BIN/git"
+}
+
+run_validator() {
+    local expected_gh_token="$1"
+    if [[ "$#" -eq 2 ]]; then
+        run env -u GH_TOKEN REPO_ERRORS="$2" EXTERNAL_CALL_LOG="$CALL_LOG" EXPECTED_GH_TOKEN="$expected_gh_token" PATH="$BIN:$PATH" "$WORK/scripts/validate-agent-setup.sh"
+    else
+        run env -u GH_TOKEN EXTERNAL_CALL_LOG="$CALL_LOG" EXPECTED_GH_TOKEN="$expected_gh_token" PATH="$BIN:$PATH" "$WORK/scripts/validate-agent-setup.sh"
+    fi
+}
+
+run_validator_with_environment_token() {
+    local expected_gh_token="$1"
+    run env GH_TOKEN="$expected_gh_token" EXTERNAL_CALL_LOG="$CALL_LOG" EXPECTED_GH_TOKEN="$expected_gh_token" PATH="$BIN:$PATH" "$WORK/scripts/validate-agent-setup.sh"
+}
+
+assert_successful_external_calls() {
+    local expected_log="$BATS_TEST_TMPDIR/expected-external-calls.log"
+    cat > "$expected_log" <<'EOF'
+gh <auth> <status>
+gh <api> </user> <--jq> <.login>
+git <config> <--list>
+git <config> <--list>
+gh <api> </repos/SiliconSaga/nordri> <--jq> <[.permissions.push, .permissions.pull] | @csv>
+gh <api> </repos/SiliconSaga/nidavellir> <--jq> <[.permissions.push, .permissions.pull] | @csv>
+gh <api> </repos/SiliconSaga/mimir> <--jq> <[.permissions.push, .permissions.pull] | @csv>
+gh <api> </repos/SiliconSaga/yggdrasil> <--jq> <[.permissions.push, .permissions.pull] | @csv>
+gh <api> </repos/SiliconSaga/vordu> <--jq> <[.permissions.push, .permissions.pull] | @csv>
+gh <api> </repos/SiliconSaga/nordri/branches/main> <--jq> <.protected>
+gh <api> </repos/SiliconSaga/nidavellir/branches/main> <--jq> <.protected>
+gh <api> </repos/SiliconSaga/mimir/branches/main> <--jq> <.protected>
+gh <api> </repos/SiliconSaga/yggdrasil/branches/main> <--jq> <.protected>
+gh <api> </repos/SiliconSaga/vordu/branches/main> <--jq> <.protected>
+EOF
+    diff -u "$expected_log" "$CALL_LOG"
+}
+
+@test "validate-agent-setup overwrites validator state loaded from literal .env data" {
+    local expected_gh_token="\$(touch $GH_MARKER)"
+    cat > "$WORK/.env" <<EOF
+GH_TOKEN=$expected_gh_token
+ERRORS=REPO_ERRORS[\$(touch $ERRORS_MARKER)0]
+EOF
+
+    run_validator "$expected_gh_token"
+
+    if [[ "$status" -ne 0 ]]; then
+        echo "$output"
+    fi
+    [ ! -e "$GH_MARKER" ]
+    [ ! -e "$ERRORS_MARKER" ]
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"GH_TOKEN loaded from .env as literal assignment data for this validation run"* ]]
+    assert_successful_external_calls
+}
+
+@test "validate-agent-setup keeps loader-local names literal across .env lines" {
+    local expected_gh_token="token"
+    cat > "$WORK/.env" <<EOF
+line_number=REPO_ERRORS[\$(touch $LOADER_MARKER)0]
+GH_TOKEN=$expected_gh_token
+EOF
+
+    run_validator "$expected_gh_token" "0"
+
+    [ ! -e "$LOADER_MARKER" ]
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"GH_TOKEN loaded from .env as literal assignment data for this validation run"* ]]
+    assert_successful_external_calls
+}
+
+@test "validate-agent-setup exits before external commands when GH_TOKEN is missing" {
+    run_validator ""
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"GH_TOKEN not set and $WORK/scripts/../.env not found"* ]]
+    [ ! -e "$CALL_LOG" ]
+}
+
+@test "validate-agent-setup exits before external commands when .env has an empty GH_TOKEN" {
+    cat > "$WORK/.env" <<'EOF'
+ENV_FILE=/attacker-controlled
+GH_TOKEN=
+EOF
+
+    run_validator ""
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"GH_TOKEN missing or empty after loading $WORK/scripts/../.env"* ]]
+    [[ "$output" != *"/attacker-controlled"* ]]
+    [ ! -e "$CALL_LOG" ]
+}
+
+@test "validate-agent-setup exits before external commands when .env is malformed" {
+    echo "this is not an assignment" > "$WORK/.env"
+
+    run_validator ""
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"invalid .env line 1"* ]]
+    [ ! -e "$CALL_LOG" ]
+}
+
+@test "validate-agent-setup gives a valid environment token precedence over hostile .env" {
+    local expected_gh_token="ambient-literal-token"
+    cat > "$WORK/.env" <<EOF
+line_number=REPO_ERRORS[\$(touch $LOADER_MARKER)0]
+this is not an assignment
+GH_TOKEN=file-token
+EOF
+
+    run_validator_with_environment_token "$expected_gh_token"
+
+    [ "$status" -eq 0 ]
+    [ ! -e "$LOADER_MARKER" ]
+    [[ "$output" == *"GH_TOKEN set in environment"* ]]
+    [[ "$output" != *"GH_TOKEN loaded from .env"* ]]
+    assert_successful_external_calls
+}


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @Cervator via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

- Make credential validation treat workspace environment files as data while preserving ordinary provider-token precedence and direct invocation.

## Test plan

- [x] Exercise literal environment parsing and validator credential precedence locally.
- [ ] Run the full workspace suite in GitHub CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Validation can now run without manually loading environment configuration first.
  - Provides clearer feedback when authentication tokens are missing, empty, loaded from the environment, or loaded from configuration files.
  - Prioritizes valid environment-provided tokens over configuration-file values.

- **Bug Fixes**
  - Prevents unsafe or malformed configuration assignments from being processed.
  - Stops validation immediately when required authentication data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->