### PR TITLE
feat(hoard): lint thalamus frontmatter, because nothing ever parsed it

### DIFF
--- a/.agent/skills/gdd-flow/SKILL.md
+++ b/.agent/skills/gdd-flow/SKILL.md
@@ -62,6 +62,10 @@ If the user declines, capture the tangent as a normal Observations entry (the ex
 
 `arcs:` is the dashboard projection — keep `next:` short and free of sensitive operational detail (URLs of internal tools, credentials, identifying detail about people). Keep the rich context in the body.
 
+**Whenever you edit an arc, stamp its `last_touched` to today in the same edit.** That includes rewriting `next:`, flipping `status:`, and adding body context under the slug — not arcs you only read. Nothing computes this field, and both the ArcDashboard's decay icons and housekeeping's stale-arc check depend on it, so an unstamped edit leaves a moving arc looking abandoned.
+
+Two habits keep `next:` renderable, both learned from arcs that drifted: it is one line of **10–20 words**, and it is a *next step*, not a status report. The moment it starts accumulating "DONE X, then Y, OLD NOTE: …" it has become a status dump — move that history into the body and leave the pointer. Quote the value and avoid embedding a `"` inside it; an unescaped quote closes the YAML scalar early and takes the **whole file's** frontmatter down with it, silently removing every arc on that host from the dashboard. `ws hoard lint` catches all three.
+
 ## Multi-Agent and Multi-Workspace
 
 Flow is the natural stance for a human overseeing parallel work:

--- a/.agent/skills/gdd-housekeeping/SKILL.md
+++ b/.agent/skills/gdd-housekeeping/SKILL.md
@@ -90,8 +90,25 @@ once the PR has merged and the canonical doc is stable.
 
 ### Step 2.5: Walk the arcs list
 
-If the active Thalamus has a non-empty `arcs:` list, walk it before
-moving on:
+**Start with `ws hoard lint`.** It checks every host's thalamus in the
+active hoard, not just this machine's, and it answers the mechanical
+questions faster and more reliably than reading: does the frontmatter
+parse, do arcs carry the required keys, is `status` renderable, is
+`next` a single line short enough for the table. Work its findings
+first, then walk the list by judgment for the things a linter cannot
+decide.
+
+Treat `unparseable_files: 1` or more as the priority item in the whole
+pass. That file's arcs are absent from the ArcDashboard entirely —
+`WHERE arcs` cannot match a file whose frontmatter failed to parse —
+so the cross-host view has been quietly wrong since the day it broke,
+and no amount of reading the file reveals it. The usual cause is an
+unescaped `"` inside a quoted `next:` value.
+
+The lint exits 1 when it reports anything; that is its findings signal,
+not a failure. Read `status:`.
+
+Then walk the list for the judgment calls:
 
 - **Stale active arcs.** Any `active` arc whose `last_touched` is more
   than ~30 days old is a candidate to flip to `parked`. Propose the
@@ -105,9 +122,13 @@ moving on:
   flagged for the human. Don't auto-resolve — ambiguous cases are
   judgment calls.
 - **Overgrown `next:` fields.** An arc's `next:` should stay under
-  ~10-20 words so the ArcDashboard reads at a glance. Move extended
-  context into a body section (the `Arc next-notes` pattern) and leave
-  a one-liner pointing at it.
+  ~10-20 words so the ArcDashboard reads at a glance. `ws hoard lint`
+  flags these by length; the judgment part is what to do with each.
+  Move extended context into a body section (the `Arc next-notes`
+  pattern) and leave a one-liner pointing at it. Watch for the shape
+  behind the length — a long `next:` is usually one that stopped being
+  a next step and became a running status report, so the fix is
+  rewriting it as an instruction, not just trimming words.
 
 Beyond triage, the arcs walk also surfaces prioritization moves when arcs carry the optional `impact:` / `urgency:` / `project:` fields:
 

--- a/.agent/skills/gdd-orientation/SKILL.md
+++ b/.agent/skills/gdd-orientation/SKILL.md
@@ -123,6 +123,20 @@ Run `ws hoard cadence` and react to its `status:` line:
 
 If the human agrees to commit now: `ws commit <hoard> <bodyfile>` → `ws pull <hoard>` (rebase) → `ws push <hoard>`. Per-machine files reduce direct conflicts, but cross-machine housekeeping can touch multiples — be ready to walk a conflict resolution. Use whatever hoard name Phase 2's `ws hoard thalamus-path` resolved (frequently `thalami-<user>`, doesn't have to be).
 
+### Frontmatter lint (only if a hoard is active)
+
+Run `ws hoard lint` and react to its `status:` line. Warn-only at orientation — never block the session, and never auto-fix.
+
+| `status:` | Action |
+|---|---|
+| `ok` / `no-active-hoard` / `no-thalamus-files` | Silent |
+| `findings`, with `unparseable_files: 0` | Mention the count in one line, offer to fix during housekeeping |
+| `findings`, with `unparseable_files` ≥ 1 | **Surface immediately** — name the file and offer to fix now |
+
+A parse failure is the one case worth interrupting for. A thalamus whose frontmatter does not parse stops matching the ArcDashboard's `WHERE arcs`, so **every arc on that host silently disappears from the cross-host view** while the file still reads perfectly to a human or an agent. It stays broken until someone happens to look. Everything else the lint reports is drift that can wait for a housekeeping pass.
+
+Note `ws hoard lint` exits 1 when it finds anything — that is the documented signal, not a tooling failure. Read `status:`, not the exit code.
+
 ### Parse Thalamus frontmatter
 
 Read the YAML between the leading `---` markers. Update `last_session` to today's date **only if parsing succeeded** — never rewrite frontmatter on a parse failure (the file may be hand-edited; clobbering loses the human's edits).
@@ -251,6 +265,10 @@ Cross-host stitching: grep sibling thalamus files in the active hoard for slugs 
 If the user agrees, propose adding the same slug to *this* host's `arcs:` list at the first arc-shaped write. Cross-host stitching is slug-discipline — same `id` clusters naturally in the dashboard.
 
 If `arcs:` is empty or absent, skip silently. No nudge to populate — that's a housekeeping concern.
+
+**Stamp `last_touched` when you work an arc.** Whenever you write an arc-shaped entry — updating that arc's `next:`, adding body context under its slug, or closing it — set its `last_touched` to today's date in the same edit. Do not batch this to end-of-session, and do not stamp arcs you merely read.
+
+This matters more than it looks: `last_touched` is what the ArcDashboard's decay icons (🔥 / 🐢 / ⚠️) and gdd-housekeeping's stale-arc check both key off. Nothing computes it — if the agent working the arc does not write it, an actively-moving arc ages into ⚠️ on the dashboard while a genuinely abandoned one can look fresh. A wrong freshness signal is worse than none, because it is trusted.
 
 ### Unclaimed intake items (when a thalami hoard is active)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ This changelog begins at the 1.0.0 GA push. The pre-1.0 history below is a curat
 
 ## [Unreleased]
 
+### Added
+
+- **`ws hoard lint`** — validates thalamus frontmatter across every host in a thalami hoard: that the block parses at all, that each arc carries the required keys, that `status` is one the dashboard can render, and that `next` is a single line short enough for its table cell (`WS_ARC_NEXT_MAX`, default 200). Reports in the `key: value` shape of `ws hoard cadence`; exits 0 clean, 1 on findings, 2 on tooling failure. `gdd-orientation` runs it as a session-start warning and `gdd-housekeeping` at the head of its arc walk. See [hoards.md](docs/gdd/hoards.md#frontmatter-lint--ws-hoard-lint).
+
+### Fixed
+
+- **A thalamus with unparseable frontmatter no longer fails silently.** The Arc Dashboard selects files with `WHERE arcs`, so a file whose frontmatter does not parse simply stops matching — every arc on that host vanishes from the cross-host view while the file still reads correctly to a human or an agent. The arc schema had three enforcement layers and all three were prose; nothing had ever parsed the YAML. `ws hoard lint` reports it, and treats it as the severe case rather than as a missing field.
+- **`last_touched` is now written, not just read.** It feeds the dashboard's decay icons and housekeeping's stale-arc check, and no skill instructed anyone to maintain it. `gdd-flow` and `gdd-orientation` now say to stamp it in the same edit that touches an arc — a wrong freshness signal is worse than an absent one.
+
 ## [1.1.0] - 2026-08-24
 
 **The 1.1 headliner: sandboxed workspaces went from roadmap track to working capability.** [`gdd-sandbox`](https://github.com/SiliconSaga/gdd-sandbox) runs a scoped GDD agent in a Docker container, reachable over chat and pointed at one target component — a chat message becomes a reviewed pull request, and merging stays human. It ships as an optional companion component fetched independently of the workspace; see the [features tour entry](docs/gdd/features.md#sandboxed-workspaces-gdd-sandbox-optional-companion-new-in-11).

--- a/docs/gdd/hoards.md
+++ b/docs/gdd/hoards.md
@@ -80,6 +80,40 @@ The check itself runs as `ws hoard cadence` and reports a status line (`clean`, 
 
 ---
 
+## Frontmatter lint — `ws hoard lint`
+
+```bash
+ws hoard lint            # the active thalami hoard
+ws hoard lint thalami    # a named one
+```
+
+Checks every `*-thalamus.md` in the hoard — all hosts, not just this machine's — for the things the [arc schema](../plans/2026-05-07-thalamus-arc-dashboard-design.md) requires and nothing else enforces:
+
+- the frontmatter block parses as YAML at all
+- each arc carries `id`, `name`, `status`, `started`, `last_touched`, `next`
+- `status` is one of `active`, `review`, `parked`, `closed`, `promoted`
+- `next` is a single line under `WS_ARC_NEXT_MAX` characters (default 200)
+
+Output is `key: value` lines plus one line per finding, the same greppable shape as `ws hoard cadence`. It exits **0** when clean, **1** when it has findings, and **2** on a tooling failure — so a caller that only wants a warning should read the `status:` line rather than the exit code.
+
+**Why it exists.** The arc schema had three enforcement layers — the schema block in `ArcDashboard.md`, the rules in `gdd-housekeeping`, the narration step in `gdd-orientation` — and all three were prose. Nothing parsed the YAML, which made one failure mode completely silent: the dashboard selects files with `WHERE arcs`, and a file whose frontmatter fails to parse simply stops matching. Every arc on that host vanishes from the cross-host view while the file still reads perfectly to a human or an agent, and it stays that way until somebody notices the row count looks low. The usual cause is an unescaped `"` inside a quoted `next:` value, which closes the scalar early and takes the whole document with it.
+
+`gdd-orientation` runs it at session start as a warning; `gdd-housekeeping` runs it at the top of the arc walk. Both are advisory — the lint never edits anything.
+
+Since `ws lint` accepts hoard names too, a realm that wants the reflex verb to work on a thalami hoard can point its adapter at this command:
+
+```yaml
+# realms/<realm>/adapters/<hoard-name>.yaml
+commands:
+  lint: "ws hoard lint <hoard-name>"
+```
+
+That is optional sugar — `ws hoard lint` works with no adapter at all.
+
+**On `last_touched`.** The lint checks the field is present, but only you can tell whether it is *true*. It is the input to the dashboard's decay icons and to housekeeping's stale-arc check, and nothing computes it — so the convention is that whoever edits an arc stamps it in the same edit. An unstamped edit leaves a moving arc looking abandoned, which is worse than no signal because the dashboard is trusted.
+
+---
+
 ## Multi-machine workflows
 
 The standard pattern with a thalami hoard across machines:
@@ -139,5 +173,6 @@ Each new type ships as a `templates/hoards/<type>/` directory with its own scaff
 - [Thalamus](thalamus.md) — the thinking-space concept the thalami type is built around.
 - [Trust and Safety](trust-and-safety.md) — hoards' trust level (your own content, equivalent to your other instructions).
 - [Roles and Stances](roles-and-stances.md) — the role and stance concepts that sessions are configured with.
-- [`gdd-orientation` skill](../../.agent/skills/gdd-orientation/SKILL.md) — how the startup sequence resolves the thalamus and reacts to `ws hoard cadence`.
-- [`gdd-housekeeping` skill](../../.agent/skills/gdd-housekeeping/SKILL.md) — multi-thalami review process.
+- [`gdd-orientation` skill](../../.agent/skills/gdd-orientation/SKILL.md) — how the startup sequence resolves the thalamus and reacts to `ws hoard cadence` and `ws hoard lint`.
+- [`gdd-housekeeping` skill](../../.agent/skills/gdd-housekeeping/SKILL.md) — multi-thalami review process, including the arc walk that `ws hoard lint` feeds.
+- [Arc Dashboard design doc](../plans/2026-05-07-thalamus-arc-dashboard-design.md) — the arc lifecycle and schema the lint enforces.

--- a/docs/gdd/thalamus.md
+++ b/docs/gdd/thalamus.md
@@ -59,6 +59,8 @@ Per-machine thalamus files carry an `arcs:` list in their frontmatter — one en
 
 The hoard ships an `ArcDashboard.md` that — when the hoard is opened as an Obsidian vault with the Dataview plugin — renders a live table of every arc across every machine's frontmatter, sorted by status and freshness (with vibe icons that decay as an arc goes stale, nudging you to move it forward or close it). The dashboard projects **only** frontmatter; the body sections (Observations, Concerns, Audit Log) sync via git like any other content but never surface in the table. The orientation skill reads the same `arcs:` frontmatter at session start to surface active arcs and offer cross-host pickups, and the housekeeping skill walks arcs through their lifecycle (active → review → closed/promoted → pruned).
 
+`ws hoard lint` validates that frontmatter against the schema — see [Frontmatter lint](hoards.md#frontmatter-lint--ws-hoard-lint). It is worth running by hand after editing arcs, because the dashboard's failure mode is silent: it selects files with `WHERE arcs`, so a thalamus whose frontmatter does not parse drops out entirely, taking every arc on that host with it while the file still reads fine to you.
+
 See the [Arc Dashboard design doc](../plans/2026-05-07-thalamus-arc-dashboard-design.md) for the full arc lifecycle, schema, and skill integration, and the hoard's own `README.md` for the one-time Obsidian + Dataview setup.
 
 ## Housekeeping

--- a/scripts/ws-hoard.sh
+++ b/scripts/ws-hoard.sh
@@ -7,6 +7,7 @@
 #                               (template defaults to 'thalami')
 #   <git-url>                   Clone an existing hoard from a git URL
 #   list                        Show hoards and which thalami hoard is active
+#   lint [hoard]                Validate thalamus frontmatter / arc schema
 #
 # Templates ship under templates/hoards/<name>/.
 # Currently shipped: thalami.
@@ -348,6 +349,10 @@ ws_hoard_help() {
     echo "                           flavor (thalami / obsidian)" >&2
     echo "  cadence                  Report dirty/staleness of the active per-machine" >&2
     echo "                           thalamus file (used by gdd-orientation Step 0a)" >&2
+    echo "  lint [hoard]             Validate thalamus frontmatter across a thalami" >&2
+    echo "                           hoard: does it parse, do arcs carry the required" >&2
+    echo "                           keys, is 'next' short enough to render. Defaults" >&2
+    echo "                           to the active hoard. Exit 1 on findings." >&2
     echo "  thalamus-path            Print the resolved path to the active per-machine" >&2
     echo "                           thalamus file (empty if no active hoard)" >&2
     echo "  upgrade <hoard> [--plan|--apply|--rollback] [--template <name>]" >&2
@@ -495,6 +500,195 @@ ws_hoard_cadence() {
     echo "elapsed_hours: $elapsed_hours"
     echo "threshold_days: $threshold_days"
     echo "last_commit_unix: $last_commit_ts"
+}
+
+# Maximum `next:` length before we warn. The documented rule in
+# gdd-housekeeping is "~10-20 words"; 200 characters is the generous
+# end of that, chosen from the real distribution across a 64-arc
+# thalami hoard (median 116, and the arcs that breach 200 are the ones
+# that had visibly rotted into status dumps rather than next steps).
+: "${WS_ARC_NEXT_MAX:=200}"
+
+# Arc statuses the ArcDashboard's decay model knows how to render.
+# An unrecognized value falls through every `choice()` branch and
+# renders as the catch-all icon, which reads as "promoted" — a
+# silently wrong row rather than a missing one.
+WS_ARC_STATUSES=(active review parked closed promoted)
+
+# Extract the leading `---` frontmatter block of a markdown file to
+# stdout. Returns 1 when the file has no frontmatter at all (first
+# line is not `---`), which callers report differently from a block
+# that exists but fails to parse.
+ws_extract_frontmatter() {
+    awk '
+        NR == 1 && $0 != "---" { exit 1 }
+        NR == 1 { next }
+        $0 == "---" { found = 1; exit }
+        { print }
+        END { if (!found) exit 1 }
+    ' "$1"
+}
+
+# Lint the thalamus frontmatter in a thalami hoard.
+#
+# This exists because the arc schema had three enforcement layers —
+# the schema block in ArcDashboard.md, the rules in gdd-housekeeping,
+# and the narration step in gdd-orientation — and none of them was
+# code. Nothing ever parsed the YAML, so the failure mode was silent:
+# a thalamus whose frontmatter does not parse simply stops matching
+# the dashboard's `WHERE arcs`, and every arc on that host disappears
+# from the cross-host view without anything reporting a problem. An
+# agent reading the same file by eye does not notice, because prose
+# degrades gracefully where a parser fails hard.
+#
+# Output is `key: value` lines plus indented per-finding lines, in the
+# same greppable shape as `ws hoard cadence`.
+#
+# Exit status:
+#   0  no findings
+#   1  findings (callers that only want a warning read `status:`)
+#   2  tooling failure — could not run at all
+ws_hoard_lint() {
+    local hoard_arg=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -h|--help)
+                echo "Usage: ws hoard lint [hoard]" >&2
+                echo "" >&2
+                echo "Validate thalamus frontmatter in a thalami hoard:" >&2
+                echo "  - the frontmatter block parses as YAML at all" >&2
+                echo "  - each arc carries id/name/status/started/last_touched/next" >&2
+                echo "  - status is one of: ${WS_ARC_STATUSES[*]}" >&2
+                echo "  - next is a single line under \$WS_ARC_NEXT_MAX chars" >&2
+                echo "    (currently $WS_ARC_NEXT_MAX)" >&2
+                echo "" >&2
+                echo "Defaults to the active thalami hoard." >&2
+                echo "Exit: 0 clean, 1 findings, 2 tooling failure." >&2
+                return 0
+                ;;
+            -*)
+                echo "ERROR: unknown flag for 'ws hoard lint': $1" >&2
+                return 2
+                ;;
+            *)
+                if [[ -n "$hoard_arg" ]]; then
+                    echo "ERROR: 'ws hoard lint' takes at most one hoard name." >&2
+                    return 2
+                fi
+                hoard_arg="$1"
+                ;;
+        esac
+        shift
+    done
+
+    local hoard="$hoard_arg"
+    if [[ -z "$hoard" ]]; then
+        hoard="$(ws_detect_thalami_hoard)"
+        if [[ -z "$hoard" ]]; then
+            echo "status: no-active-hoard"
+            return 0
+        fi
+    fi
+
+    local hoard_path="$HOARDS_DIR/$hoard"
+    if [[ ! -d "$hoard_path" ]]; then
+        echo "ERROR: no such hoard: $hoard (looked in $HOARDS_DIR)" >&2
+        return 2
+    fi
+
+    shopt -s nullglob
+    local files=("$hoard_path"/*-thalamus.md)
+    shopt -u nullglob
+
+    if [[ ${#files[@]} -eq 0 ]]; then
+        echo "status: no-thalamus-files"
+        echo "hoard: $hoard"
+        return 0
+    fi
+
+    local fm findings=0 arcs_total=0 files_bad=0
+    fm="$(mktemp)" || { echo "ERROR: could not create temp file." >&2; return 2; }
+    # shellcheck disable=SC2064  # expand $fm now, not at trap time
+    trap "rm -f '$fm'" RETURN
+
+    local f base err n i id key value next_len next_lines status
+    for f in "${files[@]}"; do
+        base="$(basename "$f")"
+
+        if ! ws_extract_frontmatter "$f" >"$fm"; then
+            echo "$base: no frontmatter block"
+            findings=$(( findings + 1 ))
+            files_bad=$(( files_bad + 1 ))
+            continue
+        fi
+
+        # The whole-document check. A parse failure here is the severe
+        # case: it takes every arc in the file off the dashboard, not
+        # just the field that broke.
+        if ! err="$(yq '.' "$fm" 2>&1 >/dev/null)"; then
+            echo "$base: YAML PARSE FAILURE — every arc in this file is invisible to the dashboard"
+            echo "    $(head -1 <<<"$err")"
+            findings=$(( findings + 1 ))
+            files_bad=$(( files_bad + 1 ))
+            continue
+        fi
+
+        n="$(yq '.arcs // [] | length' "$fm" 2>/dev/null)" || n=0
+        [[ "$n" =~ ^[0-9]+$ ]] || n=0
+        arcs_total=$(( arcs_total + n ))
+        [[ "$n" -eq 0 ]] && continue
+
+        for (( i = 0; i < n; i++ )); do
+            id="$(yq ".arcs[$i].id // \"\"" "$fm" 2>/dev/null)"
+            [[ -z "$id" || "$id" == "null" ]] && id="(arc #$i, no id)"
+
+            for key in id name status started last_touched next; do
+                value="$(yq ".arcs[$i].$key // \"\"" "$fm" 2>/dev/null)"
+                if [[ -z "$value" || "$value" == "null" ]]; then
+                    echo "$base: $id: missing required key: $key"
+                    findings=$(( findings + 1 ))
+                fi
+            done
+
+            status="$(yq ".arcs[$i].status // \"\"" "$fm" 2>/dev/null)"
+            if [[ -n "$status" && "$status" != "null" ]]; then
+                local known=0 s
+                for s in "${WS_ARC_STATUSES[@]}"; do
+                    [[ "$status" == "$s" ]] && known=1 && break
+                done
+                if [[ "$known" -eq 0 ]]; then
+                    echo "$base: $id: unknown status '$status' (expected: ${WS_ARC_STATUSES[*]})"
+                    findings=$(( findings + 1 ))
+                fi
+            fi
+
+            value="$(yq ".arcs[$i].next // \"\"" "$fm" 2>/dev/null)"
+            if [[ -n "$value" && "$value" != "null" ]]; then
+                next_len="${#value}"
+                next_lines="$(grep -c '' <<<"$value")"
+                if [[ "$next_lines" -gt 1 ]]; then
+                    echo "$base: $id: next spans $next_lines lines; the dashboard renders it as one table cell"
+                    findings=$(( findings + 1 ))
+                fi
+                if [[ "$next_len" -gt "$WS_ARC_NEXT_MAX" ]]; then
+                    echo "$base: $id: next is $next_len chars (max $WS_ARC_NEXT_MAX) — move the detail into the body and leave a one-liner"
+                    findings=$(( findings + 1 ))
+                fi
+            fi
+        done
+    done
+
+    echo "hoard: $hoard"
+    echo "files: ${#files[@]}"
+    echo "arcs: $arcs_total"
+    echo "findings: $findings"
+    if [[ "$findings" -eq 0 ]]; then
+        echo "status: ok"
+        return 0
+    fi
+    echo "unparseable_files: $files_bad"
+    echo "status: findings"
+    return 1
 }
 
 # Init a hoard from a template that uses `template.yaml` for clone-on-init
@@ -1022,6 +1216,9 @@ case "$SUBCMD" in
         ;;
     cadence)
         ws_hoard_cadence
+        ;;
+    lint)
+        ws_hoard_lint "$@"
         ;;
     thalamus-path)
         # Echo the resolved path or empty if no active hoard. The

--- a/tests/ws-hoard-lint/fixtures/clean/hoards/thalami/Alpha-thalamus.md
+++ b/tests/ws-hoard-lint/fixtures/clean/hoards/thalami/Alpha-thalamus.md
@@ -1,0 +1,26 @@
+---
+last_session: 2026-08-27
+last_audit: 2026-08-27
+arcs:
+  - id: well-formed-arc
+    name: An arc that satisfies the schema
+    status: active
+    started: 2026-08-01
+    last_touched: 2026-08-27
+    next: "Wire the lint into orientation."
+    impact: medium
+    urgency: next
+    tags: [gdd]
+  - id: a-closed-arc
+    name: Something already finished
+    status: closed
+    started: 2026-07-01
+    last_touched: 2026-07-15
+    next: "MERGED. Prune on the next audit."
+---
+
+# Thalamus
+
+## Observations
+
+Body content the lint does not care about.

--- a/tests/ws-hoard-lint/fixtures/empty-hoard/hoards/thalami/README.md
+++ b/tests/ws-hoard-lint/fixtures/empty-hoard/hoards/thalami/README.md
@@ -1,0 +1,4 @@
+# Thalami hoard
+
+A hoard that exists but has no `*-thalamus.md` files yet — the state right
+after `ws hoard init` and before the first session on any machine.

--- a/tests/ws-hoard-lint/fixtures/no-arcs/hoards/thalami/Delta-thalamus.md
+++ b/tests/ws-hoard-lint/fixtures/no-arcs/hoards/thalami/Delta-thalamus.md
@@ -1,0 +1,10 @@
+---
+last_session: 2026-08-27
+last_audit: null
+arcs: []
+---
+
+# Thalamus
+
+A host with no arcs in flight. Valid, and must not be reported as a finding —
+the orientation skill explicitly skips silently on an empty `arcs:`.

--- a/tests/ws-hoard-lint/fixtures/no-frontmatter/hoards/thalami/Epsilon-thalamus.md
+++ b/tests/ws-hoard-lint/fixtures/no-frontmatter/hoards/thalami/Epsilon-thalamus.md
@@ -1,0 +1,4 @@
+# Thalamus
+
+No frontmatter block at all. The file was probably hand-created without
+copying `templates/thalamus.md`, so it can never carry an arc.

--- a/tests/ws-hoard-lint/fixtures/schema-violations/hoards/thalami/Gamma-thalamus.md
+++ b/tests/ws-hoard-lint/fixtures/schema-violations/hoards/thalami/Gamma-thalamus.md
@@ -1,0 +1,31 @@
+---
+last_session: 2026-08-27
+arcs:
+  - id: missing-several-keys
+    status: active
+    next: "No name, no started, no last_touched."
+  - id: bogus-status
+    name: Status the dashboard cannot render
+    status: simmering
+    started: 2026-08-01
+    last_touched: 2026-08-27
+    next: "Falls through every choice() branch and renders as the catch-all icon."
+  - id: overgrown-next
+    name: A next field that rotted into a status dump
+    status: active
+    started: 2026-08-01
+    last_touched: 2026-08-27
+    next: "This next field is far longer than the schema allows, because it stopped being a next step and became a running status report instead, which is exactly the drift the length check is meant to catch before the dashboard table becomes unreadable at a glance."
+  - id: multiline-next
+    name: A next field spanning lines
+    status: parked
+    started: 2026-08-01
+    last_touched: 2026-08-27
+    next: |
+      First line of the next step.
+      Second line, which the dashboard renders into one table cell.
+---
+
+# Thalamus
+
+Body.

--- a/tests/ws-hoard-lint/fixtures/unparseable/hoards/thalami/Beta-thalamus.md
+++ b/tests/ws-hoard-lint/fixtures/unparseable/hoards/thalami/Beta-thalamus.md
@@ -1,0 +1,22 @@
+---
+last_session: 2026-08-23
+arcs:
+  - id: broken-scalar
+    name: The real-world shape of this bug
+    status: active
+    started: 2026-08-01
+    last_touched: 2026-08-23
+    next: "Current status here. OLD NOTE: " and then prose continues past the closing quote."
+  - id: collateral-damage
+    name: A perfectly valid arc in the same file
+    status: active
+    started: 2026-08-02
+    last_touched: 2026-08-23
+    next: "This one is fine, and still vanishes from the dashboard."
+---
+
+# Thalamus
+
+An unescaped `"` inside a double-quoted scalar closes it early, so the
+whole document fails to parse and BOTH arcs above stop matching the
+dashboard's `WHERE arcs`. Observed in the wild on 2026-08-24.

--- a/tests/ws-hoard-lint/lint.bats
+++ b/tests/ws-hoard-lint/lint.bats
@@ -1,0 +1,137 @@
+#!/usr/bin/env bats
+
+# Lock in `ws hoard lint` behavior against synthetic fixtures.
+#
+# The motivating bug is the `unparseable` fixture: an unescaped `"`
+# inside a double-quoted `next:` scalar closed it early, the whole
+# frontmatter block stopped parsing, and every arc on that host silently
+# disappeared from the ArcDashboard for three days. Nothing reported it,
+# because the three enforcement layers for the arc schema were all prose.
+
+load test_helper
+
+@test "a schema-conformant hoard reports status: ok and exits 0" {
+    load_fixture clean
+    run_lint
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"status: ok"* ]]
+    [[ "$output" == *"findings: 0"* ]]
+    [[ "$output" == *"arcs: 2"* ]]
+}
+
+@test "unparseable frontmatter is reported as such, not as missing keys" {
+    # The distinction matters: 'missing key' reads as one sloppy field,
+    # while the actual consequence is that the entire file drops out of
+    # the dashboard. Reporting the wrong one sends you editing the wrong
+    # thing.
+    load_fixture unparseable
+    run_lint
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"YAML PARSE FAILURE"* ]]
+    [[ "$output" == *"invisible to the dashboard"* ]]
+    [[ "$output" == *"unparseable_files: 1"* ]]
+}
+
+@test "a parse failure does not also emit per-arc findings for that file" {
+    # Once the document fails to parse we cannot read its arcs at all,
+    # so any per-arc finding would be fabricated. Guards against a
+    # regression where the arc loop runs on an empty parse result and
+    # reports every key as missing.
+    load_fixture unparseable
+    run_lint
+    [ "$status" -eq 1 ]
+    [[ "$output" != *"missing required key"* ]]
+    [[ "$output" == *"findings: 1"* ]]
+}
+
+@test "missing required keys are named individually" {
+    load_fixture schema-violations
+    run_lint
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"missing-several-keys: missing required key: name"* ]]
+    [[ "$output" == *"missing-several-keys: missing required key: started"* ]]
+    [[ "$output" == *"missing-several-keys: missing required key: last_touched"* ]]
+}
+
+@test "an unknown status is flagged with the accepted set" {
+    load_fixture schema-violations
+    run_lint
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"bogus-status: unknown status 'simmering'"* ]]
+    [[ "$output" == *"active review parked closed promoted"* ]]
+}
+
+@test "an overgrown next is flagged with its actual length" {
+    load_fixture schema-violations
+    run_lint
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"overgrown-next: next is 255 chars (max 200)"* ]]
+}
+
+@test "a multi-line next is flagged separately from length" {
+    load_fixture schema-violations
+    run_lint
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"multiline-next: next spans 2 lines"* ]]
+}
+
+@test "WS_ARC_NEXT_MAX raises the length threshold" {
+    # Non-vacuous: the same fixture that fails at the default must pass
+    # the length check at a raised ceiling, proving the knob is read
+    # rather than the finding simply being absent for another reason.
+    load_fixture schema-violations
+    WS_ARC_NEXT_MAX=500 run_lint
+    [ "$status" -eq 1 ]
+    [[ "$output" != *"overgrown-next: next is"* ]]
+    [[ "$output" == *"bogus-status: unknown status"* ]]
+}
+
+@test "an empty arcs list is clean, not a finding" {
+    load_fixture no-arcs
+    run_lint
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"status: ok"* ]]
+    [[ "$output" == *"arcs: 0"* ]]
+}
+
+@test "a file with no frontmatter at all is reported" {
+    load_fixture no-frontmatter
+    run_lint
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"no frontmatter block"* ]]
+}
+
+@test "a hoard with no thalamus files reports a status, not an error" {
+    load_fixture empty-hoard
+    run_lint
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"status: no-thalamus-files"* ]]
+}
+
+@test "an explicit hoard name overrides active-hoard detection" {
+    load_fixture clean
+    run_lint thalami
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"hoard: thalami"* ]]
+}
+
+@test "a nonexistent hoard name exits 2, distinct from a findings exit" {
+    load_fixture clean
+    run_lint no-such-hoard
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"no such hoard"* ]]
+}
+
+@test "an unknown flag exits 2 rather than being read as a hoard name" {
+    load_fixture clean
+    run_lint --nope
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"unknown flag"* ]]
+}
+
+@test "--help exits 0 and documents the exit codes" {
+    load_fixture clean
+    run_lint --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"0 clean, 1 findings, 2 tooling failure"* ]]
+}

--- a/tests/ws-hoard-lint/test_helper.bash
+++ b/tests/ws-hoard-lint/test_helper.bash
@@ -1,0 +1,33 @@
+# Shared helpers for ws-hoard-lint bats tests.
+#
+# Same fixture mechanism as ws-hoard-scan: each fixture is a directory
+# under fixtures/ containing a hoards/ tree, and HOARDS_DIR is pointed
+# at it through the environment (ws-hoard.sh honors it via parameter
+# expansion, so no flag wiring is needed).
+
+REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+WS_BIN="$REPO_ROOT/scripts/ws"
+
+load_fixture() {
+    local fixture="$1"
+    export HOARDS_DIR="$BATS_TEST_DIRNAME/fixtures/$fixture/hoards"
+    # Hard-fail rather than skip on a missing fixture — a typo'd name
+    # that silently downgrades to `skip` is indistinguishable from a
+    # deliberate skip, which hides coverage gaps.
+    if [[ ! -d "$HOARDS_DIR" ]]; then
+        echo "ERROR: fixture missing: $fixture (path: $HOARDS_DIR)" >&2
+        return 1
+    fi
+}
+
+# Run `ws hoard lint` against the loaded fixture. Requires load_fixture
+# first — without it HOARDS_DIR falls back to the workspace's real hoard
+# tree, and assertions would silently be testing the author's own notes
+# instead of the fixture.
+run_lint() {
+    if [[ -z "${HOARDS_DIR:-}" ]]; then
+        echo "ERROR: HOARDS_DIR is not set; call load_fixture <name> first" >&2
+        return 1
+    fi
+    run bash "$WS_BIN" hoard lint "$@"
+}


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @Cervator via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

- The arc schema from PR #60 has three enforcement layers — the schema block in `ArcDashboard.md`, the rules in `gdd-housekeeping`, the narration step in `gdd-orientation` — and all three are prose. Nothing has ever parsed the YAML they describe, so this adds `ws hoard lint`.
- The failure mode that motivated it is silent by construction: the dashboard selects files with `WHERE arcs`, so a thalamus whose frontmatter fails to parse simply stops matching and every arc on that host disappears from the cross-host view. `OldMacPro-thalamus.md` did exactly this for three days — an unescaped `"` in a quoted `next:` closed the scalar early — and nothing reported it, including the agent that read the file at the start of every session.
- Separately, `last_touched` was read by everything and written by nothing: it feeds the dashboard's decay icons *and* housekeeping's stale-arc check, and no skill told anyone to maintain it. `gdd-flow` and `gdd-orientation` now say to stamp it in the same edit that touches the arc.

## Decisions worth a second opinion

- **Exit 1 on findings**, diverging from the always-exit-0 convention of the neighbouring `ws hoard cadence`. Cadence reports a state; a lint reports defects, and a non-zero exit is what makes it usable from CI or a realm adapter. Warn-only callers read the `status:` line instead, so both are served — but this is the one deliberate inconsistency here.
- **200 characters for `next:`**, measured rather than invented: across this hoard's 64 arcs the median is 116, and the 10 that breach 200 are the ones that had visibly stopped being next steps and turned into status reports. `WS_ARC_NEXT_MAX` overrides. Easy to move if you would rather it were tighter.
- **A parse failure suppresses that file's per-arc checks** instead of cascading. Once the document does not parse its arcs cannot be read, so per-arc findings would be fabricated — the natural implementation reports every key as missing and sends you editing the wrong thing.
- **Orientation is told to interrupt only for `unparseable_files`.** Everything else the lint finds is drift that can wait for a housekeeping pass; a parse failure is invisible until someone looks, so it is the one case worth the interruption.

## Test plan

- [x] `bats tests/ws-hoard-lint/lint.bats` — 15 tests, fixtures modelled on the real bug.
- [x] Non-vacuity checked rather than assumed: disabling the parse check makes both parse-failure tests fail; test 8 is a built-in negative control proving `WS_ARC_NEXT_MAX` is actually read; test 6 caught a wrong constant of mine unprompted.
- [x] Runs clean under stock macOS bash **3.2.57** as well as 5.3, including the empty-array-under-`set -u` path this repo has been bitten by before.
- [x] Full tree, re-run after rebasing onto `5aafdab`: **61 of 62 files pass, nothing skipped.** Three suites (`hook`, `ws-orient`, `ws-smoke`) hard-require GNU `timeout`, which this macOS Tier-3 box lacks; rather than leave them unrun against a PR that edits the orientation skill, I ran the whole tree behind a session-scoped perl `timeout` stand-in (verified to exit 124 on expiry and pass status through otherwise) living in a scratchpad dir — nothing installed, nothing added to any PATH beyond the one run. `ws-orient` 43/43, `ws-smoke` + `hook` 354/354.
- [x] The one failure, `tests/ws-test/bats-parallel.bats` test 7, fails identically on a clean `main` worktree — pre-existing and unrelated. It concerns parallel-backend selection under system Bash, which this branch does not touch.

## Not in scope

- The 10 overgrown `next:` fields the lint now flags across 5 hosts live in a private thalami hoard, not this repo. Rewriting someone else's arc pointer is a housekeeping conversation, not a code change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `ws hoard lint` to validate frontmatter, YAML, required arc fields, statuses, and `next` formatting.
  - Added clear reporting and exit codes for clean, invalid, missing, or unreadable hoards.
  - Linting is now integrated into orientation and housekeeping workflows.

- **Documentation**
  - Added usage, validation rules, and troubleshooting guidance.
  - Documented automatic `last_touched` updates when arcs are modified.

- **Bug Fixes**
  - Improved detection of malformed frontmatter that could hide arcs from dashboards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->