### PR TITLE
fix(ws-gh): fall back to gh's ambient login when no .env token is set

### DIFF
--- a/scripts/ws-gh.sh
+++ b/scripts/ws-gh.sh
@@ -2,22 +2,17 @@
 # ws-gh.sh — GitHub CLI (gh) passthrough that injects the workspace token.
 # ws:use-when running a one-off gh command (PR/issue/api) in an agent session
 #
-# The dispatcher auto-sources .env before reaching here, so GH_TOKEN is already
-# in the environment — gh reads it natively. The value of routing through `ws`:
-# a raw `gh` in an agent's Bash tool runs in a fresh shell that never sourced
-# the workspace .env, so it falls through to an interactive `gh auth login` and
-# fails. This wrapper gives agents one auditable entry point that fails fast
-# with a useful message instead. It never prints the token (cf. the
-# never-print-the-auth-header lesson). Mirror of ws-glab.sh.
+# Mirror of ws-glab.sh.
 set -euo pipefail
 
 if [[ $# -eq 0 ]]; then
     cat <<'HELP'
 Usage: ws gh <gh args...>
 
-Runs the GitHub CLI (gh) with the workspace .env token (GH_TOKEN) injected,
-so agent/non-interactive sessions don't fall through to `gh auth login`.
-Pass any gh args through, e.g.:
+Runs the GitHub CLI (gh) with the workspace .env token (GH_TOKEN) injected
+if set, otherwise gh's own already-valid stored login — so agent/non-
+interactive sessions don't fall through to `gh auth login`. Pass any gh args
+through, e.g.:
   ws gh pr list --limit 5
   ws gh pr checks 123
   ws gh api /repos/{owner}/{repo}/pulls
@@ -34,12 +29,16 @@ for _a in "$@"; do
     case "$_a" in --help|-h) exec gh "$@" ;; esac
 done
 
-# gh reads GH_TOKEN, then GITHUB_TOKEN. Require one rather than letting gh prompt.
+# Use .env token if set, else gh's own stored login (same fallback ws cr uses).
 if [[ -z "${GH_TOKEN:-}" && -z "${GITHUB_TOKEN:-}" ]]; then
-    echo "ERROR: no GitHub token in the environment (GH_TOKEN / GITHUB_TOKEN)." >&2
-    echo "  Add 'export GH_TOKEN=<token>' to .env (see docs/git-provider-setup.md)," >&2
-    echo "  then retry. 'ws diagnose <comp>' shows which token covers a remote." >&2
-    exit 1
+    if ! gh auth status >/dev/null 2>&1; then
+        echo "ERROR: no GitHub token in the environment (GH_TOKEN / GITHUB_TOKEN)," >&2
+        echo "  and 'gh' has no valid stored login either." >&2
+        echo "  Add 'export GH_TOKEN=<token>' to .env (see docs/git-provider-setup.md)," >&2
+        echo "  or run 'gh auth login' interactively, then retry." >&2
+        echo "  'ws diagnose <comp>' shows which token covers a remote." >&2
+        exit 1
+    fi
 fi
 
 exec gh "$@"


### PR DESCRIPTION
ws gh need token before. now try gh login too.

test: pr view ok no token.
