### PR TITLE
perf(ws): use a blobless partial clone for ws clone / ws clone-fork

### DIFF
--- a/scripts/ws-clone-fork.sh
+++ b/scripts/ws-clone-fork.sh
@@ -884,7 +884,7 @@ else
     echo "         CLONE: $FORK_REMOTE_URL → $TARGET (remote: $FORK_REMOTE)"
     GIT_AUTH_ENV=()
     git_auth_env_for_url "$FORK_REMOTE_URL"
-    git_auth_run git clone --origin "$FORK_REMOTE" -- "$FORK_REMOTE_URL" "$TARGET"
+    git_auth_run git clone --filter=blob:none --origin "$FORK_REMOTE" -- "$FORK_REMOTE_URL" "$TARGET"
     git -C "$TARGET" remote add "$UPSTREAM_REMOTE_NAME" "$UPSTREAM_REMOTE_URL"
 fi
 

--- a/scripts/ws-clone.sh
+++ b/scripts/ws-clone.sh
@@ -227,7 +227,7 @@ clone_component() {
     local -a GIT_AUTH_ENV=()
     local GIT_AUTH_LABEL="" GIT_AUTH_PROVIDER=""
     git_auth_env_for_url "$repo_url"
-    git_auth_run git clone --origin "$remote" -- "$repo_url" "$target"
+    git_auth_run git clone --filter=blob:none --origin "$remote" -- "$repo_url" "$target"
 }
 
 clone_url() {
@@ -296,7 +296,7 @@ clone_url() {
         local -a GIT_AUTH_ENV=()
         local GIT_AUTH_LABEL="" GIT_AUTH_PROVIDER=""
         git_auth_env_for_url "$url"
-        git_auth_run git clone --origin "$remote" -- "$url" "$target"
+        git_auth_run git clone --filter=blob:none --origin "$remote" -- "$url" "$target"
     fi
 
     if [[ "$add_eco" == "true" ]]; then


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @soloturn via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

- `ws clone`/`ws clone-fork` now pass `--filter=blob:none` to `git clone`. A full clone of a large repo (e.g. DestinationSol) pulls every historical blob up front and can sit there for minutes before any file exists; a blobless partial clone skips that - trees/commits still come down eagerly (log/blame/diff work immediately), file contents fetch lazily on checkout and first access.

## Test plan

- [x] `ws test yggdrasil` (full bats suite) - passes; one pre-existing flake in the parallel runner (`ws-clone/security.bats` occasionally times out under `--jobs 10`) reproduces identically with and without this change, confirmed by re-running against the unmodified tree.
- [x] `tests/ws-clone/security.bats` and `tests/ws-clone-fork/*.bats` run standalone - all pass.
- [x] Manually cloned DestinationSol with the new flag: seconds instead of minutes, full working tree present.
