### PR TITLE
docs(gdd-branch-workflow): fetch before resuming a branch, not just before push

### DIFF
--- a/.agent/skills/gdd-branch-workflow/SKILL.md
+++ b/.agent/skills/gdd-branch-workflow/SKILL.md
@@ -66,10 +66,15 @@ cp templates/change.md .crs/<description>.md
 bash scripts/ws cr <component> "type: description" .crs/<description>.md
 ```
 
-## Rebasing onto Updated Main
+## Rebasing onto Updated Main (or Resuming a Branch)
 
-When main moves ahead during code review (e.g., another CR merges), rebase
-to keep a clean linear history before merging.
+Same fetch-then-rebase move, two triggers: main moved ahead during code
+review, or you're resuming a branch that may have moved on its own
+remote (another session, another push). Don't assume — fetch first:
+
+```bash
+git fetch origin <branch> && git rebase origin/<branch>
+```
 
 ### Pre-rebase checklist
 


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @soloturn via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

- `gdd-branch-workflow` skill: merged the "resume a possibly-stale branch" case into the existing "Rebasing onto Updated Main" section (same fetch-then-rebase move, two triggers) rather than adding a duplicate procedure.
- Prompted by checking out an existing branch from a stale local ref and hitting a non-fast-forward push later — the fix belongs at the start of the work, not caught only at push time.

## Test plan

- [ ] Docs-only change, no runtime surface to exercise.

## Related

