### PR TITLE
feat(ws): fmt verb to format a component's sources

### DIFF
--- a/.agent/skills/gdd-doc-writing/SKILL.md
+++ b/.agent/skills/gdd-doc-writing/SKILL.md
@@ -25,7 +25,11 @@ It does *not* apply to:
 
 "One bullet per line" means literally one line per bullet — a bullet whose text breaks across several physical lines counts as hard-wrapped prose and is to be avoided.
 
-If a file already uses hard-wrapped prose throughout, the existing wrapped content stays wrapped — don't reflow it as a side-effect of unrelated edits. But **new content added to such a file still uses the don't-wrap convention**, even when the surrounding prose is wrapped. New files always use the don't-wrap convention.
+New files always use the don't-wrap convention, and so does **new content added to a file that is already hard-wrapped** — even when every paragraph around it is wrapped. The surrounding style is not the convention; the convention is.
+
+When you find yourself editing a hard-wrapped file, **say so and ask whether to reflow it** — don't reflow it silently as a side-effect, and don't quietly leave it either. Something like: *"local-dev.md is hard-wrapped throughout (85 lines). Want me to reflow it in a separate commit while I'm here?"* A separate commit keeps the reflow diff out of the change being reviewed. If the answer is no, or you're mid-task and it would derail things, leave the old prose wrapped and still write your new prose unwrapped.
+
+Why ask rather than follow the file: matching the surrounding paragraphs feels like care, so a wrapped file quietly recruits every later edit into staying wrapped, and the violation compounds invisibly. Asking costs one sentence and puts the choice where it belongs.
 
 ## Describe current state, not history
 
@@ -42,8 +46,7 @@ The record of change lives elsewhere, and that is where history belongs:
 
 ### Rule 1: Never use `\n` in node labels
 
-`\n` does NOT render as a newline in Mermaid in most contexts (GitHub, VS Code, many
-preview tools). Use `<br/>` instead.
+`\n` does NOT render as a newline in Mermaid in most contexts (GitHub, VS Code, many preview tools). Use `<br/>` instead.
 
 ```
 WRONG: NODE["Title\nSubtitle"]
@@ -52,8 +55,7 @@ RIGHT: NODE["Title<br/>Subtitle"]
 
 ### Rule 2: No background fill colors
 
-Never use `style` declarations with `fill:` color values. They render inconsistently
-across dark/light themes and break in many Mermaid renderers.
+Never use `style` declarations with `fill:` color values. They render inconsistently across dark/light themes and break in many Mermaid renderers.
 
 ```
 WRONG: style NodeA fill:#f9d0d0
@@ -61,14 +63,11 @@ WRONG: style NodeA fill:#d0f0d0,color:#000
 RIGHT: (omit the style declaration entirely)
 ```
 
-If you need to visually distinguish nodes, use shape variants (`([...])`, `{...}`, etc.)
-or subgraph grouping — not fill colors.
+If you need to visually distinguish nodes, use shape variants (`([...])`, `{...}`, etc.) or subgraph grouping — not fill colors.
 
 ### Rule 3: Layer cake diagrams use `graph BT`
 
-For hierarchy diagrams where a foundation layer sits at the bottom (e.g., the three
-Yggdrasil platform tiers), use `graph BT` (bottom-to-top). Arrows go from the
-lower/foundation tier to the upper tier it supports.
+For hierarchy diagrams where a foundation layer sits at the bottom (e.g., the three Yggdrasil platform tiers), use `graph BT` (bottom-to-top). Arrows go from the lower/foundation tier to the upper tier it supports.
 
 ```mermaid
 graph BT
@@ -80,8 +79,7 @@ This puts the Foundation subgraph at the bottom of the rendered diagram.
 
 ### Rule 4: Multi-word subgraph labels use em dashes
 
-For subgraph title strings with multiple logical parts, use ` — ` (em dash, not double
-hyphen) as the separator. This renders cleanly as plain text.
+For subgraph title strings with multiple logical parts, use ` — ` (em dash, not double hyphen) as the separator. This renders cleanly as plain text.
 
 ```
 subgraph T1["Tier 1 — Nordri — Cluster Substrate"]
@@ -175,5 +173,4 @@ Nidavellir (apps/) → references Demicracy app-of-apps
 Demicracy (apps/) → references its own components
 ```
 
-**Never** put a Demicracy Application in Nordri's `platform/argocd/`. Nordri only knows
-about Nidavellir. Nidavellir is the forge that deploys Demicracy.
+**Never** put a Demicracy Application in Nordri's `platform/argocd/`. Nordri only knows about Nidavellir. Nidavellir is the forge that deploys Demicracy.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -63,6 +63,8 @@
       "Bash(bash scripts/ws test:*)",
       "Bash(ws lint:*)",
       "Bash(bash scripts/ws lint:*)",
+      "Bash(ws build:*)",
+      "Bash(bash scripts/ws build:*)",
       "Bash(ws review:*)",
       "Bash(bash scripts/ws review:*)",
       "Bash(ws log:*)",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -63,6 +63,8 @@
       "Bash(bash scripts/ws test:*)",
       "Bash(ws lint:*)",
       "Bash(bash scripts/ws lint:*)",
+      "Bash(ws fmt:*)",
+      "Bash(bash scripts/ws fmt:*)",
       "Bash(ws build:*)",
       "Bash(bash scripts/ws build:*)",
       "Bash(ws review:*)",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,7 @@ Reference forms in skill bodies:
 3. **`ws <cmd>`** in preference to raw `git` / `gh` / `glab` / runners (see Reflex Contract).
 4. **One command at a time.** Don't bundle with `;` `&&` `|`. The PreToolUse hook denies shell composition — use separate tool calls and native `ws` flags (`--compact`, `--limit N`, `--output <phrase>`) instead of pipes.
 5. **No raw `git`/`gh`/`glab`** for the unconditional verbs above. Wrappers handle attribution, auth, remote selection — raw tools won't.
-6. **No hard-wrapped prose.** Write each paragraph as a single line and let editors / renderers handle wrap. Code blocks, tables, and YAML frontmatter are exempt; list *structure* is too (one line per item), but each bullet's own text is still a single line — never wrap inside a bullet.
+6. **No hard-wrapped prose.** Write each paragraph as a single line and let editors / renderers handle wrap. Code blocks, tables, and YAML frontmatter are exempt; list *structure* is too (one line per item), but each bullet's own text is still a single line — never wrap inside a bullet. Editing a file that is already wrapped? Ask whether to reflow it instead of matching its style — see `gdd-doc-writing`.
 7. **Prefer native file tools over shelling out.** Use your harness's file read / write / edit tools to inspect or change files rather than `cat` / `echo` / `sed` / `tee` — clearer, and it sidesteps the shell-composition and redirection hooks. When you genuinely need a throwaway helper script (a poll loop, a one-off probe), put it under the workspace `.tmp/` (gitignored, swept by `ws clean`), never `/tmp`.
 
 ---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ The PreToolUse hook denies `git commit` / `git push` / `gh pr create` at Tier 2 
 
 Subcommands that take a target (commit, push, cr, issue, review, log, diagnose, test, lint) also accept realm and hoard names, not just components.
 
-**Adapter-routed verbs — consult `ws orient` first:** `ws test` / `ws lint` / `ws build`.
+**Adapter-routed verbs — consult `ws orient` first:** `ws test` / `ws lint` / `ws fmt` / `ws build`.
 
 The adapter wiring per component lives in `realms/<active>/adapters/<comp>.yaml`. **Run `ws orient` to see what each component's adapter resolves to** — the output surfaces each row's executed command (`knarr → ws test [runs: python3 -m pytest --ignore=tests/features]`) so you can verify what `ws test` will actually run. When an adapter is wired, the hook redirects raw `pytest` / `ruff` / `gradle test` to the corresponding `ws` form. When no adapter exists, raw runs through with a one-time nudge.
 

--- a/scripts/ws
+++ b/scripts/ws
@@ -24,11 +24,12 @@
 #   test <comp> [TestName|args...] Run tests (auto-detected; see 'ws actions <comp>')
 #   lint <comp> [args...] Run the component linter (adapter commands.lint; see 'ws actions <comp>')
 #   build <comp> [args...] Run the component build (adapter commands.build; see 'ws actions <comp>')
-#   run <comp> <action> [args...] Run any other adapter-declared action (see 'ws actions <comp>')
+#   run <comp> [args...] Run the component itself — game, dev server, sandbox (adapter commands.run)
 #   review <comp> <cr#|threads> [options]  CR review comments and threads (see ws review --help)
 #   commit <comp> <bodyfile> Commit with Co-Authored-By trailer (bodyfile-driven; see templates/commit.md)
 #   log [comp] [--oneline] Show commits on current branch vs main
 #   clean [--force]   Remove draft files from .issues/, .crs/, .commits/, .outputs/, .tmp/ (holds off below the mining threshold unless --force)
+#   clean <comp> [args...] Run the component's adapter clean (adapter commands.clean)
 #   k8s scope set|show|clear / k8s <args>   Guarded kubectl: prevalidate context + namespace
 #   docker <args>     Run docker with Windows/MSYS path conversion handled automatically
 #   whoami [--set "Name <email>"]  Show/set this session's commit identity
@@ -430,8 +431,48 @@ HELP
     fi
 }
 
+ws_clean_target() {
+    # Adapter form of clean: `ws clean <comp>` runs the component's
+    # `commands.clean` in its directory, mirroring ws build / ws run.
+    local comp="$1"
+    shift
+    ws_resolve_target "$comp"
+    cd "$COMPONENT_DIR"
+    local active_realm adapter_file clean_cmd=""
+    active_realm="$(ws_detect_realm)" || true
+    if [[ -n "$active_realm" ]]; then
+        adapter_file="$REALMS_DIR/$active_realm/adapters/$comp.yaml"
+        if [[ -f "$adapter_file" ]]; then
+            ws_require_active_realm_trust "$active_realm" || exit 1
+            # Guard the substitution: a non-zero yq exit (malformed adapter
+            # YAML) must not abort before the guidance below runs.
+            clean_cmd=$(yq -r '.commands.clean // ""' "$adapter_file" 2>/dev/null) || clean_cmd=""
+        fi
+    fi
+    if [[ -z "$clean_cmd" ]]; then
+        echo "ERROR: No clean command configured for '$comp'." >&2
+        echo "  Add 'commands.clean' to the realm adapter:" >&2
+        echo "    realms/<realm>/adapters/$comp.yaml" >&2
+        echo "  Run 'ws actions $comp' to see what's configured." >&2
+        echo "  (Bare 'ws clean' sweeps workspace draft files instead.)" >&2
+        exit 1
+    fi
+    # Adapter command contract mirrors ws-test.sh: whitespace-separated
+    # tokens only; use a wrapper script for complex quoting.
+    local clean_argv=()
+    # shellcheck disable=SC2206
+    read -r -a clean_argv <<< "$clean_cmd"
+    "${clean_argv[@]}" "$@"
+}
+
 ws_clean() {
-    # ws:use-when sweeping draft files from .commits/ .crs/ .issues/ .outputs/ .tmp/
+    # ws:use-when sweeping draft files from .commits/ .crs/ .issues/ .outputs/ .tmp/ — or, with a component, running its adapter clean
+    # Target form first: a non-flag leading arg names a component whose
+    # adapter `commands.clean` should run. Bare/flag form sweeps drafts.
+    if [[ $# -gt 0 && "${1:0:1}" != "-" ]]; then
+        ws_clean_target "$@"
+        return $?
+    fi
     local force=0
     local clean_sessions=0
     local arg
@@ -442,9 +483,13 @@ ws_clean() {
             --sessions-all) clean_sessions=1 ;;
             -h|--help)
                 echo "Usage: ws clean [--force] [--sessions-all]"
+                echo "       ws clean <component> [args...]"
                 echo ""
                 echo "Remove draft files from .issues/, .crs/, .commits/, .outputs/,"
                 echo "and the workspace scratch area .tmp/."
+                echo ""
+                echo "With a component, run the adapter's 'commands.clean' in the"
+                echo "component directory instead (see 'ws actions <comp>')."
                 echo ""
                 echo "These scratch files double as mining material for the"
                 echo "housekeeping 'mine scratch dirs' step, so ws clean holds off"

--- a/scripts/ws
+++ b/scripts/ws
@@ -23,6 +23,7 @@
 #   issue <comp> [remote] <title> <label> <bodyfile> File issue (remote from forkRemote)
 #   test <comp> [TestName|args...] Run tests (auto-detected; see 'ws actions <comp>')
 #   lint <comp> [args...] Run the component linter (adapter commands.lint; see 'ws actions <comp>')
+#   fmt <comp> [args...] Format the component's sources — rewrites files (adapter commands.fmt)
 #   build <comp> [args...] Run the component build (adapter commands.build; see 'ws actions <comp>')
 #   run <comp> [args...] Run the component itself — game, dev server, sandbox (adapter commands.run)
 #   review <comp> <cr#|threads> [options]  CR review comments and threads (see ws review --help)
@@ -1228,6 +1229,9 @@ case "$COMMAND" in
         ;;
     lint)
         bash "$SCRIPT_DIR/ws-lint.sh" "$@"
+        ;;
+    fmt)
+        bash "$SCRIPT_DIR/ws-fmt.sh" "$@"
         ;;
     build)
         bash "$SCRIPT_DIR/ws-build.sh" "$@"

--- a/scripts/ws
+++ b/scripts/ws
@@ -23,6 +23,8 @@
 #   issue <comp> [remote] <title> <label> <bodyfile> File issue (remote from forkRemote)
 #   test <comp> [TestName|args...] Run tests (auto-detected; see 'ws actions <comp>')
 #   lint <comp> [args...] Run the component linter (adapter commands.lint; see 'ws actions <comp>')
+#   build <comp> [args...] Run the component build (adapter commands.build; see 'ws actions <comp>')
+#   run <comp> <action> [args...] Run any other adapter-declared action (see 'ws actions <comp>')
 #   review <comp> <cr#|threads> [options]  CR review comments and threads (see ws review --help)
 #   commit <comp> <bodyfile> Commit with Co-Authored-By trailer (bodyfile-driven; see templates/commit.md)
 #   log [comp] [--oneline] Show commits on current branch vs main
@@ -1181,6 +1183,12 @@ case "$COMMAND" in
         ;;
     lint)
         bash "$SCRIPT_DIR/ws-lint.sh" "$@"
+        ;;
+    build)
+        bash "$SCRIPT_DIR/ws-build.sh" "$@"
+        ;;
+    run)
+        bash "$SCRIPT_DIR/ws-run.sh" "$@"
         ;;
     review)
         bash "$SCRIPT_DIR/ws-review.sh" "$@"

--- a/scripts/ws-build.sh
+++ b/scripts/ws-build.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# ws-build.sh — Run the build for a component
+# ws:use-when building the component via its adapter
+#
+# Usage:
+#   ws-build.sh <component> [args...]
+#
+# Resolves the build command from the active realm's adapter
+# (`commands.build`) and runs it in the component directory. Extra args
+# pass through to the build tool (e.g. --release).
+#
+# Structure mirrors ws-lint.sh: only the adapter-provided command is
+# supported — minimal on purpose. Auto-detection (gradle / make / npm,
+# etc.) can slot in as additional branches before the "not configured"
+# error if evidence of need arrives.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+: "${ROOT_DIR:="$(cd "$SCRIPT_DIR/.." && pwd)"}"
+
+# Load .env as literal assignments for builds that need provider tokens.
+# shellcheck source=ws-env.sh
+source "$SCRIPT_DIR/ws-env.sh"
+ws_load_env "$ROOT_DIR/.env"
+
+# shellcheck source=ws-realm.sh
+source "$SCRIPT_DIR/ws-realm.sh"
+
+build_help() {
+    local stream="${1:-2}"
+    {
+        echo "Usage: ws build <component> [args...]"
+        echo ""
+        echo "Run a component's build. The command comes from the active"
+        echo "realm adapter's 'commands.build' (run 'ws actions <comp>' to see"
+        echo "what's configured). Extra args pass through to the build tool:"
+        echo "  ws build terasology"
+        echo "  ws build destinationsol --info"
+    } >&"$stream"
+}
+
+# --- Arg parsing ---
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+    build_help 1
+    exit 0
+fi
+
+if [[ $# -eq 0 ]]; then
+    build_help 2
+    exit 1
+fi
+
+comp="$1"
+shift
+ws_resolve_target "$comp"
+cd "$COMPONENT_DIR"
+
+# --- Detect build command ---
+# Precedence: realm adapter command only (see header note).
+runner=""
+build_cmd=""
+
+# 1. Realm adapter `commands.build`
+active_realm="$(ws_detect_realm)" || true
+if [[ -n "$active_realm" ]]; then
+    adapter_file="$REALMS_DIR/$active_realm/adapters/$comp.yaml"
+    if [[ -f "$adapter_file" ]]; then
+        ws_require_active_realm_trust "$active_realm" || exit 1
+        # Guard the substitution: under `set -euo pipefail` a non-zero yq
+        # exit (malformed adapter YAML) would abort the script before the
+        # "No build command configured" guidance runs. `// ""` already maps
+        # a missing key to empty, so no separate "null" check is needed.
+        build_cmd=$(yq -r '.commands.build // ""' "$adapter_file" 2>/dev/null) || build_cmd=""
+        if [[ -n "$build_cmd" ]]; then
+            runner="adapter"
+        fi
+    fi
+fi
+
+if [[ -z "$runner" ]]; then
+    echo "ERROR: No build command configured for '$comp'." >&2
+    echo "  Add 'commands.build' to the realm adapter:" >&2
+    echo "    realms/<realm>/adapters/$comp.yaml" >&2
+    echo "  Example:" >&2
+    echo "    commands:" >&2
+    echo "      build: \"./gradlew build\"" >&2
+    echo "  Run 'ws actions $comp' to see what's configured." >&2
+    exit 1
+fi
+
+# --- Parse adapter command into an array for safe exec ---
+# Contract mirrors ws-test.sh: whitespace-separated tokens only. Args
+# with embedded whitespace/quotes are not supported — point the adapter
+# at a wrapper script if you need complex quoting.
+build_argv=()
+# shellcheck disable=SC2206
+read -r -a build_argv <<< "$build_cmd"
+
+# --- Dispatch ---
+case "$runner" in
+    adapter)
+        "${build_argv[@]}" "$@"
+        ;;
+esac

--- a/scripts/ws-fmt.sh
+++ b/scripts/ws-fmt.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# ws-fmt.sh — Format a component's sources
+# ws:use-when applying the component's formatter via its adapter
+#
+# Usage:
+#   ws-fmt.sh <component> [args...]
+#
+# Resolves the formatter from the active realm's adapter (`commands.fmt`)
+# and runs it in the component directory. Extra args pass through.
+#
+# `fmt` writes, `lint` checks — the split every ecosystem already makes
+# (`cargo fmt` vs `cargo fmt --check`, `gofmt -w` vs `gofmt -l`,
+# `black .` vs `black --check .`). So a formatting *violation* is a lint
+# failure and belongs in `commands.lint`; this verb is how you fix it.
+# Declaring a --check form here would give you a verb named fmt that
+# refuses to format.
+#
+# Structure mirrors ws-build.sh: only the adapter-provided command is
+# supported — minimal on purpose.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+: "${ROOT_DIR:="$(cd "$SCRIPT_DIR/.." && pwd)"}"
+
+# Load .env as literal assignments for formatters that need provider tokens.
+# shellcheck source=ws-env.sh
+source "$SCRIPT_DIR/ws-env.sh"
+ws_load_env "$ROOT_DIR/.env"
+
+# shellcheck source=ws-realm.sh
+source "$SCRIPT_DIR/ws-realm.sh"
+
+fmt_help() {
+    local stream="${1:-2}"
+    {
+        echo "Usage: ws fmt <component> [args...]"
+        echo ""
+        echo "Format a component's sources — this rewrites files. The command"
+        echo "comes from the active realm adapter's 'commands.fmt' (run"
+        echo "'ws actions <comp>' to see what's configured). Extra args pass"
+        echo "through to the formatter:"
+        echo "  ws fmt kanidm"
+        echo "  ws fmt kanidm --all"
+        echo ""
+        echo "To *check* formatting without rewriting, put the check form"
+        echo "(e.g. 'cargo fmt --check') in the adapter's 'commands.lint' —"
+        echo "a formatting violation is a lint failure."
+    } >&"$stream"
+}
+
+# --- Arg parsing ---
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+    fmt_help 1
+    exit 0
+fi
+
+if [[ $# -eq 0 ]]; then
+    fmt_help 2
+    exit 1
+fi
+
+comp="$1"
+shift
+ws_resolve_target "$comp"
+cd "$COMPONENT_DIR"
+
+# --- Detect format command ---
+# Precedence: realm adapter command only (see header note).
+runner=""
+fmt_cmd=""
+
+# 1. Realm adapter `commands.fmt`
+active_realm="$(ws_detect_realm)" || true
+if [[ -n "$active_realm" ]]; then
+    adapter_file="$REALMS_DIR/$active_realm/adapters/$comp.yaml"
+    if [[ -f "$adapter_file" ]]; then
+        ws_require_active_realm_trust "$active_realm" || exit 1
+        # Guard the substitution: under `set -euo pipefail` a non-zero yq
+        # exit (malformed adapter YAML) would abort the script before the
+        # "No fmt command configured" guidance runs. `// ""` already maps
+        # a missing key to empty, so no separate "null" check is needed.
+        fmt_cmd=$(yq -r '.commands.fmt // ""' "$adapter_file" 2>/dev/null) || fmt_cmd=""
+        if [[ -n "$fmt_cmd" ]]; then
+            runner="adapter"
+        fi
+    fi
+fi
+
+if [[ -z "$runner" ]]; then
+    echo "ERROR: No fmt command configured for '$comp'." >&2
+    echo "  Add 'commands.fmt' to the realm adapter:" >&2
+    echo "    realms/<realm>/adapters/$comp.yaml" >&2
+    echo "  Example:" >&2
+    echo "    commands:" >&2
+    echo "      fmt: \"cargo fmt\"" >&2
+    echo "  Run 'ws actions $comp' to see what's configured." >&2
+    exit 1
+fi
+
+# --- Parse adapter command into an array for safe exec ---
+# Contract mirrors ws-test.sh: whitespace-separated tokens only. Args
+# with embedded whitespace/quotes are not supported — point the adapter
+# at a wrapper script if you need complex quoting.
+fmt_argv=()
+# shellcheck disable=SC2206
+read -r -a fmt_argv <<< "$fmt_cmd"
+
+# --- Dispatch ---
+case "$runner" in
+    adapter)
+        "${fmt_argv[@]}" "$@"
+        ;;
+esac

--- a/scripts/ws-orient.sh
+++ b/scripts/ws-orient.sh
@@ -379,7 +379,7 @@ _emit_one_adapter() {
     echo "  $comp"
     local adapter_file="$REALMS_DIR/$active_realm/adapters/$comp.yaml"
     local verb cmd rc=0 any=0 parse_failed=0
-    for verb in test lint build; do
+    for verb in test lint build run clean; do
         rc=0
         cmd="$(ADAPTER_VERB="$verb" yq -r '.commands[strenv(ADAPTER_VERB)] // ""' "$adapter_file" 2>/dev/null)" || rc=$?
         if [[ $rc -ne 0 ]]; then

--- a/scripts/ws-orient.sh
+++ b/scripts/ws-orient.sh
@@ -324,8 +324,8 @@ emit_workspace_selftest() {
     printf '    ws test yggdrasil [runs: bats tests/**/*.bats]\n'
 }
 
-# Render one component's adapter wiring. Walks the three plan-named
-# verbs explicitly (test/lint/build) so a typo in the YAML doesn't
+# Render one component's adapter wiring. Walks the adapter verbs
+# explicitly (test/lint/fmt/build/run/clean) so a typo in the YAML doesn't
 # silently swallow a missing slot — the diagnostic message stays
 # loud either way.
 #
@@ -379,7 +379,7 @@ _emit_one_adapter() {
     echo "  $comp"
     local adapter_file="$REALMS_DIR/$active_realm/adapters/$comp.yaml"
     local verb cmd rc=0 any=0 parse_failed=0
-    for verb in test lint build run clean; do
+    for verb in test lint fmt build run clean; do
         rc=0
         cmd="$(ADAPTER_VERB="$verb" yq -r '.commands[strenv(ADAPTER_VERB)] // ""' "$adapter_file" 2>/dev/null)" || rc=$?
         if [[ $rc -ne 0 ]]; then
@@ -421,7 +421,7 @@ _emit_one_adapter() {
     if [[ $parse_failed -eq 1 ]]; then
         echo "    (adapter present but YAML parse failed — fix $adapter_file)"
     elif [[ $any -eq 0 ]]; then
-        echo "    (adapter present but no commands.{test,lint,build} wired)"
+        echo "    (adapter present but no commands.{test,lint,fmt,build} wired)"
     fi
 }
 

--- a/scripts/ws-run.sh
+++ b/scripts/ws-run.sh
@@ -1,18 +1,20 @@
 #!/usr/bin/env bash
-# ws-run.sh — Run a named adapter action for a component
-# ws:use-when executing an adapter-declared action beyond test/lint/build
+# ws-run.sh — Run a component (game, dev server, sandbox, …)
+# ws:use-when launching the component itself via its adapter
 #
 # Usage:
-#   ws-run.sh <component> <action> [args...]
+#   ws-run.sh <component> [args...]
 #
-# Resolves `commands.<action>` from the active realm's adapter and runs
-# it in the component directory. Extra args pass through to the command.
-# The dedicated verbs (test, lint, build) keep their own dispatch paths
-# and are rejected here so there is exactly one way to run each.
+# Resolves the run command from the active realm's adapter
+# (`commands.run`) and runs it in the component directory. Extra args
+# pass through to the command.
+#
+# Structure mirrors ws-build.sh: only the adapter-provided command is
+# supported — minimal on purpose.
 #
 # Unlike test/lint/build, `ws run` is deliberately NOT pre-allowed in
-# .claude/settings.json — adapter-declared actions can launch long-lived
-# or interactive processes (a game, a server), so each invocation stays
+# .claude/settings.json — a run command is typically a long-lived or
+# interactive process (a game, a server), so each invocation stays
 # behind the normal permission prompt.
 
 set -euo pipefail
@@ -20,7 +22,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 : "${ROOT_DIR:="$(cd "$SCRIPT_DIR/.." && pwd)"}"
 
-# Load .env as literal assignments for actions that need provider tokens.
+# Load .env as literal assignments for run targets that need tokens.
 # shellcheck source=ws-env.sh
 source "$SCRIPT_DIR/ws-env.sh"
 ws_load_env "$ROOT_DIR/.env"
@@ -31,16 +33,14 @@ source "$SCRIPT_DIR/ws-realm.sh"
 run_help() {
     local stream="${1:-2}"
     {
-        echo "Usage: ws run <component> <action> [args...]"
+        echo "Usage: ws run <component> [args...]"
         echo ""
-        echo "Run a named action from the active realm adapter's 'commands.<action>'"
-        echo "(run 'ws actions <comp>' to see what's declared). Extra args pass"
-        echo "through to the command:"
-        echo "  ws run terasology run"
-        echo "  ws run terasology clean"
-        echo ""
-        echo "test, lint, and build have dedicated verbs — use 'ws test', 'ws lint',"
-        echo "or 'ws build' for those."
+        echo "Run the component itself — launch the game, start the dev server,"
+        echo "bring up the sandbox. The command comes from the active realm"
+        echo "adapter's 'commands.run' (run 'ws actions <comp>' to see what's"
+        echo "configured). Extra args pass through:"
+        echo "  ws run terasology"
+        echo "  ws run leidangr --port 3001"
     } >&"$stream"
 }
 
@@ -51,52 +51,45 @@ if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
     exit 0
 fi
 
-if [[ $# -lt 2 ]]; then
+if [[ $# -eq 0 ]]; then
     run_help 2
     exit 1
 fi
 
 comp="$1"
-action="$2"
-shift 2
-
-# Action names are adapter map keys — constrain the shape before it goes
-# anywhere near a yq lookup, so an odd token cannot alter the query.
-if [[ ! "$action" =~ ^[a-z][a-z0-9_-]*$ ]]; then
-    echo "ERROR: Invalid action name '$action' (lowercase letters, digits, '-', '_')." >&2
-    exit 1
-fi
-
-case "$action" in
-    test|lint|build)
-        echo "ERROR: '$action' has a dedicated verb — use 'ws $action $comp' instead." >&2
-        exit 1
-        ;;
-esac
-
+shift
 ws_resolve_target "$comp"
 cd "$COMPONENT_DIR"
 
-# --- Resolve the action command (adapter only) ---
+# --- Detect run command ---
+# Precedence: realm adapter command only (see header note).
+runner=""
 run_cmd=""
 
+# 1. Realm adapter `commands.run`
 active_realm="$(ws_detect_realm)" || true
 if [[ -n "$active_realm" ]]; then
     adapter_file="$REALMS_DIR/$active_realm/adapters/$comp.yaml"
     if [[ -f "$adapter_file" ]]; then
         ws_require_active_realm_trust "$active_realm" || exit 1
         # Guard the substitution: under `set -euo pipefail` a non-zero yq
-        # exit (malformed adapter YAML) would abort before the "not
-        # configured" guidance runs. The action name travels via env so
-        # it is data to yq, never part of the expression.
-        run_cmd=$(WS_RUN_ACTION="$action" yq -r '.commands[strenv(WS_RUN_ACTION)] // ""' "$adapter_file" 2>/dev/null) || run_cmd=""
+        # exit (malformed adapter YAML) would abort the script before the
+        # "No run command configured" guidance runs. `// ""` already maps
+        # a missing key to empty, so no separate "null" check is needed.
+        run_cmd=$(yq -r '.commands.run // ""' "$adapter_file" 2>/dev/null) || run_cmd=""
+        if [[ -n "$run_cmd" ]]; then
+            runner="adapter"
+        fi
     fi
 fi
 
-if [[ -z "$run_cmd" ]]; then
-    echo "ERROR: No '$action' action configured for '$comp'." >&2
-    echo "  Add 'commands.$action' to the realm adapter:" >&2
+if [[ -z "$runner" ]]; then
+    echo "ERROR: No run command configured for '$comp'." >&2
+    echo "  Add 'commands.run' to the realm adapter:" >&2
     echo "    realms/<realm>/adapters/$comp.yaml" >&2
+    echo "  Example:" >&2
+    echo "    commands:" >&2
+    echo "      run: \"./gradlew :facades:PC:run\"" >&2
     echo "  Run 'ws actions $comp' to see what's configured." >&2
     exit 1
 fi
@@ -109,4 +102,9 @@ run_argv=()
 # shellcheck disable=SC2206
 read -r -a run_argv <<< "$run_cmd"
 
-"${run_argv[@]}" "$@"
+# --- Dispatch ---
+case "$runner" in
+    adapter)
+        "${run_argv[@]}" "$@"
+        ;;
+esac

--- a/scripts/ws-run.sh
+++ b/scripts/ws-run.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# ws-run.sh — Run a named adapter action for a component
+# ws:use-when executing an adapter-declared action beyond test/lint/build
+#
+# Usage:
+#   ws-run.sh <component> <action> [args...]
+#
+# Resolves `commands.<action>` from the active realm's adapter and runs
+# it in the component directory. Extra args pass through to the command.
+# The dedicated verbs (test, lint, build) keep their own dispatch paths
+# and are rejected here so there is exactly one way to run each.
+#
+# Unlike test/lint/build, `ws run` is deliberately NOT pre-allowed in
+# .claude/settings.json — adapter-declared actions can launch long-lived
+# or interactive processes (a game, a server), so each invocation stays
+# behind the normal permission prompt.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+: "${ROOT_DIR:="$(cd "$SCRIPT_DIR/.." && pwd)"}"
+
+# Load .env as literal assignments for actions that need provider tokens.
+# shellcheck source=ws-env.sh
+source "$SCRIPT_DIR/ws-env.sh"
+ws_load_env "$ROOT_DIR/.env"
+
+# shellcheck source=ws-realm.sh
+source "$SCRIPT_DIR/ws-realm.sh"
+
+run_help() {
+    local stream="${1:-2}"
+    {
+        echo "Usage: ws run <component> <action> [args...]"
+        echo ""
+        echo "Run a named action from the active realm adapter's 'commands.<action>'"
+        echo "(run 'ws actions <comp>' to see what's declared). Extra args pass"
+        echo "through to the command:"
+        echo "  ws run terasology run"
+        echo "  ws run terasology clean"
+        echo ""
+        echo "test, lint, and build have dedicated verbs — use 'ws test', 'ws lint',"
+        echo "or 'ws build' for those."
+    } >&"$stream"
+}
+
+# --- Arg parsing ---
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+    run_help 1
+    exit 0
+fi
+
+if [[ $# -lt 2 ]]; then
+    run_help 2
+    exit 1
+fi
+
+comp="$1"
+action="$2"
+shift 2
+
+# Action names are adapter map keys — constrain the shape before it goes
+# anywhere near a yq lookup, so an odd token cannot alter the query.
+if [[ ! "$action" =~ ^[a-z][a-z0-9_-]*$ ]]; then
+    echo "ERROR: Invalid action name '$action' (lowercase letters, digits, '-', '_')." >&2
+    exit 1
+fi
+
+case "$action" in
+    test|lint|build)
+        echo "ERROR: '$action' has a dedicated verb — use 'ws $action $comp' instead." >&2
+        exit 1
+        ;;
+esac
+
+ws_resolve_target "$comp"
+cd "$COMPONENT_DIR"
+
+# --- Resolve the action command (adapter only) ---
+run_cmd=""
+
+active_realm="$(ws_detect_realm)" || true
+if [[ -n "$active_realm" ]]; then
+    adapter_file="$REALMS_DIR/$active_realm/adapters/$comp.yaml"
+    if [[ -f "$adapter_file" ]]; then
+        ws_require_active_realm_trust "$active_realm" || exit 1
+        # Guard the substitution: under `set -euo pipefail` a non-zero yq
+        # exit (malformed adapter YAML) would abort before the "not
+        # configured" guidance runs. The action name travels via env so
+        # it is data to yq, never part of the expression.
+        run_cmd=$(WS_RUN_ACTION="$action" yq -r '.commands[strenv(WS_RUN_ACTION)] // ""' "$adapter_file" 2>/dev/null) || run_cmd=""
+    fi
+fi
+
+if [[ -z "$run_cmd" ]]; then
+    echo "ERROR: No '$action' action configured for '$comp'." >&2
+    echo "  Add 'commands.$action' to the realm adapter:" >&2
+    echo "    realms/<realm>/adapters/$comp.yaml" >&2
+    echo "  Run 'ws actions $comp' to see what's configured." >&2
+    exit 1
+fi
+
+# --- Parse adapter command into an array for safe exec ---
+# Contract mirrors ws-test.sh: whitespace-separated tokens only. Args
+# with embedded whitespace/quotes are not supported — point the adapter
+# at a wrapper script if you need complex quoting.
+run_argv=()
+# shellcheck disable=SC2206
+read -r -a run_argv <<< "$run_cmd"
+
+"${run_argv[@]}" "$@"

--- a/templates/components/gh-pages/README.md
+++ b/templates/components/gh-pages/README.md
@@ -360,6 +360,7 @@ few common next steps, in roughly increasing complexity:
   with its own setup. Ask your agent for the typical patterns —
   Disqus or utterances for comments, GoatCounter or Plausible for
   cookieless analytics, lunr or Algolia for search.
+- **Shared CI: PR previews and visual diffs.** [Völundr](https://github.com/SiliconSaga/volundr) holds reusable workflows the SiliconSaga sites share, so every pull request gets its own preview URL and a screenshot diff against `main`, and your repo carries two thin caller stubs instead of a copy of the CI logic. Two things have to change first, and both contradict what Chapter 1 set up: the site needs a checked-in `Gemfile` using the `github-pages` gem, and Pages has to serve from a `gh-pages` branch rather than `main` — the deploy workflow publishes there. Adding the Gemfile also switches local preview to `bundle exec jekyll serve`, as noted under **Local preview** below. Your default branch has to be `main`. Ask your agent to walk you through it: the adoption steps live in Völundr's `aspect/SKILL.md`, and it can apply them for you.
 
 Each of these is more involved than the Chapter 1+2 loop and
 benefits from breaking into its own PR with its own review cycle.

--- a/templates/components/gh-pages/README.md
+++ b/templates/components/gh-pages/README.md
@@ -1,86 +1,43 @@
 # Your GitHub Pages site
 
-> **You can ask your AI agent to walk you through any step below, or
-> follow this guide directly. Both paths arrive at roughly the same
-> place.** The agent is non-deterministic; this guide is the
-> deterministic path. They do the same thing in spirit.
+> **You can ask your AI agent to walk you through any step below, or follow this guide directly. Both paths arrive at roughly the same place.** The agent is non-deterministic; this guide is the deterministic path. They do the same thing in spirit.
 >
-> **First time through? Turn on mentoring for Chapter 1.** Ask your
-> agent: *"let's turn on mentoring while I work through this
-> tutorial."* Mentoring explains each command and decision in
-> detail rather than just running them — invaluable for the first
-> deploy where every `ws` subcommand is new. The orientation skill
-> should already offer this when it sees you've started a tutorial;
-> if not, just ask. Once you reach Chapter 2, the agent can ease off
-> the per-command narration — the basics are familiar by then, and
-> the bot-review loop is the focus.
+> **First time through? Turn on mentoring for Chapter 1.** Ask your agent: *"let's turn on mentoring while I work through this tutorial."* Mentoring explains each command and decision in detail rather than just running them — invaluable for the first deploy where every `ws` subcommand is new. The orientation skill should already offer this when it sees you've started a tutorial; if not, just ask. Once you reach Chapter 2, the agent can ease off the per-command narration — the basics are familiar by then, and the bot-review loop is the focus.
 
-This is a starter site scaffolded from the GDD `gh-pages` component
-template. It deploys to GitHub Pages as-is, lets you exercise the
-full GDD-and-bot-review workflow with a tiny live target, and is
-meant to be edited from day one.
+This is a starter site scaffolded from the GDD `gh-pages` component template. It deploys to GitHub Pages as-is, lets you exercise the full GDD-and-bot-review workflow with a tiny live target, and is meant to be edited from day one.
 
-The walkthrough is split into chapters so you can stop after Ch 1
-with a working live site, then come back for Ch 2 (bots) and Ch 3+
-(theming, custom domain, going further) when you're ready.
+The walkthrough is split into chapters so you can stop after Ch 1 with a working live site, then come back for Ch 2 (bots) and Ch 3+ (theming, custom domain, going further) when you're ready.
 
 ---
 
 # Chapter 1: First deploy
 
-Goal: from `ws component init` to a live site you've edited, in
-roughly 10–15 minutes. No third-party apps to install yet. Pure GDD
-loop on a tiny target.
+Goal: from `ws component init` to a live site you've edited, in roughly 10–15 minutes. No third-party apps to install yet. Pure GDD loop on a tiny target.
 
 ## 1. Create the GitHub repo
 
-After `ws component init gh-pages <name>` finished, the suggested
-next step it printed was something like:
+After `ws component init gh-pages <name>` finished, the suggested next step it printed was something like:
 
 ```bash
 gh repo create <yourname>/<name> --public \
   --source=components/<name> --remote=<yourname> --push
 ```
 
-Run that. It creates a public repo on your GitHub account, sets
-your username as the remote name (avoids the generic `origin`),
-and pushes the initial commit.
+Run that. It creates a public repo on your GitHub account, sets your username as the remote name (avoids the generic `origin`), and pushes the initial commit.
 
-> **Why public?** Free GitHub Pages on personal accounts requires a
-> public repo. A private Pages site is paid (GitHub Pro / Team /
-> Enterprise). If you want it private, swap `--public` for
-> `--private` in the suggested command and accept the cost on your
-> end.
+> **Why public?** Free GitHub Pages on personal accounts requires a public repo. A private Pages site is paid (GitHub Pro / Team / Enterprise). If you want it private, swap `--public` for `--private` in the suggested command and accept the cost on your end.
 >
-> **Auth wrinkle for agent-account tokens.** If your `.env` holds a
-> bot/agent token (e.g. one issued to `agent-refr`) rather than a
-> personal PAT, `gh repo create <yourname>/<name>` may fail with
-> *"cannot create a repository for `<yourname>`"* — the agent
-> identity can't create repos under your username. **Recommended
-> fix:** open a fresh shell, `export GH_TOKEN=<your-personal-pat>`,
-> and run the create command under your personal token. The
-> tutorial repo lives under your account — that's what Chapter 2's
-> CodeRabbit/Copilot install assumes (you need admin on the repo's
-> account to install GitHub Apps), and what `<yourname>.github.io`
-> deploys reflect.
+> **Auth wrinkle for agent-account tokens.** If your `.env` holds a bot/agent token (e.g. one issued to `agent-refr`) rather than a personal PAT, `gh repo create <yourname>/<name>` may fail with *"cannot create a repository for `<yourname>`"* — the agent identity can't create repos under your username. **Recommended fix:** open a fresh shell, `export GH_TOKEN=<your-personal-pat>`, and run the create command under your personal token. The tutorial repo lives under your account — that's what Chapter 2's CodeRabbit/Copilot install assumes (you need admin on the repo's account to install GitHub Apps), and what `<yourname>.github.io` deploys reflect.
 >
-> Creating the repo under the agent's namespace
-> (`gh repo create <agent-account>/<name>`) is a stopgap **only**
-> if you also administer that namespace yourself (rare). Otherwise
-> Chapter 2 stalls — you can't install CodeRabbit on an account you
-> don't control, so the bot-reviewed half of the tutorial becomes
-> impossible to complete.
+> Creating the repo under the agent's namespace (`gh repo create <agent-account>/<name>`) is a stopgap **only** if you also administer that namespace yourself (rare). Otherwise Chapter 2 stalls — you can't install CodeRabbit on an account you don't control, so the bot-reviewed half of the tutorial becomes impossible to complete.
 
 If you'd rather create the repo by hand:
 
 1. Go to `https://github.com/new` while signed in.
 2. Repository name: `<name>` (matching the directory). Public.
-3. Skip the README / .gitignore / license options — your scaffold
-   already has them.
+3. Skip the README / .gitignore / license options — your scaffold already has them.
 4. Click **Create repository**.
-5. Back in your terminal, set the remote and push (`ws push` wires
-   up upstream tracking automatically on the first push, so
-   subsequent `ws push <name>` calls work without arguments):
+5. Back in your terminal, set the remote and push (`ws push` wires up upstream tracking automatically on the first push, so subsequent `ws push <name>` calls work without arguments):
 
    ```bash
    git -C components/<name> remote add <yourname> https://github.com/<yourname>/<name>.git
@@ -89,21 +46,16 @@ If you'd rather create the repo by hand:
 
 ## 2. Enable GitHub Pages
 
-GitHub doesn't auto-enable Pages on new repos. You enable it once.
-Two equivalent paths:
+GitHub doesn't auto-enable Pages on new repos. You enable it once. Two equivalent paths:
 
 **Via the UI** (most common, more discoverable):
 
 1. In your new repo on GitHub, click **Settings** (top nav).
-2. In the left sidebar, click **Pages** (under "Code and
-   automation").
+2. In the left sidebar, click **Pages** (under "Code and automation").
 3. Under **Source**, choose **Deploy from a branch**.
-4. Under **Branch**, pick `main` and folder `/ (root)`.
-   Click **Save**.
+4. Under **Branch**, pick `main` and folder `/ (root)`. Click **Save**.
 
-**Via `gh api`** (one-liner, useful for scripted setups). Note
-the path has no leading `/` — Windows Git Bash's MSYS layer
-otherwise rewrites `/repos/...` as a Windows filesystem path:
+**Via `gh api`** (one-liner, useful for scripted setups). Note the path has no leading `/` — Windows Git Bash's MSYS layer otherwise rewrites `/repos/...` as a Windows filesystem path:
 
 ```bash
 gh api -X POST repos/<yourname>/<name>/pages \
@@ -111,18 +63,13 @@ gh api -X POST repos/<yourname>/<name>/pages \
   --raw-field 'source[path]=/'
 ```
 
-Either way, wait ~1 minute. Refresh the Pages settings page; it'll
-show a green banner with the URL once the first build is done.
+Either way, wait ~1 minute. Refresh the Pages settings page; it'll show a green banner with the URL once the first build is done.
 
-Your site lives at `https://<yourname>.github.io/<name>/`. Visit it
-and you should see the placeholder page.
+Your site lives at `https://<yourname>.github.io/<name>/`. Visit it and you should see the placeholder page.
 
 ## 3. Make your first edit (and clean up placeholders)
 
-The point of the demo is to feel the full GDD loop — write,
-propose, merge — on a tiny target. The walkthrough below stays in
-the yggdrasil workspace root throughout (no `cd`-juggling), since
-`ws` operates on components by name from there.
+The point of the demo is to feel the full GDD loop — write, propose, merge — on a tiny target. The walkthrough below stays in the yggdrasil workspace root throughout (no `cd`-juggling), since `ws` operates on components by name from there.
 
 The scaffold ships with a few literal placeholders that are **visible on the live site immediately** — clean these up in your first edit so the deployed page doesn't say `Your Name's page` in the browser tab. (The title placeholder deliberately avoids angle brackets: browsers swallow `<like this>` as an unknown HTML tag, which used to leave a silly-looking bare `'s page`.)
 
@@ -143,14 +90,9 @@ git -C components/<name> checkout -b first-post
 | `components/<name>/index.md` | the placeholder paragraph in the body | Whatever you want the home page to say |
 | `components/<name>/LICENSE` | `Copyright (c) <year> <name>` | The current year and your name |
 
-The agent can fill these in based on your `identity.human_account`
-if you'd rather not edit by hand — just ask.
+The agent can fill these in based on your `identity.human_account` if you'd rather not edit by hand — just ask.
 
-**3. Write a commit bodyfile.** `ws commit` is bodyfile-driven —
-every commit declares the files it stages, so there's no separate
-`git add` step. Create `.commits/first-post.md` *in the yggdrasil
-workspace root* (the `.commits/` directory is gitignored at the
-workspace level) with this content:
+**3. Write a commit bodyfile.** `ws commit` is bodyfile-driven — every commit declares the files it stages, so there's no separate `git add` step. Create `.commits/first-post.md` *in the yggdrasil workspace root* (the `.commits/` directory is gitignored at the workspace level) with this content:
 
 ```markdown
 ---
@@ -164,9 +106,7 @@ First edit on the new GitHub Pages site. Replaced placeholder
 title, copyright, and home-page body.
 ```
 
-The `add:` paths are relative to the component, not the workspace
-root — `ws commit` cd's into `components/<name>/` before staging.
-The body below the frontmatter becomes the commit message body.
+The `add:` paths are relative to the component, not the workspace root — `ws commit` cd's into `components/<name>/` before staging. The body below the frontmatter becomes the commit message body.
 
 **4. Commit and push:**
 
@@ -175,29 +115,20 @@ ws commit <name> .commits/first-post.md
 ws push <name> first-post
 ```
 
-`ws commit` stages the listed files, builds the message, and
-appends a Co-Authored-By trailer. `ws push` picks the right remote
-from your identity config.
+`ws commit` stages the listed files, builds the message, and appends a Co-Authored-By trailer. `ws push` picks the right remote from your identity config.
 
 ## 4. Open a (simple) PR
 
-Chapter 1 keeps the PR step simple — open it, merge it, see it
-live. Bot review comes in Chapter 2.
+Chapter 1 keeps the PR step simple — open it, merge it, see it live. Bot review comes in Chapter 2.
 
-Like `ws commit`, `ws cr` is bodyfile-driven. Copy the change
-template to `.crs/first-post.md` *in the yggdrasil workspace root*
-(gitignored) and fill in the summary:
+Like `ws commit`, `ws cr` is bodyfile-driven. Copy the change template to `.crs/first-post.md` *in the yggdrasil workspace root* (gitignored) and fill in the summary:
 
 ```bash
 cp templates/change.md .crs/first-post.md
 $EDITOR .crs/first-post.md
 ```
 
-Replace the bracketed placeholder under **Summary** with one bullet
-describing the edit, and either keep the **Test plan** as-is
-(loading the deployed site is the test) or trim it. The
-`@HUMAN_ACCOUNT` / `@GDD_HOME` markers in the body are substituted
-at CR-creation time from your identity config.
+Replace the bracketed placeholder under **Summary** with one bullet describing the edit, and either keep the **Test plan** as-is (loading the deployed site is the test) or trim it. The `@HUMAN_ACCOUNT` / `@GDD_HOME` markers in the body are substituted at CR-creation time from your identity config.
 
 Open the PR:
 
@@ -205,41 +136,23 @@ Open the PR:
 ws cr <name> "First post + placeholder cleanup" .crs/first-post.md
 ```
 
-`ws cr` picks the right remote from your identity, runs the
-underlying `gh pr create`, and prints the PR URL.
+`ws cr` picks the right remote from your identity, runs the underlying `gh pr create`, and prints the PR URL.
 
 ## 5. Merge and see it live
 
-1. Click **Merge pull request** on the PR, then **Create a merge
-   commit**. The GDD convention is to keep the original commit
-   (with its body and Co-Authored-By trailer) in `main` history
-   rather than collapse it via *Squash and merge* — the trail is
-   more useful when you're scanning history later, and AI-pair-
-   programming attribution stays intact.
-2. GitHub Pages rebuilds the site within a minute or so. There's
-   no click required — the rebuild fires on every push to `main`.
-3. Refresh `https://<yourname>.github.io/<name>/`. Your edit is
-   live, the placeholders are gone, and the browser tab shows your
-   real title.
+1. Click **Merge pull request** on the PR, then **Create a merge commit**. The GDD convention is to keep the original commit (with its body and Co-Authored-By trailer) in `main` history rather than collapse it via *Squash and merge* — the trail is more useful when you're scanning history later, and AI-pair- programming attribution stays intact.
+2. GitHub Pages rebuilds the site within a minute or so. There's no click required — the rebuild fires on every push to `main`.
+3. Refresh `https://<yourname>.github.io/<name>/`. Your edit is live, the placeholders are gone, and the browser tab shows your real title.
 
-**That's Chapter 1.** You've cloned, scaffolded, deployed, edited,
-opened a PR, and merged — the whole no-bots GDD loop. Stop here
-for now if you like. Come back to Chapter 2 when you want to add
-the bot-review layer.
+**That's Chapter 1.** You've cloned, scaffolded, deployed, edited, opened a PR, and merged — the whole no-bots GDD loop. Stop here for now if you like. Come back to Chapter 2 when you want to add the bot-review layer.
 
 ---
 
 # Chapter 2: Bot-reviewed PRs
 
-Goal: install CodeRabbit (and optionally Copilot review), push a
-follow-up edit, and watch the bots leave inline review threads.
-This is where GDD's review loop really earns its keep.
+Goal: install CodeRabbit (and optionally Copilot review), push a follow-up edit, and watch the bots leave inline review threads. This is where GDD's review loop really earns its keep.
 
-> By Chapter 2 the basic `ws` commands (`commit`, `push`, `cr`,
-> `review`) are familiar from Chapter 1. Mentoring can ease
-> off — the agent doesn't need to re-narrate them in the same
-> detail. The new material is the bot side: installation, what they
-> look for, how to read and resolve review threads.
+> By Chapter 2 the basic `ws` commands (`commit`, `push`, `cr`, `review`) are familiar from Chapter 1. Mentoring can ease off — the agent doesn't need to re-narrate them in the same detail. The new material is the bot side: installation, what they look for, how to read and resolve review threads.
 
 ## 1. Install CodeRabbit
 
@@ -247,43 +160,26 @@ CodeRabbit is a GitHub App. Free for public repos.
 
 1. Visit https://github.com/marketplace/coderabbit
 2. Click **Set up a plan** → pick the free tier for public repos.
-3. Choose the repos you want it to review. Either install on your
-   personal account (covers all your public repos) or scope it to
-   the tutorial repo specifically.
+3. Choose the repos you want it to review. Either install on your personal account (covers all your public repos) or scope it to the tutorial repo specifically.
 4. Authorize the app's permissions.
 
-> **Why this is its own chapter:** if your tutorial repo is on a
-> bot/agent account (not your personal namespace), the App install
-> needs to happen on whichever account hosts the repo. A fresh user
-> shouldn't have to authorise a third-party app just to ship a
-> first deploy — that's why Chapter 1 skipped it.
+> **Why this is its own chapter:** if your tutorial repo is on a bot/agent account (not your personal namespace), the App install needs to happen on whichever account hosts the repo. A fresh user shouldn't have to authorise a third-party app just to ship a first deploy — that's why Chapter 1 skipped it.
 >
-> **If your Ch 1 repo ended up under an agent namespace** you don't
-> administer, Chapter 2 is blocked here — you can't install
-> CodeRabbit on someone else's account. Re-create the tutorial repo
-> under your personal account first (per the Ch 1 §1 auth wrinkle):
-> `export GH_TOKEN=<your-personal-pat>` in a fresh shell, then
-> `gh repo create <yourname>/<name> --public --source=components/<name> --remote=<yourname> --push`,
-> then come back here.
+> **If your Ch 1 repo ended up under an agent namespace** you don't administer, Chapter 2 is blocked here — you can't install CodeRabbit on someone else's account. Re-create the tutorial repo under your personal account first (per the Ch 1 §1 auth wrinkle): `export GH_TOKEN=<your-personal-pat>` in a fresh shell, then `gh repo create <yourname>/<name> --public --source=components/<name> --remote=<yourname> --push`, then come back here.
 
 ## 2. Optional: enable Copilot review
 
-If you have a GitHub Copilot subscription, you can also request
-Copilot's review on PRs:
+If you have a GitHub Copilot subscription, you can also request Copilot's review on PRs:
 
 - On the PR page, click the gear icon next to **Reviewers**.
 - Choose **GitHub Copilot**.
-- Copilot doesn't re-review automatically on every push — click
-  **Re-request review** in the same panel after addressing
-  feedback.
+- Copilot doesn't re-review automatically on every push — click **Re-request review** in the same panel after addressing feedback.
 
-Copilot's findings often complement CodeRabbit's; they catch
-different things. Worth running both if you have access.
+Copilot's findings often complement CodeRabbit's; they catch different things. Worth running both if you have access.
 
 ## 3. Push a second edit
 
-Make a fresh topic branch and edit something visible — adding a
-new page or a paragraph works well:
+Make a fresh topic branch and edit something visible — adding a new page or a paragraph works well:
 
 ```bash
 git -C components/<name> checkout main
@@ -305,66 +201,39 @@ ws cr <name> "Second post" .crs/second-post.md
 
 ## 4. Read and address review threads
 
-Within a couple of minutes, CodeRabbit will post inline comments
-on the PR. Fetch them in one shell view:
+Within a couple of minutes, CodeRabbit will post inline comments on the PR. Fetch them in one shell view:
 
 ```bash
 ws review <name> <pr#>
 ```
 
-The output groups inline diff comments by file, plus a summary at
-the bottom. For each finding, decide:
+The output groups inline diff comments by file, plus a summary at the bottom. For each finding, decide:
 
-- **Address it.** Edit the file, write a fixup bodyfile, `ws
-  commit` and `ws push` — CodeRabbit auto-resolves the thread when
-  the next commit lands.
-- **Reply with reasoning.** `ws review <name> reply <pr#> <thread-id>
-  "<message>" --resolve` lets you respond and close the thread in
-  one go.
-- **Decline.** Sometimes the bot's suggestion isn't right.
-  Reply explaining why, mark resolved, move on.
+- **Address it.** Edit the file, write a fixup bodyfile, `ws commit` and `ws push` — CodeRabbit auto-resolves the thread when the next commit lands.
+- **Reply with reasoning.** `ws review <name> reply <pr#> <thread-id> "<message>" --resolve` lets you respond and close the thread in one go.
+- **Decline.** Sometimes the bot's suggestion isn't right. Reply explaining why, mark resolved, move on.
 
 Repeat the push/review cycle until the bots are quiet.
 
 ## 5. Merge
 
-Same as Chapter 1 — **Merge pull request** → **Create a merge
-commit**. Your second edit deploys within a minute.
+Same as Chapter 1 — **Merge pull request** → **Create a merge commit**. Your second edit deploys within a minute.
 
-**That's Chapter 2.** From here on you've got the review loop in
-muscle memory: edit → commit → push → cr → review → fix → merge.
-The same flow scales to real components.
+**That's Chapter 2.** From here on you've got the review loop in muscle memory: edit → commit → push → cr → review → fix → merge. The same flow scales to real components.
 
 ---
 
 # Chapter 3+: Going further
 
-The template stays minimal so you can take it where you want. A
-few common next steps, in roughly increasing complexity:
+The template stays minimal so you can take it where you want. A few common next steps, in roughly increasing complexity:
 
-- **Different theme.** Edit the `theme:` line in `_config.yml`. The
-  comments next to that line list other GitHub-supported themes
-  you can pick from. For richer theming (custom CSS, layouts),
-  you'd either fork a Jekyll theme repo or move to a different
-  static-site generator (Astro, VitePress, 11ty, Hugo). Ask your
-  agent to walk you through whichever path interests you — *or
-  capture a Thalamus todo about the theme work and come back to it
-  later when you have ideas*.
-- **More pages.** Add `<page-name>.md` files alongside `index.md`,
-  link from `index.md` (Markdown links: `[About](about.md)`).
-- **Custom domain.** Drop a `CNAME` file at the repo root
-  containing your domain. Configure DNS to point at GitHub Pages'
-  servers (instructions in your domain registrar's docs + GitHub's
-  [custom domain guide](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site)).
-- **Comments / analytics / search.** Each is a separate add-on
-  with its own setup. Ask your agent for the typical patterns —
-  Disqus or utterances for comments, GoatCounter or Plausible for
-  cookieless analytics, lunr or Algolia for search.
+- **Different theme.** Edit the `theme:` line in `_config.yml`. The comments next to that line list other GitHub-supported themes you can pick from. For richer theming (custom CSS, layouts), you'd either fork a Jekyll theme repo or move to a different static-site generator (Astro, VitePress, 11ty, Hugo). Ask your agent to walk you through whichever path interests you — *or capture a Thalamus todo about the theme work and come back to it later when you have ideas*.
+- **More pages.** Add `<page-name>.md` files alongside `index.md`, link from `index.md` (Markdown links: `[About](about.md)`).
+- **Custom domain.** Drop a `CNAME` file at the repo root containing your domain. Configure DNS to point at GitHub Pages' servers (instructions in your domain registrar's docs + GitHub's [custom domain guide](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site)).
+- **Comments / analytics / search.** Each is a separate add-on with its own setup. Ask your agent for the typical patterns — Disqus or utterances for comments, GoatCounter or Plausible for cookieless analytics, lunr or Algolia for search.
 - **Shared CI: PR previews and visual diffs.** [Völundr](https://github.com/SiliconSaga/volundr) holds reusable workflows the SiliconSaga sites share, so every pull request gets its own preview URL and a screenshot diff against `main`, and your repo carries two thin caller stubs instead of a copy of the CI logic. Two things have to change first, and both contradict what Chapter 1 set up: the site needs a checked-in `Gemfile` using the `github-pages` gem, and Pages has to serve from a `gh-pages` branch rather than `main` — the deploy workflow publishes there. Adding the Gemfile also switches local preview to `bundle exec jekyll serve`, as noted under **Local preview** below. Your default branch has to be `main`. Ask your agent to walk you through it: the adoption steps live in Völundr's `aspect/SKILL.md`, and it can apply them for you.
 
-Each of these is more involved than the Chapter 1+2 loop and
-benefits from breaking into its own PR with its own review cycle.
-The basic shape doesn't change — you've already practiced it.
+Each of these is more involved than the Chapter 1+2 loop and benefits from breaking into its own PR with its own review cycle. The basic shape doesn't change — you've already practiced it.
 
 ## Local preview (optional)
 
@@ -384,10 +253,4 @@ The scaffold ships no `Gemfile`, so plain `jekyll serve` is the right form. If y
 - `.gitignore` — keeps Jekyll's local build output out of git
 - `LICENSE` — MIT, with placeholders you replaced in Ch 1
 
-The component is registered in your workspace's
-`ecosystem.local.yaml` under `components.<name>` so `ws status`,
-`ws push <name>`, `ws log <name>`, etc. all work from the
-yggdrasil root. To share this component with your community, move
-that `ecosystem.local.yaml` entry into your realm's
-`ecosystem.yaml` with realm-appropriate fields (tier, etc.) and
-push the realm.
+The component is registered in your workspace's `ecosystem.local.yaml` under `components.<name>` so `ws status`, `ws push <name>`, `ws log <name>`, etc. all work from the yggdrasil root. To share this component with your community, move that `ecosystem.local.yaml` entry into your realm's `ecosystem.yaml` with realm-appropriate fields (tier, etc.) and push the realm.

--- a/tests/templates/line-wrap.bats
+++ b/tests/templates/line-wrap.bats
@@ -18,9 +18,10 @@
 #
 # Coverage grows in rings: templates/*.md and docs/gdd/*.md are fully
 # clean and locked; .agent/skills/ locks the clean files while the
-# GRANDFATHERED list carries the legacy-wrapped ones (per the doc-writing
-# convention, existing wrapped prose stays wrapped until deliberately
-# reflowed). Shrink the list as files get cleaned — never add to it.
+# GRANDFATHERED list carries the legacy-wrapped ones. Being on that list
+# is a debt, not a licence: the doc-writing convention says to ASK about
+# reflowing a wrapped file you are editing rather than quietly matching
+# it. Shrink the list as files get cleaned — never add to it.
 
 _wrap_detect() {
     awk '
@@ -59,7 +60,7 @@ _wrap_detect() {
 }
 
 # Legacy-wrapped skills awaiting deliberate reflow. Shrink-only.
-GRANDFATHERED="gdd gdd-bdd gdd-bdd-pytest gdd-branch-workflow gdd-doc-writing gdd-flow gdd-github-issues gdd-housekeeping gdd-mcp gdd-mentoring gdd-permissions gdd-quick gdd-review-triage gdd-scribe gdd-workflow-audit gdd-zen"
+GRANDFATHERED="gdd gdd-bdd gdd-bdd-pytest gdd-branch-workflow gdd-flow gdd-github-issues gdd-housekeeping gdd-mcp gdd-mentoring gdd-permissions gdd-quick gdd-review-triage gdd-scribe gdd-workflow-audit gdd-zen"
 
 @test "top-level templates contain no hard-wrapped prose" {
     local repo_root

--- a/tests/ws-build/build.bats
+++ b/tests/ws-build/build.bats
@@ -1,0 +1,78 @@
+#!/usr/bin/env bats
+
+# Tests for `ws build`. It resolves commands.build from the active realm
+# adapter, runs it in the component directory, passes extra args through,
+# and errors helpfully when no build command is configured.
+
+load test_helper
+
+setup() {
+    setup_synthetic_realm
+}
+
+@test "build refuses stale active-realm trust for workspace targets" {
+    write_adapter_build "./buildstub"
+    BUILD_CMD="./buildstub --release" yq -i \
+        '.commands.build = strenv(BUILD_CMD)' \
+        "$REALMS_DIR/realm-test/adapters/yggdrasil.yaml"
+
+    run_ws_build yggdrasil
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"trust reapproval is required"* ]]
+    [ ! -f "$ROOT_DIR/build_ran.marker" ]
+}
+
+@test "build runs the adapter's commands.build" {
+    write_adapter_build "./buildstub"
+    run_ws_build yggdrasil
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"BUILD_ARGS:"* ]]
+}
+
+@test "build passes extra args through to the builder" {
+    write_adapter_build "./buildstub"
+    run_ws_build yggdrasil --release
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"BUILD_ARGS:--release"* ]]
+}
+
+@test "build runs in the component directory" {
+    write_adapter_build "./buildstub"
+    run_ws_build yggdrasil
+    [ "$status" -eq 0 ]
+    # The stub touched its marker in cwd; it must land in the component dir.
+    [ -f "$ROOT_DIR/build_ran.marker" ]
+}
+
+@test "build errors helpfully when no commands.build is configured" {
+    # Adapter exists but declares only a test command, no build.
+    cat > "$REALMS_DIR/realm-test/adapters/yggdrasil.yaml" <<'EOF'
+commands:
+  test: "true"
+EOF
+    approve_synthetic_realm
+    run_ws_build yggdrasil
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"No build command configured"* ]]
+}
+
+@test "build rejects malformed adapter YAML as stale trust" {
+    # An unterminated flow mapping cannot match the content that was approved.
+    printf 'commands: {\n' > "$REALMS_DIR/realm-test/adapters/yggdrasil.yaml"
+    run_ws_build yggdrasil
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"trust reapproval is required"* ]]
+}
+
+@test "build with no component prints usage and exits nonzero" {
+    run_ws_build
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Usage: ws build"* ]]
+}
+
+@test "build --help prints usage and exits 0" {
+    run_ws_build --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage: ws build"* ]]
+}

--- a/tests/ws-build/test_helper.bash
+++ b/tests/ws-build/test_helper.bash
@@ -1,0 +1,58 @@
+# Shared helpers for ws-build bats tests.
+#
+# Mirrors the ws-lint harness: synthetic workspace under $BATS_TEST_TMPDIR,
+# the "yggdrasil" component name (→ COMPONENT_DIR=$ROOT_DIR), a single
+# realm-test realm with an adapter YAML, and a stub builder that records
+# how it was invoked (args + that it ran in the component dir).
+
+REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+WS_BUILD_BIN="$REPO_ROOT/scripts/ws-build.sh"
+REALM_LIB="$REPO_ROOT/scripts/ws-realm.sh"
+
+setup_synthetic_realm() {
+    export ROOT_DIR="$BATS_TEST_TMPDIR/root"
+    export REALMS_DIR="$ROOT_DIR/realms"
+    export ECOSYSTEM_LOCAL="$ROOT_DIR/ecosystem.local.yaml"
+
+    mkdir -p "$REALMS_DIR/realm-test/adapters"
+    printf 'components: {}\n' > "$ROOT_DIR/ecosystem.yaml"
+    printf 'components: {}\n' > "$REALMS_DIR/realm-test/ecosystem.yaml"
+    printf 'realm: realm-test\n' > "$ECOSYSTEM_LOCAL"
+
+    # Stub builder: drops a marker in its cwd (proves it ran in the
+    # component dir, robust to /var vs /private/var symlink differences)
+    # and echoes the args it received.
+    cat > "$ROOT_DIR/buildstub" <<'EOF'
+#!/usr/bin/env bash
+touch build_ran.marker
+echo "BUILD_ARGS:$*"
+EOF
+    chmod +x "$ROOT_DIR/buildstub"
+
+    approve_synthetic_realm
+}
+
+approve_synthetic_realm() {
+    local fingerprint
+    fingerprint="$(bash -c 'source "$1"; ws_realm_trust_fingerprint realm-test' _ "$REALM_LIB")"
+    REALM_FINGERPRINT="$fingerprint" yq -i '
+        ._gdd.realmTrust = {
+          "realm": "realm-test",
+          "fingerprint": strenv(REALM_FINGERPRINT)
+        }
+    ' "$ECOSYSTEM_LOCAL"
+}
+
+# Write the realm adapter with the given commands.build value.
+write_adapter_build() {
+    local cmd="$1"
+    cat > "$REALMS_DIR/realm-test/adapters/yggdrasil.yaml" <<EOF
+commands:
+  build: "$cmd"
+EOF
+    approve_synthetic_realm
+}
+
+run_ws_build() {
+    run bash "$WS_BUILD_BIN" "$@"
+}

--- a/tests/ws-clean/target.bats
+++ b/tests/ws-clean/target.bats
@@ -1,0 +1,101 @@
+#!/usr/bin/env bats
+
+# Tests for the target form of `ws clean`: `ws clean <comp>` runs the
+# adapter's commands.clean in the component directory, while the bare
+# and flag forms keep sweeping workspace draft files (covered in
+# clean.bats). Drives the full dispatcher so the routing split between
+# the two forms is what's exercised.
+
+load test_helper
+
+REALM_LIB="$REPO_ROOT/scripts/ws-realm.sh"
+
+setup() {
+    init_clean_workspace
+
+    mkdir -p "$REALMS_DIR/realm-test/adapters"
+    printf 'components: {}\n' > "$REALMS_DIR/realm-test/ecosystem.yaml"
+    printf 'realm: realm-test\n' >> "$ECOSYSTEM_LOCAL"
+
+    # Stub cleaner: drops a marker in its cwd and echoes the args it got.
+    cat > "$ROOT_DIR/cleanstub" <<'EOF'
+#!/usr/bin/env bash
+touch clean_ran.marker
+echo "CLEAN_ARGS:$*"
+EOF
+    chmod +x "$ROOT_DIR/cleanstub"
+}
+
+approve_synthetic_realm() {
+    local fingerprint
+    fingerprint="$(bash -c 'source "$1"; ws_realm_trust_fingerprint realm-test' _ "$REALM_LIB")"
+    REALM_FINGERPRINT="$fingerprint" yq -i '
+        ._gdd.realmTrust = {
+          "realm": "realm-test",
+          "fingerprint": strenv(REALM_FINGERPRINT)
+        }
+    ' "$ECOSYSTEM_LOCAL"
+}
+
+write_adapter_clean() {
+    local cmd="$1"
+    cat > "$REALMS_DIR/realm-test/adapters/yggdrasil.yaml" <<EOF
+commands:
+  clean: "$cmd"
+EOF
+    approve_synthetic_realm
+}
+
+@test "clean <comp> runs the adapter's commands.clean" {
+    write_adapter_clean "./cleanstub"
+    run_ws clean yggdrasil
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"CLEAN_ARGS:"* ]]
+    [ -f "$ROOT_DIR/clean_ran.marker" ]
+}
+
+@test "clean <comp> passes extra args through" {
+    write_adapter_clean "./cleanstub"
+    run_ws clean yggdrasil --deep
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"CLEAN_ARGS:--deep"* ]]
+}
+
+@test "clean <comp> refuses stale active-realm trust" {
+    write_adapter_clean "./cleanstub"
+    CLEAN_CMD="./cleanstub --deep" yq -i \
+        '.commands.clean = strenv(CLEAN_CMD)' \
+        "$REALMS_DIR/realm-test/adapters/yggdrasil.yaml"
+
+    run_ws clean yggdrasil
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"trust reapproval is required"* ]]
+    [ ! -f "$ROOT_DIR/clean_ran.marker" ]
+}
+
+@test "clean <comp> errors helpfully when no commands.clean is configured" {
+    cat > "$REALMS_DIR/realm-test/adapters/yggdrasil.yaml" <<'EOF'
+commands:
+  test: "true"
+EOF
+    approve_synthetic_realm
+    run_ws clean yggdrasil
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"No clean command configured"* ]]
+    [[ "$output" == *"Bare 'ws clean' sweeps workspace draft files"* ]]
+}
+
+@test "bare clean still sweeps drafts, untouched by the target form" {
+    export WS_CLEAN_MINE_THRESHOLD=1
+    make_drafts .commits 2
+    run_ws clean --force
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Cleaned 2 draft file(s) total."* ]]
+}
+
+@test "clean with an unknown flag still errors as before" {
+    run_ws clean --bogus
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Usage: ws clean"* ]]
+}

--- a/tests/ws-fmt/fmt.bats
+++ b/tests/ws-fmt/fmt.bats
@@ -1,0 +1,91 @@
+#!/usr/bin/env bats
+
+# Tests for `ws fmt`. It resolves commands.fmt from the active realm
+# adapter, runs the formatter in the component directory, passes extra args
+# through, propagates its exit status, and errors helpfully when no fmt
+# command is configured.
+#
+# `fmt` writes and `lint` checks, so the check form of a formatter belongs
+# in commands.lint — see the header of scripts/ws-fmt.sh.
+
+load test_helper
+
+setup() {
+    setup_synthetic_realm
+}
+
+@test "fmt refuses stale active-realm trust for workspace targets" {
+    write_adapter_fmt "./fmtstub"
+    FMT_CMD="./fmtstub --all" yq -i \
+        '.commands.fmt = strenv(FMT_CMD)' \
+        "$REALMS_DIR/realm-test/adapters/yggdrasil.yaml"
+
+    run_ws_fmt yggdrasil
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"trust reapproval is required"* ]]
+    [ ! -f "$ROOT_DIR/fmt_ran.marker" ]
+}
+
+@test "fmt runs the adapter's commands.fmt" {
+    write_adapter_fmt "./fmtstub"
+    run_ws_fmt yggdrasil
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"FMT_ARGS:"* ]]
+}
+
+@test "fmt passes extra args through to the formatter" {
+    write_adapter_fmt "./fmtstub"
+    run_ws_fmt yggdrasil --all
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"FMT_ARGS:--all"* ]]
+}
+
+@test "fmt runs in the component directory" {
+    write_adapter_fmt "./fmtstub"
+    run_ws_fmt yggdrasil
+    [ "$status" -eq 0 ]
+    # The stub touched its marker in cwd; it must land in the component dir.
+    [ -f "$ROOT_DIR/fmt_ran.marker" ]
+}
+
+@test "fmt propagates a failing formatter" {
+    # A formatter that cannot rewrite (unparseable source, read-only file)
+    # must not be reported as success.
+    write_adapter_fmt "./fmtstub-fail"
+    run_ws_fmt yggdrasil
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"FMT_VIOLATIONS"* ]]
+}
+
+@test "fmt errors helpfully when no commands.fmt is configured" {
+    # Adapter exists but declares only a lint command, no fmt.
+    cat > "$REALMS_DIR/realm-test/adapters/yggdrasil.yaml" <<'EOF'
+commands:
+  lint: "true"
+EOF
+    approve_synthetic_realm
+    run_ws_fmt yggdrasil
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"No fmt command configured"* ]]
+}
+
+@test "fmt rejects malformed adapter YAML as stale trust" {
+    # An unterminated flow mapping cannot match the content that was approved.
+    printf 'commands: {\n' > "$REALMS_DIR/realm-test/adapters/yggdrasil.yaml"
+    run_ws_fmt yggdrasil
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"trust reapproval is required"* ]]
+}
+
+@test "fmt with no component prints usage and exits nonzero" {
+    run_ws_fmt
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Usage: ws fmt"* ]]
+}
+
+@test "fmt --help prints usage and exits 0" {
+    run_ws_fmt --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage: ws fmt"* ]]
+}

--- a/tests/ws-fmt/test_helper.bash
+++ b/tests/ws-fmt/test_helper.bash
@@ -1,0 +1,67 @@
+# Shared helpers for ws-fmt bats tests.
+#
+# Mirrors the ws-build harness: synthetic workspace under $BATS_TEST_TMPDIR,
+# the "yggdrasil" component name (→ COMPONENT_DIR=$ROOT_DIR), a single
+# realm-test realm with an adapter YAML, and a stub formatter that records
+# how it was invoked (args + that it ran in the component dir).
+
+REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+WS_FMT_BIN="$REPO_ROOT/scripts/ws-fmt.sh"
+REALM_LIB="$REPO_ROOT/scripts/ws-realm.sh"
+
+setup_synthetic_realm() {
+    export ROOT_DIR="$BATS_TEST_TMPDIR/root"
+    export REALMS_DIR="$ROOT_DIR/realms"
+    export ECOSYSTEM_LOCAL="$ROOT_DIR/ecosystem.local.yaml"
+
+    mkdir -p "$REALMS_DIR/realm-test/adapters"
+    printf 'components: {}\n' > "$ROOT_DIR/ecosystem.yaml"
+    printf 'components: {}\n' > "$REALMS_DIR/realm-test/ecosystem.yaml"
+    printf 'realm: realm-test\n' > "$ECOSYSTEM_LOCAL"
+
+    # Stub formatter: drops a marker in its cwd (proves it ran in the
+    # component dir, robust to /var vs /private/var symlink differences)
+    # and echoes the args it received.
+    cat > "$ROOT_DIR/fmtstub" <<'EOF'
+#!/usr/bin/env bash
+touch fmt_ran.marker
+echo "FMT_ARGS:$*"
+EOF
+    chmod +x "$ROOT_DIR/fmtstub"
+
+    # Failing variant — a formatter that cannot rewrite its input. The verb
+    # must surface that exit status rather than swallowing it.
+    cat > "$ROOT_DIR/fmtstub-fail" <<'EOF'
+#!/usr/bin/env bash
+echo "FMT_VIOLATIONS"
+exit 1
+EOF
+    chmod +x "$ROOT_DIR/fmtstub-fail"
+
+    approve_synthetic_realm
+}
+
+approve_synthetic_realm() {
+    local fingerprint
+    fingerprint="$(bash -c 'source "$1"; ws_realm_trust_fingerprint realm-test' _ "$REALM_LIB")"
+    REALM_FINGERPRINT="$fingerprint" yq -i '
+        ._gdd.realmTrust = {
+          "realm": "realm-test",
+          "fingerprint": strenv(REALM_FINGERPRINT)
+        }
+    ' "$ECOSYSTEM_LOCAL"
+}
+
+# Write the realm adapter with the given commands.fmt value.
+write_adapter_fmt() {
+    local cmd="$1"
+    cat > "$REALMS_DIR/realm-test/adapters/yggdrasil.yaml" <<EOF
+commands:
+  fmt: "$cmd"
+EOF
+    approve_synthetic_realm
+}
+
+run_ws_fmt() {
+    run bash "$WS_FMT_BIN" "$@"
+}

--- a/tests/ws-run/run.bats
+++ b/tests/ws-run/run.bats
@@ -1,9 +1,8 @@
 #!/usr/bin/env bats
 
-# Tests for `ws run`. It resolves commands.<action> from the active realm
+# Tests for `ws run`. It resolves commands.run from the active realm
 # adapter, runs it in the component directory, passes extra args through,
-# rejects reserved verbs and malformed action names, and errors helpfully
-# when the action is not configured.
+# and errors helpfully when no run command is configured.
 
 load test_helper
 
@@ -12,65 +11,61 @@ setup() {
 }
 
 @test "run refuses stale active-realm trust for workspace targets" {
-    write_adapter_action clean "./actionstub"
-    CLEAN_CMD="./actionstub --deep" yq -i \
-        '.commands.clean = strenv(CLEAN_CMD)' \
+    write_adapter_run "./runstub"
+    RUN_CMD="./runstub --windowed" yq -i \
+        '.commands.run = strenv(RUN_CMD)' \
         "$REALMS_DIR/realm-test/adapters/yggdrasil.yaml"
 
-    run_ws_run yggdrasil clean
+    run_ws_run yggdrasil
 
     [ "$status" -ne 0 ]
     [[ "$output" == *"trust reapproval is required"* ]]
-    [ ! -f "$ROOT_DIR/action_ran.marker" ]
+    [ ! -f "$ROOT_DIR/run_ran.marker" ]
 }
 
-@test "run executes the adapter's named action" {
-    write_adapter_action clean "./actionstub"
-    run_ws_run yggdrasil clean
+@test "run executes the adapter's commands.run" {
+    write_adapter_run "./runstub"
+    run_ws_run yggdrasil
     [ "$status" -eq 0 ]
-    [[ "$output" == *"ACTION_ARGS:"* ]]
+    [[ "$output" == *"RUN_ARGS:"* ]]
 }
 
-@test "run passes extra args through to the action" {
-    write_adapter_action clean "./actionstub"
-    run_ws_run yggdrasil clean --deep
+@test "run passes extra args through to the run target" {
+    write_adapter_run "./runstub"
+    run_ws_run yggdrasil --port 3001
     [ "$status" -eq 0 ]
-    [[ "$output" == *"ACTION_ARGS:--deep"* ]]
+    [[ "$output" == *"RUN_ARGS:--port 3001"* ]]
 }
 
 @test "run executes in the component directory" {
-    write_adapter_action clean "./actionstub"
-    run_ws_run yggdrasil clean
-    [ "$status" -eq 0 ]
-    [ -f "$ROOT_DIR/action_ran.marker" ]
-}
-
-@test "run rejects reserved verbs with a pointer to the dedicated command" {
-    write_adapter_action test "./actionstub"
-    run_ws_run yggdrasil test
-    [ "$status" -ne 0 ]
-    [[ "$output" == *"dedicated verb"* ]]
-    [[ "$output" == *"ws test yggdrasil"* ]]
-    [ ! -f "$ROOT_DIR/action_ran.marker" ]
-}
-
-@test "run rejects a malformed action name before any lookup" {
-    write_adapter_action clean "./actionstub"
-    run_ws_run yggdrasil 'clean; rm -rf /'
-    [ "$status" -ne 0 ]
-    [[ "$output" == *"Invalid action name"* ]]
-    [ ! -f "$ROOT_DIR/action_ran.marker" ]
-}
-
-@test "run errors helpfully when the action is not configured" {
-    write_adapter_action clean "./actionstub"
-    run_ws_run yggdrasil deploy
-    [ "$status" -ne 0 ]
-    [[ "$output" == *"No 'deploy' action configured"* ]]
-}
-
-@test "run with too few args prints usage and exits nonzero" {
+    write_adapter_run "./runstub"
     run_ws_run yggdrasil
+    [ "$status" -eq 0 ]
+    [ -f "$ROOT_DIR/run_ran.marker" ]
+}
+
+@test "run errors helpfully when no commands.run is configured" {
+    # Adapter exists but declares only a test command, no run.
+    cat > "$REALMS_DIR/realm-test/adapters/yggdrasil.yaml" <<'EOF'
+commands:
+  test: "true"
+EOF
+    approve_synthetic_realm
+    run_ws_run yggdrasil
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"No run command configured"* ]]
+}
+
+@test "run rejects malformed adapter YAML as stale trust" {
+    # An unterminated flow mapping cannot match the content that was approved.
+    printf 'commands: {\n' > "$REALMS_DIR/realm-test/adapters/yggdrasil.yaml"
+    run_ws_run yggdrasil
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"trust reapproval is required"* ]]
+}
+
+@test "run with no component prints usage and exits nonzero" {
+    run_ws_run
     [ "$status" -ne 0 ]
     [[ "$output" == *"Usage: ws run"* ]]
 }

--- a/tests/ws-run/run.bats
+++ b/tests/ws-run/run.bats
@@ -1,0 +1,82 @@
+#!/usr/bin/env bats
+
+# Tests for `ws run`. It resolves commands.<action> from the active realm
+# adapter, runs it in the component directory, passes extra args through,
+# rejects reserved verbs and malformed action names, and errors helpfully
+# when the action is not configured.
+
+load test_helper
+
+setup() {
+    setup_synthetic_realm
+}
+
+@test "run refuses stale active-realm trust for workspace targets" {
+    write_adapter_action clean "./actionstub"
+    CLEAN_CMD="./actionstub --deep" yq -i \
+        '.commands.clean = strenv(CLEAN_CMD)' \
+        "$REALMS_DIR/realm-test/adapters/yggdrasil.yaml"
+
+    run_ws_run yggdrasil clean
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"trust reapproval is required"* ]]
+    [ ! -f "$ROOT_DIR/action_ran.marker" ]
+}
+
+@test "run executes the adapter's named action" {
+    write_adapter_action clean "./actionstub"
+    run_ws_run yggdrasil clean
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"ACTION_ARGS:"* ]]
+}
+
+@test "run passes extra args through to the action" {
+    write_adapter_action clean "./actionstub"
+    run_ws_run yggdrasil clean --deep
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"ACTION_ARGS:--deep"* ]]
+}
+
+@test "run executes in the component directory" {
+    write_adapter_action clean "./actionstub"
+    run_ws_run yggdrasil clean
+    [ "$status" -eq 0 ]
+    [ -f "$ROOT_DIR/action_ran.marker" ]
+}
+
+@test "run rejects reserved verbs with a pointer to the dedicated command" {
+    write_adapter_action test "./actionstub"
+    run_ws_run yggdrasil test
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"dedicated verb"* ]]
+    [[ "$output" == *"ws test yggdrasil"* ]]
+    [ ! -f "$ROOT_DIR/action_ran.marker" ]
+}
+
+@test "run rejects a malformed action name before any lookup" {
+    write_adapter_action clean "./actionstub"
+    run_ws_run yggdrasil 'clean; rm -rf /'
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Invalid action name"* ]]
+    [ ! -f "$ROOT_DIR/action_ran.marker" ]
+}
+
+@test "run errors helpfully when the action is not configured" {
+    write_adapter_action clean "./actionstub"
+    run_ws_run yggdrasil deploy
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"No 'deploy' action configured"* ]]
+}
+
+@test "run with too few args prints usage and exits nonzero" {
+    run_ws_run yggdrasil
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Usage: ws run"* ]]
+}
+
+@test "run --help prints usage and exits 0" {
+    run_ws_run --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage: ws run"* ]]
+}

--- a/tests/ws-run/test_helper.bash
+++ b/tests/ws-run/test_helper.bash
@@ -2,7 +2,7 @@
 #
 # Mirrors the ws-build harness: synthetic workspace under $BATS_TEST_TMPDIR,
 # the "yggdrasil" component name (→ COMPONENT_DIR=$ROOT_DIR), a single
-# realm-test realm with an adapter YAML, and a stub action that records
+# realm-test realm with an adapter YAML, and a stub run target that records
 # how it was invoked (args + that it ran in the component dir).
 
 REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
@@ -19,14 +19,14 @@ setup_synthetic_realm() {
     printf 'components: {}\n' > "$REALMS_DIR/realm-test/ecosystem.yaml"
     printf 'realm: realm-test\n' > "$ECOSYSTEM_LOCAL"
 
-    # Stub action: drops a marker in its cwd (proves it ran in the
+    # Stub run target: drops a marker in its cwd (proves it ran in the
     # component dir) and echoes the args it received.
-    cat > "$ROOT_DIR/actionstub" <<'EOF'
+    cat > "$ROOT_DIR/runstub" <<'EOF'
 #!/usr/bin/env bash
-touch action_ran.marker
-echo "ACTION_ARGS:$*"
+touch run_ran.marker
+echo "RUN_ARGS:$*"
 EOF
-    chmod +x "$ROOT_DIR/actionstub"
+    chmod +x "$ROOT_DIR/runstub"
 
     approve_synthetic_realm
 }
@@ -42,12 +42,12 @@ approve_synthetic_realm() {
     ' "$ECOSYSTEM_LOCAL"
 }
 
-# Write the realm adapter declaring the given action name and command.
-write_adapter_action() {
-    local action="$1" cmd="$2"
+# Write the realm adapter with the given commands.run value.
+write_adapter_run() {
+    local cmd="$1"
     cat > "$REALMS_DIR/realm-test/adapters/yggdrasil.yaml" <<EOF
 commands:
-  $action: "$cmd"
+  run: "$cmd"
 EOF
     approve_synthetic_realm
 }

--- a/tests/ws-run/test_helper.bash
+++ b/tests/ws-run/test_helper.bash
@@ -1,0 +1,57 @@
+# Shared helpers for ws-run bats tests.
+#
+# Mirrors the ws-build harness: synthetic workspace under $BATS_TEST_TMPDIR,
+# the "yggdrasil" component name (→ COMPONENT_DIR=$ROOT_DIR), a single
+# realm-test realm with an adapter YAML, and a stub action that records
+# how it was invoked (args + that it ran in the component dir).
+
+REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+WS_RUN_BIN="$REPO_ROOT/scripts/ws-run.sh"
+REALM_LIB="$REPO_ROOT/scripts/ws-realm.sh"
+
+setup_synthetic_realm() {
+    export ROOT_DIR="$BATS_TEST_TMPDIR/root"
+    export REALMS_DIR="$ROOT_DIR/realms"
+    export ECOSYSTEM_LOCAL="$ROOT_DIR/ecosystem.local.yaml"
+
+    mkdir -p "$REALMS_DIR/realm-test/adapters"
+    printf 'components: {}\n' > "$ROOT_DIR/ecosystem.yaml"
+    printf 'components: {}\n' > "$REALMS_DIR/realm-test/ecosystem.yaml"
+    printf 'realm: realm-test\n' > "$ECOSYSTEM_LOCAL"
+
+    # Stub action: drops a marker in its cwd (proves it ran in the
+    # component dir) and echoes the args it received.
+    cat > "$ROOT_DIR/actionstub" <<'EOF'
+#!/usr/bin/env bash
+touch action_ran.marker
+echo "ACTION_ARGS:$*"
+EOF
+    chmod +x "$ROOT_DIR/actionstub"
+
+    approve_synthetic_realm
+}
+
+approve_synthetic_realm() {
+    local fingerprint
+    fingerprint="$(bash -c 'source "$1"; ws_realm_trust_fingerprint realm-test' _ "$REALM_LIB")"
+    REALM_FINGERPRINT="$fingerprint" yq -i '
+        ._gdd.realmTrust = {
+          "realm": "realm-test",
+          "fingerprint": strenv(REALM_FINGERPRINT)
+        }
+    ' "$ECOSYSTEM_LOCAL"
+}
+
+# Write the realm adapter declaring the given action name and command.
+write_adapter_action() {
+    local action="$1" cmd="$2"
+    cat > "$REALMS_DIR/realm-test/adapters/yggdrasil.yaml" <<EOF
+commands:
+  $action: "$cmd"
+EOF
+    approve_synthetic_realm
+}
+
+run_ws_run() {
+    run bash "$WS_RUN_BIN" "$@"
+}


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @soloturn via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

- Adds `ws fmt <comp>`, running the adapter's `commands.fmt`. Same gap this branch closes for build/run/clean: realms could already declare the key and nothing in the CLI ever read it — realm-kanidm has carried one since it was written.
- It **formats** rather than checks. That is the split every ecosystem already makes (`cargo fmt` vs `cargo fmt --check`, `gofmt -w` vs `gofmt -l`), so a formatting violation is a lint failure that belongs in `commands.lint`, and this verb is how you fix it. Declaring the `--check` form under `commands.fmt` would give you a verb named fmt that refuses to format.
- Orient advertises it alongside the other adapter verbs, so discovery still matches dispatch in both directions.
- Allowlisted like test/lint/build — it is scoped to a component and non-interactive. (It does write files, so if you would rather it stay behind the prompt like `run`, say so and I will drop those two lines.)

Stacked on #152 rather than main because it is the same shape of change and touches `scripts/ws` and `ws-orient.sh` in the same places.

Found while using GDD against kanidm: `ws lint` ran clippy only, so a branch went red on every commit for rustfmt alone. The realm-side half of the fix (lint covering both CI gates, `fmt` becoming the writing form) is in soloturn/realm-kanidm.

## Test plan

- [x] `tests/ws-fmt/fmt.bats` — 9/9: adapter resolution, args passthrough, component cwd, non-zero propagation, unconfigured guidance, malformed-YAML trust rejection, usage/help
- [x] Full suite via `ws test yggdrasil` — 1251 pass, 1 unrelated pre-existing failure in `tests/ws-push` (GH_TOKEN credential-helper test; **not yet confirmed against the base branch**)
- [ ] Ubuntu CI on this PR

## Notes

Deliberately no `[adapter-redirect-commands]` entry: raw `cargo fmt` already means what the verb means, so there is nothing to correct the user toward. `black` stays mapped to `lint` — remapping it now that a `fmt` verb exists is a behaviour change for existing realms, not a drive-by.
