### PR TITLE
docs(gh-pages): point at the Völundr CI extras

### DIFF
--- a/templates/components/gh-pages/README.md
+++ b/templates/components/gh-pages/README.md
@@ -360,6 +360,7 @@ few common next steps, in roughly increasing complexity:
   with its own setup. Ask your agent for the typical patterns —
   Disqus or utterances for comments, GoatCounter or Plausible for
   cookieless analytics, lunr or Algolia for search.
+- **Shared CI: PR previews and visual diffs.** [Völundr](https://github.com/SiliconSaga/volundr) holds reusable workflows the SiliconSaga sites share, so every pull request gets its own preview URL and a screenshot diff against `main`, and your repo carries two thin caller stubs instead of a copy of the CI logic. Two things have to change first, and both contradict what Chapter 1 set up: the site needs a checked-in `Gemfile` using the `github-pages` gem, and Pages has to serve from a `gh-pages` branch rather than `main` — the deploy workflow publishes there. Adding the Gemfile also switches local preview to `bundle exec jekyll serve`, as noted under **Local preview** below. Your default branch has to be `main`. Ask your agent to walk you through it: the adoption steps live in Völundr's `aspect/SKILL.md`, and it can apply them for you.
 
 Each of these is more involved than the Chapter 1+2 loop and
 benefits from breaking into its own PR with its own review cycle.


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @Cervator via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

- One bullet in the `gh-pages` template's Chapter 3+ list, pointing at [Völundr](https://github.com/SiliconSaga/volundr)'s shared CI: per-PR preview URLs and screenshot diffs against `main`, via two thin caller stubs rather than a copy of the CI logic per repo.
- **Prose, not scaffolding.** The template stays minimal and Ch 3+ is where optional upgrades live, so adoption stays a real step the reader takes. Nothing Backstage-flavored either — the pointer is at Völundr's `aspect/SKILL.md`, the agent door, which needs no instance. That matters because most of this template's audience has none.
- **Names all three prerequisites, because two of them contradict Chapter 1.** The scaffold ships no `Gemfile` and points Pages at `main`; the workflows need a Gemfile and publish to `gh-pages`. The third is that the default branch must be `main`. Better stated here than discovered from a CI failure.

## Test plan

- [ ] Read the new bullet against the **Local preview** section below it — that section already anticipates a `Gemfile` arriving later and explains the switch to `bundle exec`, so it needed no change. Checked rather than assumed.
- [ ] No command to run; this is one line of prose in a template README.

## Related

- The aspect it points at: [volundr#4](https://github.com/SiliconSaga/volundr/pull/4) (merged). Design and plan: [leidangr#19](https://github.com/SiliconSaga/leidangr/pull/19).
- **Note for a follow-up, not done here:** this README is hard-wrapped throughout (145 lines). Per the convention added in `gdd-doc-writing`, I am asking rather than reflowing it as a side effect — happy to do it as its own commit if you want.
